### PR TITLE
Relaxed version dependencies on both WordPressShared and WordPressKit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -17,8 +17,8 @@ target 'WordPressAuthenticator' do
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  pod 'WordPressKit', '1.4.1-beta.2'
-  pod 'WordPressShared', '1.1.1-beta.2'
+  pod 'WordPressKit', '~> 1.4.1-beta.3'
+  pod 'WordPressShared', '~> 1.1.1-beta.4'
   pod 'wpxmlrpc', '~> 0.8'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,14 +45,14 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.1-beta.2):
+  - WordPressKit (1.4.1-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (= 1.1.1-beta.2)
+    - WordPressShared (~> 1.1.1-beta.4)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.1.1-beta.2):
+  - WordPressShared (1.1.1-beta.4):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.6)
@@ -73,8 +73,8 @@ DEPENDENCIES:
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPressKit (= 1.4.1-beta.2)
-  - WordPressShared (= 1.1.1-beta.2)
+  - WordPressKit (~> 1.4.1-beta.3)
+  - WordPressShared (~> 1.1.1-beta.4)
   - WordPressUI (~> 1.0)
   - wpxmlrpc (~> 0.8)
 
@@ -118,11 +118,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: a4ccc4bbbc6f8e194becf18b47af212f367fe3ab
-  WordPressShared: c4d4356a06fc73bde9b782f26768d42e62a330ef
+  WordPressKit: 1fecd89dc42115fe55640d49b9f6e905a94c6a70
+  WordPressShared: fc613aa29351c73677c421daacb36eacf53f100d
   WordPressUI: af141587ec444f9af753a00605bd0d3f14d8d8a3
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: f8b43cd0a518f7b18cd345af0b3197091330858d
+PODFILE CHECKSUM: 7ea7cc44c0d95a36ac49e9513022c014a975e8d5
 
 COCOAPODS: 1.5.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.1.0-beta.1"
+  s.version       = "1.1.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignInRepacked', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
-  s.dependency 'WordPressKit', '1.4.1-beta.2'
-  s.dependency 'WordPressShared', '1.1.1-beta.2'
+  s.dependency 'WordPressKit', '~> 1.4.1-beta.2'
+  s.dependency 'WordPressShared', '~> 1.1.1-beta.4'
   s.dependency 'wpxmlrpc', '~> 0.8'
 end


### PR DESCRIPTION
In reference to [this change](https://github.com/wordpress-mobile/WordPress-iOS/pull/10210), this PR  relaxes dependencies expressed against both `WordPressKit` & `WordPressShared`.

The `.podspec` has also been updated to accommodate the next minor version.