### PR TITLE
Issues/wpcom credentials change

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.1.11"
+  s.version       = "1.2.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -247,10 +247,7 @@ import WordPressUI
             return false
         }
 
-        guard let loginFields = retrieveLoginInfoForTokenAuth() else {
-            DDLogInfo("App opened with authentication link but info wasn't found for token.")
-            return false
-        }
+        let loginFields = retrieveLoginInfoForTokenAuth()
 
         // The only time we should expect a magic link login when there is already a default wpcom account
         // is when a user is logging into Jetpack.
@@ -265,7 +262,6 @@ import WordPressUI
             return false
         }
         loginController.loginFields = loginFields
-        loginController.email = loginFields.username
         loginController.token = token
         let controller = loginController
 
@@ -370,13 +366,14 @@ import WordPressUI
     ///
     /// - Returns: A loginFields instance or nil.
     ///
-    class func retrieveLoginInfoForTokenAuth() -> LoginFields? {
-
-        guard let dict = UserDefaults.standard.dictionary(forKey: Constants.authenticationInfoKey) else {
-            return nil
-        }
+    class func retrieveLoginInfoForTokenAuth() -> LoginFields {
 
         let loginFields = LoginFields()
+
+        guard let dict = UserDefaults.standard.dictionary(forKey: Constants.authenticationInfoKey) else {
+            return loginFields
+        }
+
         if let username = dict[Constants.username] as? String {
             loginFields.username = username
         }

--- a/WordPressAuthenticator/Credentials/WordPressCredentials.swift
+++ b/WordPressAuthenticator/Credentials/WordPressCredentials.swift
@@ -9,5 +9,5 @@ public enum WordPressCredentials {
 
     /// WordPress.com Site Credentials.
     ///
-    case wpcom(username: String, authToken: String, isJetpackLogin: Bool, multifactor: Bool)
+    case wpcom(authToken: String, isJetpackLogin: Bool, multifactor: Bool)
 }

--- a/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
@@ -9,15 +9,13 @@ import WordPressShared
 ///
 class NUXLinkAuthViewController: LoginViewController {
     @IBOutlet weak var statusLabel: UILabel?
-    @objc var email: String = ""
     @objc var token: String = ""
     @objc var didSync: Bool = false
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        // Gotta have email and token to use this vc
-        assert(!email.isEmpty, "Email cannot be nil")
+        // Gotta have a token to use this vc
         assert(!token.isEmpty, "Email token cannot be nil")
 
         if didSync {
@@ -26,7 +24,7 @@ class NUXLinkAuthViewController: LoginViewController {
 
         didSync = true // Make sure we don't call this twice by accident
 
-        let credentials = WordPressCredentials.wpcom(username: email, authToken: token, isJetpackLogin: isJetpackLogin, multifactor: false)
+        let credentials = WordPressCredentials.wpcom(authToken: token, isJetpackLogin: isJetpackLogin, multifactor: false)
         syncWPComAndPresentEpilogue(credentials: credentials)
 
         // Count this as success since we're authed. Even if there is a glitch

--- a/WordPressAuthenticator/Services/LoginFacade.h
+++ b/WordPressAuthenticator/Services/LoginFacade.h
@@ -150,7 +150,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Called when finished logging in to a WordPress.com site
  *
- *  @param username                 username of the site
  *  @param authToken                authToken to be used to access the site
  *  @param requiredMultifactorCode  whether the login required a 2fa code
  */

--- a/WordPressAuthenticator/Services/LoginFacade.h
+++ b/WordPressAuthenticator/Services/LoginFacade.h
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param authToken                authToken to be used to access the site
  *  @param requiredMultifactorCode  whether the login required a 2fa code
  */
-- (void)finishedLoginWithUsername:(NSString *)username authToken:(NSString *)authToken requiredMultifactorCode:(BOOL)requiredMultifactorCode;
+- (void)finishedLoginWithAuthToken:(NSString *)authToken requiredMultifactorCode:(BOOL)requiredMultifactorCode;
 
 
 /**

--- a/WordPressAuthenticator/Services/LoginFacade.m
+++ b/WordPressAuthenticator/Services/LoginFacade.m
@@ -122,8 +122,8 @@
     }
 
     [self.wordpressComOAuthClientFacade authenticateWithUsername:loginFields.username password:loginFields.password multifactorCode:loginFields.multifactorCode success:^(NSString *authToken) {
-        if ([self.delegate respondsToSelector:@selector(finishedLoginWithUsername:authToken:requiredMultifactorCode:)]) {
-            [self.delegate finishedLoginWithUsername:loginFields.username authToken:authToken requiredMultifactorCode:loginFields.meta.requiredMultifactor];
+        if ([self.delegate respondsToSelector:@selector(finishedLoginWithAuthToken:requiredMultifactorCode:)]) {
+            [self.delegate finishedLoginWithAuthToken:authToken requiredMultifactorCode:loginFields.meta.requiredMultifactor];
         }
     } needsMultiFactor:^{
         if ([self.delegate respondsToSelector:@selector(needsMultifactorCode)]) {

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -172,7 +172,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
     }
 
     func finishedLogin(withNonceAuthToken authToken: String) {
-        let credentials = WordPressCredentials.wpcom(username: loginFields.username, authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: true)
+        let credentials = WordPressCredentials.wpcom(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: true)
         syncWPComAndPresentEpilogue(credentials: credentials)
 
         // Disconnect now that we're done with Google.

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -538,7 +538,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 // LoginFacadeDelegate methods for Google Google Sign In
 extension LoginEmailViewController {
     func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
-        let credentials = WordPressCredentials.wpcom(username: loginFields.username, authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: false)
+        let credentials = WordPressCredentials.wpcom(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: false)
         syncWPComAndPresentEpilogue(credentials: credentials)
 
         // Disconnect now that we're done with Google.

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -155,8 +155,8 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     }
 
     // MARK: SigninWPComSyncHandler methods
-    dynamic open func finishedLogin(withUsername username: String, authToken: String, requiredMultifactorCode: Bool) {
-        let credentials = WordPressCredentials.wpcom(username: username, authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: requiredMultifactorCode)
+    dynamic open func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
+        let credentials = WordPressCredentials.wpcom(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: requiredMultifactorCode)
 
         syncWPComAndPresentEpilogue(credentials: credentials)
 
@@ -247,7 +247,7 @@ extension LoginViewController {
         switch credentials {
         case .wporg:
             break
-        case .wpcom(_, _, _, let multifactor):
+        case .wpcom(_, _, let multifactor):
             properties = [
                 "multifactor": multifactor.description,
                 "dotcom_user": true.description

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -100,7 +100,7 @@ private extension SignupGoogleViewController {
 
         service.createWPComUserWithGoogle(token: googleToken, success: { [weak self] accountCreated, wpcomUsername, wpcomToken in
 
-            let credentials = WordPressCredentials.wpcom(username: wpcomUsername, authToken: wpcomToken, isJetpackLogin: false, multifactor: false)
+            let credentials = WordPressCredentials.wpcom(authToken: wpcomToken, isJetpackLogin: false, multifactor: false)
 
             /// New Account: We'll signal the host app right away!
             ///

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -46,12 +46,13 @@ class WordPressAuthenticatorTests: XCTestCase {
         WordPressAuthenticator.storeLoginInfoForTokenAuth(loginFields)
 
         var retrievedLoginFields = WordPressAuthenticator.retrieveLoginInfoForTokenAuth()
-        let retrievedEmail = loginFields.username
+        var retrievedEmail = retrievedLoginFields.username
         XCTAssert(email == retrievedEmail, "The email retrived should match the email that was saved.")
 
         WordPressAuthenticator.deleteLoginInfoForTokenAuth()
         retrievedLoginFields = WordPressAuthenticator.retrieveLoginInfoForTokenAuth()
+        retrievedEmail = retrievedLoginFields.username
 
-        XCTAssert(retrievedLoginFields == nil, "Saved loginFields should be deleted after calling deleteLoginInfoForTokenAuth.")
+        XCTAssert(email != retrievedEmail, "Saved loginFields should be deleted after calling deleteLoginInfoForTokenAuth.")
     }
 }

--- a/WordPressAuthenticatorTests/Services/LoginFacadeTests.m
+++ b/WordPressAuthenticatorTests/Services/LoginFacadeTests.m
@@ -71,7 +71,7 @@ describe(@"signInWithLoginFields", ^{
                 
                 successStub(authToken);
             }];
-            [[mockLoginFacadeDelegate expect] finishedLoginWithUsername:loginFields.username authToken:authToken requiredMultifactorCode:loginFields.meta.requiredMultifactor];
+            [[mockLoginFacadeDelegate expect] finishedLoginWithAuthToken:authToken requiredMultifactorCode:loginFields.meta.requiredMultifactor];
             
             [loginFacade signInWithLoginFields:loginFields];
             


### PR DESCRIPTION
This PR removes the `username` from wpcom credentials. 

The motivation for this change is to allow log in with *just* an auth token, and letting the username be synced later with the rest of a user's account information. 

To Test: 
Run tests and ensure they pass. 
Test the changes branch with the companion WPiOS PR.

Needs review: @ScoutHarris would you be game to look at this one? 

cc @mindgraffiti @bummytime - FYI. I haven't looked to see how this impacts WooCommerce-iOS but its on my todos.