### PR TITLE
CircleCI: Update specs repo before validating podspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.10
+  ios: wordpress-mobile/ios@0.0.13
 
 workflows:
   test_and_validate:
@@ -15,3 +15,4 @@ workflows:
       - ios/validate-podspec:
           name: Validate Podspec
           podspec-path: WordPressAuthenticator.podspec
+          update-specs-repo: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org' do
   gem 'cocoapods', '1.5.3'
-  gem 'cocoapods-check'
   gem 'cocoapods-repo-update'
   gem 'xcpretty'
 end


### PR DESCRIPTION
This is a small CircleCI config update that ensures the specs repo is up to date before validating the podspec. Without this change, CI could fail to find recently updated pods.

@stevebaranski This fixes the failure you encountered in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/50