### PR TITLE
Corrected podspec version number

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.1.9-beta"
+  s.version       = "1.1.9-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
In the [preceding PR](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/49/), I omitted the beta suffix from the version in the podspec