### PR TITLE
Check if fetchSiteInfo fails due to authorization required (private)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -17,7 +17,7 @@ target 'WordPressAuthenticator' do
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  pod 'WordPressKit', '~> 2.1.0-beta.1'
+  pod 'WordPressKit', '~> 2.1.0-beta.2'
   pod 'WordPressShared', '~> 1.4'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -17,7 +17,8 @@ target 'WordPressAuthenticator' do
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  pod 'WordPressKit', '~> 2.0-beta'
+  #pod 'WordPressKit', '~> 2.0-beta'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '900a32001f4acbbd688b3677c0eee2a2be9e36d6'
   pod 'WordPressShared', '~> 1.4'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -17,8 +17,7 @@ target 'WordPressAuthenticator' do
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  #pod 'WordPressKit', '~> 2.0-beta'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '900a32001f4acbbd688b3677c0eee2a2be9e36d6'
+  pod 'WordPressKit', '~> 2.1.0-beta.1'
   pod 'WordPressShared', '~> 1.4'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -52,7 +52,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.6.0):
+  - WordPressShared (1.7.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
@@ -72,7 +72,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `900a32001f4acbbd688b3677c0eee2a2be9e36d6`)
+  - WordPressKit (~> 2.1.0-beta.1)
   - WordPressShared (~> 1.4)
   - WordPressUI (~> 1.0)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :commit: 900a32001f4acbbd688b3677c0eee2a2be9e36d6
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 900a32001f4acbbd688b3677c0eee2a2be9e36d6
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -126,10 +117,10 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPressKit: 8605e6564f1dfa846265b2d3b48f950d02ae3173
-  WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
+  WordPressShared: cfbda56868419842dd7a106a4e807069a0c17aa9
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 3194ff70efcb1bb9c9a5c05d592e16f533803a41
+PODFILE CHECKSUM: 13ca7f3f55bbb52f21f966a1b0a562739dcbe177
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (2.1.0-beta.1):
+  - WordPressKit (2.1.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -72,7 +72,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 2.1.0-beta.1)
+  - WordPressKit (~> 2.1.0-beta.2)
   - WordPressShared (~> 1.4)
   - WordPressUI (~> 1.0)
 
@@ -116,11 +116,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 8605e6564f1dfa846265b2d3b48f950d02ae3173
+  WordPressKit: 7d4e523fe984ecb913342a456d458f50844f416b
   WordPressShared: cfbda56868419842dd7a106a4e807069a0c17aa9
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 13ca7f3f55bbb52f21f966a1b0a562739dcbe177
+PODFILE CHECKSUM: 79c15e97af9d0b04178bef7c338a4be0a5a918d0
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (2.0.0-beta.1):
+  - WordPressKit (2.1.0-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -72,7 +72,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 2.0-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `900a32001f4acbbd688b3677c0eee2a2be9e36d6`)
   - WordPressShared (~> 1.4)
   - WordPressUI (~> 1.0)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :commit: 900a32001f4acbbd688b3677c0eee2a2be9e36d6
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 900a32001f4acbbd688b3677c0eee2a2be9e36d6
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -116,11 +125,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 2b6f01a7459d358b8cf6d825348c6cf7174107b2
+  WordPressKit: 8605e6564f1dfa846265b2d3b48f950d02ae3173
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 82ea8bb53494ef9ee71085384656b7fd8edc69b8
+PODFILE CHECKSUM: 3194ff70efcb1bb9c9a5c05d592e16f533803a41
 
 COCOAPODS: 1.5.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.2.0-beta.1"
+  s.version       = "1.1.9"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -34,6 +34,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignInRepacked', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
-  s.dependency 'WordPressKit', '~> 2.1.0-beta.1'
+  s.dependency 'WordPressKit', '~> 2.1.0-beta.2'
   s.dependency 'WordPressShared', '~> 1.4'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.1.9"
+  s.version       = "1.2.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -34,6 +34,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignInRepacked', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
-  s.dependency 'WordPressKit', '~> 2.0-beta'
+  s.dependency 'WordPressKit', '~> 2.1.0-beta.1'
   s.dependency 'WordPressShared', '~> 1.4'
 end

--- a/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -33,6 +33,22 @@ class WordPressComBlogService {
             failure(result)
         })
     }
+    
+     func fetchUnauthenticatedSiteInfoForAddress(for address: String, success: @escaping (WordPressComSiteInfo) -> Void, failure: @escaping (Error) -> Void) {
+        let remote = BlogServiceRemoteREST(wordPressComRestApi: anonymousAPI, siteID: 0)
+        remote.fetchUnauthenticatedSiteInfo(forAddress: address, success: { response in
+            guard let response = response else {
+                failure(ServiceError.unknown)
+                return
+            }
+            
+            let site = WordPressComSiteInfo(remote: response)
+            success(site)
+        }, failure: { error in
+            let result = error ?? ServiceError.unknown
+            failure(result)
+        }) 
+    }
 }
 
 


### PR DESCRIPTION
And handle accordingly.
Fix: #52 

If fetchSiteInfo fails due to privacy we call a new method that utilizes the call for connect/site-info.
If this call returns successfully we check if the user is already logged in with a WPCom site and if they are we show the alert to logout.