### PR TITLE
Add the ability to override text displayed to the user

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		B5ED791D207E993E00A8FD8C /* WPAuthenticatorLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = B5ED7918207E993E00A8FD8C /* WPAuthenticatorLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5ED791F207E993E00A8FD8C /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ED791A207E993E00A8FD8C /* CocoaLumberjack.swift */; };
 		B5ED7920207E993E00A8FD8C /* WPAuthenticatorLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = B5ED791B207E993E00A8FD8C /* WPAuthenticatorLogging.m */; };
+		CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */; };
 		CE1B18C920EEC2C200BECC3F /* SocialService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18C820EEC2C200BECC3F /* SocialService.swift */; };
 		CE1B18CC20EEC32400BECC3F /* WordPressCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CB20EEC32400BECC3F /* WordPressCredentials.swift */; };
 		CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */; };
@@ -234,6 +235,7 @@
 		B5ED791A207E993E00A8FD8C /* CocoaLumberjack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaLumberjack.swift; sourceTree = "<group>"; };
 		B5ED791B207E993E00A8FD8C /* WPAuthenticatorLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAuthenticatorLogging.m; sourceTree = "<group>"; };
 		C736FF243DE333FCAB1C2614 /* Pods_WordPressAuthenticator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressAuthenticator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDisplayText.swift; sourceTree = "<group>"; };
 		CE1B18C820EEC2C200BECC3F /* SocialService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialService.swift; sourceTree = "<group>"; };
 		CE1B18CB20EEC32400BECC3F /* WordPressCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressCredentials.swift; sourceTree = "<group>"; };
 		CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDelegateProtocol.swift; sourceTree = "<group>"; };
@@ -401,6 +403,7 @@
 				B56090F6208A533200399AE4 /* WordPressSupportSourceTag.swift */,
 				CE1B18CF20EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift */,
 				CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */,
+				CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */,
 			);
 			path = Authenticator;
 			sourceTree = "<group>";
@@ -841,6 +844,7 @@
 				CE1B18D020EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift in Sources */,
 				CE1B18D220EEC44400BECC3F /* WordPressAuthenticatorStyles.swift in Sources */,
 				B56090F0208A527000399AE4 /* FancyAlertViewController+LoginError.swift in Sources */,
+				CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift in Sources */,
 				CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */,
 				B5609110208A54F800399AE4 /* OnePasswordFacade.swift in Sources */,
 				B5609109208A54F800399AE4 /* SignupService.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -96,7 +96,7 @@
 		B5ED791D207E993E00A8FD8C /* WPAuthenticatorLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = B5ED7918207E993E00A8FD8C /* WPAuthenticatorLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5ED791F207E993E00A8FD8C /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ED791A207E993E00A8FD8C /* CocoaLumberjack.swift */; };
 		B5ED7920207E993E00A8FD8C /* WPAuthenticatorLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = B5ED791B207E993E00A8FD8C /* WPAuthenticatorLogging.m */; };
-		CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */; };
+		CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayStrings.swift */; };
 		CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177721B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift */; };
 		CE1B18C920EEC2C200BECC3F /* SocialService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18C820EEC2C200BECC3F /* SocialService.swift */; };
 		CE1B18CC20EEC32400BECC3F /* WordPressCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CB20EEC32400BECC3F /* WordPressCredentials.swift */; };
@@ -236,7 +236,7 @@
 		B5ED791A207E993E00A8FD8C /* CocoaLumberjack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaLumberjack.swift; sourceTree = "<group>"; };
 		B5ED791B207E993E00A8FD8C /* WPAuthenticatorLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAuthenticatorLogging.m; sourceTree = "<group>"; };
 		C736FF243DE333FCAB1C2614 /* Pods_WordPressAuthenticator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressAuthenticator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDisplayText.swift; sourceTree = "<group>"; };
+		CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDisplayStrings.swift; sourceTree = "<group>"; };
 		CE16177721B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDisplayTextTests.swift; sourceTree = "<group>"; };
 		CE1B18C820EEC2C200BECC3F /* SocialService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialService.swift; sourceTree = "<group>"; };
 		CE1B18CB20EEC32400BECC3F /* WordPressCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressCredentials.swift; sourceTree = "<group>"; };
@@ -406,7 +406,7 @@
 				B56090F6208A533200399AE4 /* WordPressSupportSourceTag.swift */,
 				CE1B18CF20EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift */,
 				CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */,
