### PR TITLE
Updating Authenticator delegate

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -61,7 +61,7 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///     - credentials: WordPress Site Credentials.
     ///     - onCompletion: Closure to be executed on completion.
     ///
-    func sync(credentials: WordPressCredentials, onCompletion: @escaping (Error?) -> Void)
+    func sync(credentials: WordPressCredentials, onCompletion: @escaping () -> Void)
 
     /// Signals the Host App that a given Analytics Event has occurred.
     ///

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -274,7 +274,7 @@ extension LoginSelfHostedViewController {
         }
 
         let credentials = WordPressCredentials.wporg(username: username, password: password, xmlrpc: xmlrpc, options: options)
-        delegate.sync(credentials: credentials) { [weak self] _ in
+        delegate.sync(credentials: credentials) { [weak self] in
 
             NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
             self?.showLoginEpilogue(for: credentials)

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -220,7 +220,7 @@ extension LoginViewController {
 
         configureStatusLabel(NSLocalizedString("Getting account information", comment: "Alerts the user that wpcom account information is being retrieved."))
 
-        authenticationDelegate.sync(credentials: credentials) { [weak self] _ in
+        authenticationDelegate.sync(credentials: credentials) { [weak self] in
 
             self?.configureStatusLabel("")
             self?.configureViewLoading(false)

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -113,7 +113,7 @@ private extension SignupGoogleViewController {
 
             /// Existing Account: We'll synchronize all the things before proceeding to the next screen.
             ///
-            self?.authenticationDelegate.sync(credentials: credentials) { _ in
+            self?.authenticationDelegate.sync(credentials: credentials) {
                 SVProgressHUD.dismiss()
                 self?.wasLoggedInInstead(with: credentials)
             }


### PR DESCRIPTION
### Details:
Just a little bit of housekeeping: the method `sync` has a closure callback, which expects an **Error** optional. However: such parameter is never, not ever used.

In this PR we're simply dropping such parameter.

### Testing:
Please refer to [this WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/9750) for testing steps.

Thanks in advance!!
