### PR TITLE
Configure subheadline button title color

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -37,9 +37,13 @@ public struct WordPressAuthenticatorStyle {
 
     public let disabledTitleColor: UIColor
 
+    /// Style: Subheadline
+    ///
+    public let subheadlineColor: UIColor
+
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, subheadlineColor: UIColor) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -53,6 +57,7 @@ public struct WordPressAuthenticatorStyle {
         self.primaryTitleColor = primaryTitleColor
         self.secondaryTitleColor = secondaryTitleColor
         self.disabledTitleColor = disabledTitleColor
+        self.subheadlineColor = subheadlineColor
     }
 }
 
@@ -70,6 +75,7 @@ public extension WordPressAuthenticatorStyle {
                                            disabledBorderColor: WPStyleGuide.greyLighten30(),
                                            primaryTitleColor: UIColor.white,
                                            secondaryTitleColor: WPStyleGuide.darkGrey(),
-                                           disabledTitleColor: WPStyleGuide.greyLighten30())
+                                           disabledTitleColor: WPStyleGuide.greyLighten30(),
+                                           subheadlineColor: WPStyleGuide.wordPressBlue())
     }
 }

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -7,7 +7,7 @@ final class SubheadlineButton: UIButton {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             titleLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
-            titleLabel?.tintColor = WordPressAuthenticator.shared.style.subheadlineColor
+            setTitleColor(WordPressAuthenticator.shared.style.subheadlineColor, for: .normal)
         }
     }
 }
@@ -163,7 +163,7 @@ extension WPStyleGuide {
         button.titleLabel?.font = font
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.lineBreakMode = .byWordWrapping
-        button.titleLabel?.tintColor = WordPressAuthenticator.shared.style.subheadlineColor
+        button.setTitleColor(WordPressAuthenticator.shared.style.subheadlineColor, for: .normal) 
 
         // These constraints work around some issues with multiline buttons and
         // vertical layout.  Without them the button's height may not account

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -7,6 +7,7 @@ final class SubheadlineButton: UIButton {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             titleLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
+            titleLabel?.tintColor = WordPressAuthenticator.shared.style.subheadlineColor
         }
     }
 }
@@ -162,6 +163,7 @@ extension WPStyleGuide {
         button.titleLabel?.font = font
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.lineBreakMode = .byWordWrapping
+        button.titleLabel?.tintColor = WordPressAuthenticator.shared.style.subheadlineColor
 
         // These constraints work around some issues with multiline buttons and
         // vertical layout.  Without them the button's height may not account


### PR DESCRIPTION
Fixes #15 

**Background:** In WCiOS (host app) all UIButton instances had their UIAppearance set with a text color of `wooPurple`. Setting UIAppearance for all UIButton instances causes bugs because it's too general. For example, the Logout button should be a dark red "destructive action" color, but it's purple. 

## To Test

1. check out this branch
2. check out the host app branch: https://github.com/woocommerce/woocommerce-ios/pull/154
3. delete any existing WCiOS app builds
4. open WCiOS podfile
5. point to the WordPressAuthenticator development pod (`pod 'WordPressAuthenticator', :path => '/your/path/to/WPAuth'`
6. `pod install`
7. run WCiOS
8. verify the subheadline buttons remain purple (see list of button titles below)
9. attempt to paste some text into the password field the "Paste" tooltip should have a white text color instead of purple.
10. after logging in, an "Unable to find WooCommerce stores connected to this account" message will appear. Tap the "Continue" button. 
11. navigate to Orders > select an order > check the "Fulfill order" button. The button text color should be white.

### Subheadline buttons found in WPAuth
(Not all of these buttons appear in WCiOS.)
- [ ] Log in with Google
- [ ] Log in by entering your site address
- [ ] Enter your password instead
- [ ] Forgot password
- [ ] Lost your password
- [ ] Send another code
- [ ] Need help finding your site address

#### Title color issues checklist
- [ ] Paste tooltip is white text not purple 
<img width="69" alt="screen shot 2018-07-11 at 12 23 20 pm" src="https://user-images.githubusercontent.com/1062444/42700672-0fb812ee-868a-11e8-9af2-2b1472887983.png">

- [ ] Fulfill order button has white text not purple 
<img width="240" alt="screen shot 2018-07-13 at 10 47 22 am" src="https://user-images.githubusercontent.com/1062444/42700693-24cadbc6-868a-11e8-82c9-654ae37d3072.png">