-				CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */,
+				CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayStrings.swift */,
 			);
 			path = Authenticator;
 			sourceTree = "<group>";
@@ -847,7 +847,7 @@
 				CE1B18D020EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift in Sources */,
 				CE1B18D220EEC44400BECC3F /* WordPressAuthenticatorStyles.swift in Sources */,
 				B56090F0208A527000399AE4 /* FancyAlertViewController+LoginError.swift in Sources */,
-				CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift in Sources */,
+				CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayStrings.swift in Sources */,
 				CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */,
 				B5609110208A54F800399AE4 /* OnePasswordFacade.swift in Sources */,
 				B5609109208A54F800399AE4 /* SignupService.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		B5ED791F207E993E00A8FD8C /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ED791A207E993E00A8FD8C /* CocoaLumberjack.swift */; };
 		B5ED7920207E993E00A8FD8C /* WPAuthenticatorLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = B5ED791B207E993E00A8FD8C /* WPAuthenticatorLogging.m */; };
 		CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */; };
+		CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177721B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift */; };
 		CE1B18C920EEC2C200BECC3F /* SocialService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18C820EEC2C200BECC3F /* SocialService.swift */; };
 		CE1B18CC20EEC32400BECC3F /* WordPressCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CB20EEC32400BECC3F /* WordPressCredentials.swift */; };
 		CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */; };
@@ -236,6 +237,7 @@
 		B5ED791B207E993E00A8FD8C /* WPAuthenticatorLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAuthenticatorLogging.m; sourceTree = "<group>"; };
 		C736FF243DE333FCAB1C2614 /* Pods_WordPressAuthenticator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressAuthenticator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDisplayText.swift; sourceTree = "<group>"; };
+		CE16177721B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDisplayTextTests.swift; sourceTree = "<group>"; };
 		CE1B18C820EEC2C200BECC3F /* SocialService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialService.swift; sourceTree = "<group>"; };
 		CE1B18CB20EEC32400BECC3F /* WordPressCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressCredentials.swift; sourceTree = "<group>"; };
 		CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDelegateProtocol.swift; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 			isa = PBXGroup;
 			children = (
 				B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */,
+				CE16177721B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift */,
 			);
 			path = Authenticator;
 			sourceTree = "<group>";
@@ -883,6 +886,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */,
+				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,
 				B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */,
 			);

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -59,7 +59,9 @@ import WordPressUI
 
     /// Designated Initializer
     ///
