### PR TITLE
Update accessibility identifiers to unique values

### DIFF
--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -110,14 +110,14 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             instructionLabel?.text = WordPressAuthenticator.shared.displayStrings.emailLoginInstructions
         }
         emailTextField.placeholder = NSLocalizedString("Email address", comment: "Placeholder for a textfield. The user may enter their email address.")
-        emailTextField.accessibilityIdentifier = "Email address"
+        emailTextField.accessibilityIdentifier = "Login Email Address"
 
         alternativeLoginLabel?.text = NSLocalizedString("Alternatively:", comment: "String displayed before offering alternative login methods")
 
         let submitButtonTitle = NSLocalizedString("Next", comment: "Title of a button. The text should be capitalized.").localizedCapitalized
         submitButton?.setTitle(submitButtonTitle, for: .normal)
         submitButton?.setTitle(submitButtonTitle, for: .highlighted)
-        submitButton?.accessibilityIdentifier = "Next Button"
+        submitButton?.accessibilityIdentifier = "Login Email Next Button"
     }
 
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -63,7 +63,7 @@ class LoginPrologueViewController: LoginViewController {
         let loginTitle = NSLocalizedString("Log In", comment: "Button title.  Tapping takes the user to the login form.")
         let createTitle = NSLocalizedString("Sign up for WordPress.com", comment: "Button title. Tapping begins the process of creating a WordPress.com account.")
 
-        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Log In Button") { [weak self] in
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
             self?.loginTapped()
         }
         buttonViewController.setupBottomButton(title: createTitle, isPrimary: false) { [weak self] in

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -74,7 +74,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         let submitButtonTitle = NSLocalizedString("Next", comment: "Title of a button. The text should be capitalized.").localizedCapitalized
         submitButton?.setTitle(submitButtonTitle, for: .normal)
         submitButton?.setTitle(submitButtonTitle, for: .highlighted)
-        submitButton?.accessibilityIdentifier = "Next Button"
+        submitButton?.accessibilityIdentifier = "Site Address Next Button"
 
         let siteAddressHelpTitle = NSLocalizedString("Need help finding your site address?", comment: "A button title.")
         siteAddressHelpButton.setTitle(siteAddressHelpTitle, for: .normal)

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -131,7 +131,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         let submitButtonTitle = NSLocalizedString("Next", comment: "Title of a button. The text should be capitalized.").localizedCapitalized
         submitButton?.setTitle(submitButtonTitle, for: .normal)
         submitButton?.setTitle(submitButtonTitle, for: .highlighted)
-        submitButton?.accessibilityIdentifier = "Log In Button"
+        submitButton?.accessibilityIdentifier = "Password Next Button"
 
         let forgotPasswordTitle = NSLocalizedString("Lost your password?", comment: "Title of a button. ")
         forgotPasswordButton?.setTitle(forgotPasswordTitle, for: .normal)

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -74,13 +74,13 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
         instructionLabel?.text = NSLocalizedString("To create your new WordPress.com account, please enter your email address.", comment: "Text instructing the user to enter their email address.")
 
         emailField.placeholder = NSLocalizedString("Email address", comment: "Placeholder for a textfield. The user may enter their email address.")
-        emailField.accessibilityIdentifier = "Email address"
+        emailField.accessibilityIdentifier = "Signup Email Address"
         emailField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
 
         let submitButtonTitle = NSLocalizedString("Next", comment: "Title of a button. The text should be capitalized.").localizedCapitalized
         submitButton?.setTitle(submitButtonTitle, for: .normal)
         submitButton?.setTitle(submitButtonTitle, for: .highlighted)
-        submitButton?.accessibilityIdentifier = "Next Button"
+        submitButton?.accessibilityIdentifier = "Signup Email Next Button"
     }
 
     /// Configure the view for an editing state. Should only be called from viewWillAppear


### PR DESCRIPTION
This PR updates duplicate accessibility identifiers ("Email address", "Log In Button", and "Next Button") to unique values. This ensures that during UI testing we're targeting the correct element.

Corresponding WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/10987