### PR TITLE
Hide address-based option in social errors

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -254,7 +254,7 @@ public struct WordPressAuthenticatorConfiguration {
         let storyboard = UIStoryboard(name: "Login", bundle: bundle)
         if let controller = storyboard.instantiateInitialViewController() {
             if let childController = controller.childViewControllers.first as? LoginPrologueViewController {
-                childController.restrictToWPCom = restrictToWPCom
+                childController.loginFields.restrictToWPCom = restrictToWPCom
                 childController.showCancel = showCancel
             }
             presenter.present(controller, animated: animated, completion: nil)
@@ -272,7 +272,7 @@ public struct WordPressAuthenticatorConfiguration {
             return
         }
 
-        controller.restrictToWPCom = true
+        controller.loginFields.restrictToWPCom = true
         controller.loginFields.meta.jetpackBlogXMLRPC = xmlrpc
         controller.loginFields.meta.jetpackBlogUsername = username
 

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -30,6 +30,9 @@ public class LoginFields: NSObject {
     /// User ID for use with the nonce for social login
     @objc public var nonceUserID: Int = 0
 
+    /// Used to restrict login to WordPress.com
+    public var restrictToWPCom = false
+
     /// Used by the SignupViewController. Signup currently asks for both a
     /// username and an email address.  This can be factored away when we revamp
     /// the signup flow.

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -386,6 +386,7 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription)
             let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
             socialErrorVC.delegate = self
+            socialErrorVC.loginFields = loginFields
             present(socialErrorNav, animated: true) {}
         } else {
             errorToPresent = error

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -93,7 +93,7 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     ///
     func configureForWPComOnlyIfNeeded() {
         wpcomSignupButton?.isHidden = !offerSignupOption
-        selfHostedLoginButton?.isHidden = restrictToWPCom
+        selfHostedLoginButton?.isHidden = loginFields.restrictToWPCom
     }
 
 

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -29,6 +29,10 @@ class LoginSocialErrorViewController: NUXTableViewController {
         case tryEmail = 0
         case tryAddress = 1
         case signup = 2
+
+        static var count: Int {
+            return signup.rawValue + 1
+        }
     }
 
     /// Create and instance of LoginSocialErrorViewController
@@ -67,7 +71,11 @@ class LoginSocialErrorViewController: NUXTableViewController {
         case Buttons.tryEmail.rawValue:
             delegate.retryWithEmail()
         case Buttons.tryAddress.rawValue:
-            delegate.retryWithAddress()
+            if loginFields.restrictToWPCom {
+                fallthrough
+            } else {
+                delegate.retryWithAddress()
+            }
         case Buttons.signup.rawValue:
             fallthrough
         default:
@@ -98,8 +106,8 @@ extension LoginSocialErrorViewController {
 // MARK: UITableViewDataSource methods
 
 extension LoginSocialErrorViewController {
-    private struct Constants {
-        static let buttonCount = 3
+    private func numberOfButtonsToShow() -> Int {
+        return loginFields.restrictToWPCom ? Buttons.count - 1 : Buttons.count
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -111,7 +119,7 @@ extension LoginSocialErrorViewController {
         case Sections.titleAndDescription.rawValue:
             return 1
         case Sections.buttons.rawValue:
-            return Constants.buttonCount
+            return numberOfButtonsToShow()
         default:
             return 0
         }
@@ -153,8 +161,12 @@ extension LoginSocialErrorViewController {
             buttonText = NSLocalizedString("Try with another email", comment: "When social login fails, this button offers to let the user try again with a differen email address")
             buttonIcon = Gridicon.iconOfType(.undo)
         case Buttons.tryAddress.rawValue:
-            buttonText = NSLocalizedString("Try with the site address", comment: "When social login fails, this button offers to let them try tp login using a URL")
-            buttonIcon = Gridicon.iconOfType(.domains)
+            if loginFields.restrictToWPCom {
+                fallthrough
+            } else {
+                buttonText = NSLocalizedString("Try with the site address", comment: "When social login fails, this button offers to let them try tp login using a URL")
+                buttonIcon = Gridicon.iconOfType(.domains)
+            }
         case Buttons.signup.rawValue:
             fallthrough
         default:

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -6,7 +6,6 @@ import WordPressKit
 class LoginViewController: NUXViewController, LoginFacadeDelegate {
     @IBOutlet var instructionLabel: UILabel?
     @objc var errorToPresent: Error?
-    var restrictToWPCom = false
 
     lazy var loginFacade: LoginFacade = {
         let configuration = WordPressAuthenticator.shared.configuration
@@ -142,7 +141,6 @@ class LoginViewController: NUXViewController, LoginFacadeDelegate {
         }
 
         destination.loginFields = source.loginFields
-        destination.restrictToWPCom = source.restrictToWPCom
         destination.dismissBlock = source.dismissBlock
         destination.errorToPresent = source.errorToPresent
     }

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -165,7 +165,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
         super.prepare(for: segue, sender: sender)
         // Configure login flow to allow only .com login and prefill the email
         if let destination = segue.destination as? LoginEmailViewController {
-            destination.restrictToWPCom = true
+            destination.loginFields.restrictToWPCom = true
             destination.loginFields.username = loginFields.emailAddress
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/8388

![simulator screen shot - iphone x - 2018-06-26 at 12 12 09](https://user-images.githubusercontent.com/517257/41931082-3695053c-793a-11e8-84f2-13a6d1c81d15.png)

When logging in with `restrictToWPCom` turned on, and the uses selects to login via Google, we now hide the option to login via address when there is an error. This will improve error recovery for these users.

# To test:
- Login to the app using a self-hosted site
- On the Me tab, tap to login to wpcom
- Chose to login via Google
- Force an error (I modify `googleLoginTapped()` in `LoginEmailViewController`)
- Ensure that the option to retry via site address is gone, and that the other two options still work
- Ensure that the three options all appear and work when login is not restricted to wpcom