-    private init(configuration: WordPressAuthenticatorConfiguration, style: WordPressAuthenticatorStyle, text: WordPressAuthenticatorDisplayText) {
+    private init(configuration: WordPressAuthenticatorConfiguration,
+                 style: WordPressAuthenticatorStyle,
+                 text: WordPressAuthenticatorDisplayText) {
         self.configuration = configuration
         self.style = style
         self.text = text

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -38,7 +38,7 @@ import WordPressUI
 
     /// Authenticator's Display Texts.
     ///
-    public let text: WordPressAuthenticatorDisplayText
+    public let displayStrings: WordPressAuthenticatorDisplayStrings
 
     /// Notification to be posted whenever the signing flow completes.
     ///
@@ -61,22 +61,22 @@ import WordPressUI
     ///
     private init(configuration: WordPressAuthenticatorConfiguration,
                  style: WordPressAuthenticatorStyle,
-                 text: WordPressAuthenticatorDisplayText) {
+                 displayStrings: WordPressAuthenticatorDisplayStrings) {
         self.configuration = configuration
         self.style = style
-        self.text = text
+        self.displayStrings = displayStrings
     }
 
     /// Initializes the WordPressAuthenticator with the specified Configuration.
     ///
     public static func initialize(configuration: WordPressAuthenticatorConfiguration,
                                   style: WordPressAuthenticatorStyle = .defaultStyle,
-                                  text: WordPressAuthenticatorDisplayText = .defaultText) {
+                                  displayStrings: WordPressAuthenticatorDisplayStrings = .defaultStrings) {
         guard privateInstance == nil else {
             fatalError("WordPressAuthenticator is already initialized")
         }
 
-        privateInstance = WordPressAuthenticator(configuration: configuration, style: style, text: text)
+        privateInstance = WordPressAuthenticator(configuration: configuration, style: style, displayStrings: displayStrings)
     }
 
     // MARK: - Public Methods

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -36,6 +36,10 @@ import WordPressUI
     ///
     public let style: WordPressAuthenticatorStyle
 
+    /// Authenticator's Display Texts.
+    ///
+    public let text: WordPressAuthenticatorDisplayText
+
     /// Notification to be posted whenever the signing flow completes.
     ///
     @objc public static let WPSigninDidFinishNotification = "WPSigninDidFinishNotification"
@@ -55,19 +59,22 @@ import WordPressUI
 
     /// Designated Initializer
     ///
-    private init(configuration: WordPressAuthenticatorConfiguration, style: WordPressAuthenticatorStyle) {
+    private init(configuration: WordPressAuthenticatorConfiguration, style: WordPressAuthenticatorStyle, text: WordPressAuthenticatorDisplayText) {
         self.configuration = configuration
         self.style = style
+        self.text = text
     }
 
     /// Initializes the WordPressAuthenticator with the specified Configuration.
     ///
-    public static func initialize(configuration: WordPressAuthenticatorConfiguration, style: WordPressAuthenticatorStyle = .defaultStyle) {
+    public static func initialize(configuration: WordPressAuthenticatorConfiguration,
+                                  style: WordPressAuthenticatorStyle = .defaultStyle,
+                                  text: WordPressAuthenticatorDisplayText = .defaultText) {
         guard privateInstance == nil else {
             fatalError("WordPressAuthenticator is already initialized")
         }
 
-        privateInstance = WordPressAuthenticator(configuration: configuration, style: style)
+        privateInstance = WordPressAuthenticator(configuration: configuration, style: style, text: text)
     }
 
     // MARK: - Public Methods

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 
-// MARK: - WordPress Authenticator Display Text
+// MARK: - WordPress Authenticator Display Strings
 //
-public struct WordPressAuthenticatorDisplayText {
-    /// Text: Login instructions.
+public struct WordPressAuthenticatorDisplayStrings {
+    /// Strings: Login instructions.
     ///
     public let emailLoginInstructions: String
 
@@ -21,9 +21,9 @@ public struct WordPressAuthenticatorDisplayText {
     }
 }
 
-public extension WordPressAuthenticatorDisplayText {
-    public static var defaultText: WordPressAuthenticatorDisplayText {
-        return WordPressAuthenticatorDisplayText(emailLoginInstructions: NSLocalizedString("Log in to WordPress.com using an email address to manage all your WordPress sites.", comment: "Instruction text on the login's email address screen."),
+public extension WordPressAuthenticatorDisplayStrings {
+    public static var defaultStrings: WordPressAuthenticatorDisplayStrings {
+        return WordPressAuthenticatorDisplayStrings(emailLoginInstructions: NSLocalizedString("Log in to WordPress.com using an email address to manage all your WordPress sites.", comment: "Instruction text on the login's email address screen."),
                                                  jetpackLoginInstructions: NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.", comment: "Instruction text on the login's email address screen."),
                                                  siteLoginInstructions: NSLocalizedString("Enter the address of your WordPress site you'd like to connect.", comment: "Instruction text on the login's site addresss screen."))
     }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayText.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayText.swift
@@ -1,9 +1,27 @@
-//
-//  WordPressAuthenticatorDisplayText.swift
-//  WordPressAuthenticator
-//
-//  Created by Thuy Copeland on 12/4/18.
-//  Copyright © 2018 Automattic. All rights reserved.
-//
-
 import Foundation
+
+
+// MARK: - WordPress Authenticator Display Text
+//
+public struct WordPressAuthenticatorDisplayText {
+    /// Text: Login instructions.
+    ///
+    public let emailLoginInstructions: String
+
+    public let siteLoginInstructions: String
+
+
+    /// Designated initializer.
+    ///
+    public init(emailLoginInstructions: String, siteLoginInstructions: String) {
+        self.emailLoginInstructions = emailLoginInstructions
+        self.siteLoginInstructions = siteLoginInstructions
+    }
+}
+
+public extension WordPressAuthenticatorDisplayText {
+    public static var defaultText: WordPressAuthenticatorDisplayText {
+        return WordPressAuthenticatorDisplayText(emailLoginInstructions: NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.", comment: "Instruction text on the login's email address screen."),
+                                                 siteLoginInstructions: NSLocalizedString("Enter the address of your WordPress site you'd like to connect.", comment: "Instruction text on the login's site addresss screen."))
+    }
+}

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayText.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayText.swift
@@ -8,20 +8,23 @@ public struct WordPressAuthenticatorDisplayText {
     ///
     public let emailLoginInstructions: String
 
-    public let siteLoginInstructions: String
+    public let jetpackLoginInstructions: String
 
+    public let siteLoginInstructions: String
 
     /// Designated initializer.
     ///
-    public init(emailLoginInstructions: String, siteLoginInstructions: String) {
+    public init(emailLoginInstructions: String, jetpackLoginInstructions: String, siteLoginInstructions: String) {
         self.emailLoginInstructions = emailLoginInstructions
+        self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
     }
 }
 
 public extension WordPressAuthenticatorDisplayText {
     public static var defaultText: WordPressAuthenticatorDisplayText {
-        return WordPressAuthenticatorDisplayText(emailLoginInstructions: NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.", comment: "Instruction text on the login's email address screen."),
+        return WordPressAuthenticatorDisplayText(emailLoginInstructions: NSLocalizedString("Log in to WordPress.com using an email address to manage all your WordPress sites.", comment: "Instruction text on the login's email address screen."),
+                                                 jetpackLoginInstructions: NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.", comment: "Instruction text on the login's email address screen."),
                                                  siteLoginInstructions: NSLocalizedString("Enter the address of your WordPress site you'd like to connect.", comment: "Instruction text on the login's site addresss screen."))
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayText.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayText.swift
@@ -1,0 +1,9 @@
+//
+//  WordPressAuthenticatorDisplayText.swift
+//  WordPressAuthenticator
+//
+//  Created by Thuy Copeland on 12/4/18.
+//  Copyright © 2018 Automattic. All rights reserved.
+//
+
+import Foundation

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -100,8 +100,10 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
     func localizeControls() {
+        let displayText = WordPressAuthenticatorDisplayText.defaultText
+
         if loginFields.meta.jetpackLogin {
-            instructionLabel?.text = NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.", comment: "Instruction text on the login's email address screen.")
+            instructionLabel?.text = displayText.emailLoginInstructions
         } else {
             instructionLabel?.text = NSLocalizedString("Log in to WordPress.com using an email address to manage all your WordPress sites.", comment: "Instruction text on the login's email address screen.")
         }

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -101,9 +101,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     ///
     func localizeControls() {
         if loginFields.meta.jetpackLogin {
-            instructionLabel?.text = WordPressAuthenticator.shared.text.jetpackLoginInstructions
+            instructionLabel?.text = WordPressAuthenticator.shared.displayStrings.jetpackLoginInstructions
         } else {
-            instructionLabel?.text = WordPressAuthenticator.shared.text.emailLoginInstructions
+            instructionLabel?.text = WordPressAuthenticator.shared.displayStrings.emailLoginInstructions
         }
         emailTextField.placeholder = NSLocalizedString("Email address", comment: "Placeholder for a textfield. The user may enter their email address.")
         emailTextField.accessibilityIdentifier = "Email address"

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -100,10 +100,8 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
     func localizeControls() {
-        let displayText = WordPressAuthenticatorDisplayText.defaultText
-
         if loginFields.meta.jetpackLogin {
-            instructionLabel?.text = displayText.emailLoginInstructions
+            instructionLabel?.text = WordPressAuthenticator.shared.text.emailLoginInstructions
         } else {
             instructionLabel?.text = NSLocalizedString("Log in to WordPress.com using an email address to manage all your WordPress sites.", comment: "Instruction text on the login's email address screen.")
         }

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -101,9 +101,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     ///
     func localizeControls() {
         if loginFields.meta.jetpackLogin {
-            instructionLabel?.text = WordPressAuthenticator.shared.text.emailLoginInstructions
+            instructionLabel?.text = WordPressAuthenticator.shared.text.jetpackLoginInstructions
         } else {
-            instructionLabel?.text = NSLocalizedString("Log in to WordPress.com using an email address to manage all your WordPress sites.", comment: "Instruction text on the login's email address screen.")
+            instructionLabel?.text = WordPressAuthenticator.shared.text.emailLoginInstructions
         }
         emailTextField.placeholder = NSLocalizedString("Email address", comment: "Placeholder for a textfield. The user may enter their email address.")
         emailTextField.accessibilityIdentifier = "Email address"

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -67,7 +67,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
     @objc func localizeControls() {
-        instructionLabel?.text = WordPressAuthenticator.shared.text.siteLoginInstructions
+        instructionLabel?.text = WordPressAuthenticator.shared.displayStrings.siteLoginInstructions
 
         siteURLField.placeholder = NSLocalizedString("example.wordpress.com", comment: "Site Address placeholder")
 

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -67,7 +67,8 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
     @objc func localizeControls() {
-        instructionLabel?.text = NSLocalizedString("Enter the address of your WordPress site you'd like to connect.", comment: "Instruction text on the login's site addresss screen.")
+        let displayText = WordPressAuthenticatorDisplayText.defaultText
+        instructionLabel?.text = displayText.siteLoginInstructions
 
         siteURLField.placeholder = NSLocalizedString("example.wordpress.com", comment: "Site Address placeholder")
 

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -67,8 +67,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
     @objc func localizeControls() {
-        let displayText = WordPressAuthenticatorDisplayText.defaultText
-        instructionLabel?.text = displayText.siteLoginInstructions
+        instructionLabel?.text = WordPressAuthenticator.shared.text.siteLoginInstructions
 
         siteURLField.placeholder = NSLocalizedString("example.wordpress.com", comment: "Site Address placeholder")
 

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorDisplayTextTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorDisplayTextTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import WordPressAuthenticator
+
+// MARK: - WordPressAuthenticator Display Text Unit Tests
+//
+class WordPressAuthenticatorDisplayTextTests: XCTestCase {
+    /// Default display text instance
+    ///
+    let displayTextDefaults = WordPressAuthenticatorDisplayText.defaultText
+
+    /// Verifies that values in defaultText are not nil
+    ///
+    func testThatDefaultTextValuesAreNotNil() {
+        XCTAssertNotNil(displayTextDefaults.emailLoginInstructions)
+        XCTAssertNotNil(displayTextDefaults.siteLoginInstructions)
+    }
+
+    /// Verifies that values in defaultText are not empty strings
+    ///
+    func testThatDefaultTextValuesAreNotEmpty() {
+        XCTAssertFalse(displayTextDefaults.emailLoginInstructions.isEmpty)
+        XCTAssertFalse(displayTextDefaults.siteLoginInstructions.isEmpty)
+    }
+}

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorDisplayTextTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorDisplayTextTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class WordPressAuthenticatorDisplayTextTests: XCTestCase {
     /// Default display text instance
     ///
-    let displayTextDefaults = WordPressAuthenticatorDisplayText.defaultText
+    let displayTextDefaults = WordPressAuthenticatorDisplayStrings.defaultText
 
     /// Verifies that values in defaultText are not nil
     ///


### PR DESCRIPTION
Fixes #35. Ref. https://github.com/woocommerce/woocommerce-ios/issues/472.

**Background**
Some of the login text that displays to the user has instructions that are WordPress focused. It can be confusing to a user when the host app is WooCommerce instead. 

**Summary**
In this PR, we're exposing the instructions label and allowing the text to be overridden on init. The default display text remains the same for WordPress users. The `WordPressAuthenticatorDisplayText` struct is introduced as a way to manage any text that displays directly to the user. 

Better names welcomed! I tried: UserMessages, UIText, and TextOverrides. None of them quite fit.

**To Test (Pick one) - WCiOS Option**
1. Check out this PR and run it: https://github.com/woocommerce/woocommerce-ios/pull/487#event-2005399244

**To Test - WPiOS Option**
1. Using WPiOS, point the podfile to this branch: `pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS', :branch => 'feature/35-expose-login-text'`
2. `pod install` followed by `pod update`
3. Run the app and go through the email login flow, with an account that has Jetpack. The instructions should remain unchanged and say ```Log in to the WordPress.com account you used to connect Jetpack.``` 
4. Go to the site login flow. the instructions should remain unchanged and say ```Enter the address of your WordPress site you'd like to connect.``` 

Screenshots of WPiOS after installing this pod update:
<img src="https://user-images.githubusercontent.com/1062444/49472826-0beddc80-f7d6-11e8-9fdc-4cd9d6c52abf.png" width="350" />

<img src="https://user-images.githubusercontent.com/1062444/49472834-1019fa00-f7d6-11e8-88cf-164647e5e993.png" width="350" />