### PR TITLE
iOS 12 Beta 6: Fixing Autofill Crash

### DIFF
--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -193,7 +193,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
 
             // because the string was stripped of whitespace, we can't return true and we update the textfield ourselves
             textField.text = cleanedCode
-            handleTextFieldDidChange()
+            handleTextFieldDidChange(textField)
         case .invalid(nonNumbers: true):
             displayError(message: NSLocalizedString("A verification code will only contain numbers.", comment: "Shown when a user types a non-number into the two factor field."))
         default:
@@ -231,7 +231,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         return false
     }
 
-    func handleTextFieldDidChange() {
+    @IBAction func handleTextFieldDidChange(_ sender: UITextField) {
         loginFields.multifactorCode = verificationCodeField.nonNilTrimmedText()
         configureSubmitButton(animating: false)
     }
@@ -283,7 +283,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         case .valid(let cleanedCode):
             displayError(message: "")
             verificationCodeField.text = cleanedCode
-            handleTextFieldDidChange()
+            handleTextFieldDidChange(verificationCodeField)
         default:
             break
         }


### PR DESCRIPTION
### Details:
This PR exposes the method `handleTextFieldDidChange`, so that:

A. It matches the Storyboard Signature (incoming parameter)
B. It's exposed to ObjC

Ref. [WPiOS Issue #9979](https://github.com/wordpress-mobile/WordPress-iOS/pull/9979)

cc @frosty @jklausa  (Thank you  two!!!)

### Testing:
Please refer to [this WP issue for testing steps](https://github.com/wordpress-mobile/WordPress-iOS/pull/9979)
