### PR TITLE
Bump upstream dependencies

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -17,8 +17,8 @@ target 'WordPressAuthenticator' do
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  pod 'WordPressKit', '~> 1.4.1'
-  pod 'WordPressShared', '~> 1.1.1'
+  pod 'WordPressKit', '~> 1.4.2-beta.3'
+  pod 'WordPressShared', '~> 1.2.0-beta.1'
   pod 'wpxmlrpc', '~> 0.8'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,14 +45,14 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.1):
+  - WordPressKit (1.4.2-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (~> 1.1.1-beta.4)
+    - WordPressShared (= 1.2.0-beta.1)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.1.1):
+  - WordPressShared (1.2.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.6)
@@ -73,8 +73,8 @@ DEPENDENCIES:
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPressKit (~> 1.4.1)
-  - WordPressShared (~> 1.1.1)
+  - WordPressKit (~> 1.4.2-beta.3)
+  - WordPressShared (~> 1.2.0-beta.1)
   - WordPressUI (~> 1.0)
   - wpxmlrpc (~> 0.8)
 
@@ -118,11 +118,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: d95804a925e3d23f6a8cc0d47424c673253a65b6
-  WordPressShared: d2d652c40b3b68904c88d59df428c00c4e7dd180
+  WordPressKit: afbdb50a6bbf3c6a0c0b2c1463bbcc6eca405fcd
+  WordPressShared: a1a3923a22456dfe77428dbbe6e95397c4f7000a
   WordPressUI: af141587ec444f9af753a00605bd0d3f14d8d8a3
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 0c20513abe520d26a6bbd2b045ff7b6c2def9c95
+PODFILE CHECKSUM: 4565f112781a9f5fab1a97962aef604b3d131aeb
 
 COCOAPODS: 1.5.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.1.1"
+  s.version       = "1.1.2-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignInRepacked', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
-  s.dependency 'WordPressKit', '~> 1.4.1-beta.2'
-  s.dependency 'WordPressShared', '~> 1.1.1-beta.4'
+  s.dependency 'WordPressKit', '~> 1.4.2-beta.3'
+  s.dependency 'WordPressShared', '~> 1.2.0-beta.1'
   s.dependency 'wpxmlrpc', '~> 0.8'
 end


### PR DESCRIPTION
With the update to `WordPressShared` & `WordPressKit`, we also need to increment this dependency.

After running `pod install --repo-update` locally, the branch should build and tests should pass.