### PR TITLE
Updated WordPressAuthenticator to absorb latest changes to WordPressKit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -17,7 +17,8 @@ target 'WordPressAuthenticator' do
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  pod 'WordPressKit', '~> 2.1.0-beta.2'
+  #pod 'WordPressKit', '~> 2.1.0-beta.2'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0e2a035'
   pod 'WordPressShared', '~> 1.4'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -17,8 +17,7 @@ target 'WordPressAuthenticator' do
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  #pod 'WordPressKit', '~> 2.1.0-beta.2'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0e2a035'
+  pod 'WordPressKit', '~> 3.0.0-beta.1'
   pod 'WordPressShared', '~> 1.4'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0e2a035`)
+  - WordPressKit (~> 3.0.0-beta.1)
   - WordPressShared (~> 1.4)
   - WordPressUI (~> 1.0)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :commit: 0e2a035
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 0e2a035
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -130,6 +121,6 @@ SPEC CHECKSUMS:
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 5e3e670c805373c6a257b7a6eb607a0c8d7a8e0e
+PODFILE CHECKSUM: bba3fa5287f208435d83f079ef7069a51a5c090a
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (2.1.0-beta.2):
+  - WordPressKit (3.0.0-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -72,7 +72,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 2.1.0-beta.2)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0e2a035`)
   - WordPressShared (~> 1.4)
   - WordPressUI (~> 1.0)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :commit: 0e2a035
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 0e2a035
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -116,11 +125,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 7d4e523fe984ecb913342a456d458f50844f416b
+  WordPressKit: 843906cb26fb8a92dddefd9a324a821555bf2b94
   WordPressShared: cfbda56868419842dd7a106a4e807069a0c17aa9
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 79c15e97af9d0b04178bef7c338a4be0a5a918d0
+PODFILE CHECKSUM: 5e3e670c805373c6a257b7a6eb607a0c8d7a8e0e
 
 COCOAPODS: 1.5.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.1.9"
+  s.version       = "1.1.10-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -34,6 +34,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignInRepacked', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
-  s.dependency 'WordPressKit', '~> 2.1.0-beta.2'
+  s.dependency 'WordPressKit', '~> 3.0.0-beta.1'
   s.dependency 'WordPressShared', '~> 1.4'
 end

--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -21,10 +21,8 @@ class SignupService {
                                    failure: @escaping (_ error: Error) -> Void) {
 
         let remote = WordPressComServiceRemote(wordPressComRestApi: anonymousAPI)
-        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
 
         remote.createWPComAccount(withGoogle: token,
-                                  andLocale: locale,
                                   andClientID: configuration.wpcomClientId,
                                   andClientSecret: configuration.wpcomSecret,
                                   success: { response in


### PR DESCRIPTION
Supports the resolution of [this issue](https://github.com/wordpress-mobile/WordPressKit-iOS/issues/86) in `WordPressKit`.

I've designated this a Draft PR, unless or until the associated update to [`WordPressKit`](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/103) has been properly versioned.

To test:

- Branch should build.
- Tests should pass.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.