### PR TITLE
Login2FAViewController: Enabling iOS 12 OTP Autofill

### DIFF
--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -103,6 +103,10 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
     ///
     @objc func configureTextFields() {
         verificationCodeField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+
+        if #available(iOS 12, *) {
+            verificationCodeField.textContentType = .oneTimeCode
+        }
     }
 
     /// Configures the appearance and state of the submit button.

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -104,9 +104,11 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
     @objc func configureTextFields() {
         verificationCodeField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
 
+#if swift(>=4.2)
         if #available(iOS 12, *) {
             verificationCodeField.textContentType = .oneTimeCode
         }
+#endif
     }
 
     /// Configures the appearance and state of the submit button.


### PR DESCRIPTION
### Details:
This PR enables the One Time Code textField for iOS 12 autofill.

Testing instructions [detailed here](https://github.com/wordpress-mobile/WordPress-iOS/pull/9767).

@frosty Thanks in advance!!!
