### PR TITLE
Fix compatibility with recent versions of CocoaPods (> 1.5.3)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,20 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.13
+  ios: wordpress-mobile/ios@0.0.23
 
 workflows:
   test_and_validate:
     jobs:
       - ios/test:
           name: Test
+          xcode-version: "10.1.0"
           workspace: WordPressAuthenticator.xcworkspace
           scheme: WordPressAuthenticator
-          destination: "platform=iOS Simulator,name=iPhone XS,OS=latest"
+          device: iPhone XS
+          ios-version: "12.1"
       - ios/validate-podspec:
           name: Validate Podspec
+          xcode-version: "10.1.0"
           podspec-path: WordPressAuthenticator.podspec
           update-specs-repo: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.0)
-    activesupport (4.2.11)
+    activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -28,26 +28,24 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.1)
       xcodeproj (>= 1.5.7, < 2.0)
-    cocoapods-check (1.0.2)
-      cocoapods (~> 1.0)
     cocoapods-core (1.5.3)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
-    cocoapods-deintegrate (1.0.2)
+    cocoapods-deintegrate (1.0.3)
     cocoapods-downloader (1.2.2)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-repo-update (0.0.4)
       cocoapods (~> 1.0, >= 1.3.0)
     cocoapods-search (1.0.0)
-    cocoapods-stats (1.0.0)
+    cocoapods-stats (1.1.0)
     cocoapods-trunk (1.3.1)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     escape (0.0.4)
     fourflusher (2.0.1)
     fuzzy_match (2.0.4)
@@ -60,11 +58,11 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     rouge (2.0.7)
-    ruby-macho (1.3.1)
+    ruby-macho (1.4.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.7.0)
+    xcodeproj (1.8.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -78,7 +76,6 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.5.3)!
-  cocoapods-check!
   cocoapods-repo-update!
   xcpretty!
 

--- a/Podfile
+++ b/Podfile
@@ -26,7 +26,7 @@ target 'WordPressAuthenticator' do
   pod '1PasswordExtension', '1.8.5'
   pod 'Alamofire', '4.7.3'
   pod 'CocoaLumberjack', '3.4.2'
-  pod 'GoogleSignInRepacked', '4.1.2'
+  pod 'GoogleSignIn', '4.1.2'
   pod 'lottie-ios', '2.5.2'
   pod 'NSURL+IDN', '0.3'
   pod 'SVProgressHUD', '2.2.5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,9 +11,11 @@ PODS:
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
-  - GoogleSignInRepacked (4.1.2):
+  - GoogleSignIn (4.1.2):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
     - "GoogleToolboxForMac/NSString+URLArguments (~> 2.1)"
+    - GTMOAuth2 (~> 1.0)
+    - GTMSessionFetcher/Core (~> 1.1)
   - GoogleToolboxForMac/DebugUtils (2.2.0):
     - GoogleToolboxForMac/Defines (= 2.2.0)
   - GoogleToolboxForMac/Defines (2.2.0)
@@ -23,6 +25,13 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.0)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.0)"
   - Gridicons (0.18)
+  - GTMOAuth2 (1.1.6):
+    - GTMSessionFetcher (~> 1.1)
+  - GTMSessionFetcher (1.2.1):
+    - GTMSessionFetcher/Full (= 1.2.1)
+  - GTMSessionFetcher/Core (1.2.1)
+  - GTMSessionFetcher/Full (1.2.1):
+    - GTMSessionFetcher/Core (= 1.2.1)
   - lottie-ios (2.5.2)
   - NSObject-SafeExpectations (0.0.3)
   - "NSURL+IDN (0.3)"
@@ -63,7 +72,7 @@ DEPENDENCIES:
   - Alamofire (= 4.7.3)
   - CocoaLumberjack (= 3.4.2)
   - Expecta (= 1.0.6)
-  - GoogleSignInRepacked (= 4.1.2)
+  - GoogleSignIn (= 4.1.2)
   - Gridicons (~> 0.15)
   - lottie-ios (= 2.5.2)
   - "NSURL+IDN (= 0.3)"
@@ -83,9 +92,11 @@ SPEC REPOS:
     - CocoaLumberjack
     - Expecta
     - FormatterKit
-    - GoogleSignInRepacked
+    - GoogleSignIn
     - GoogleToolboxForMac
     - Gridicons
+    - GTMOAuth2
+    - GTMSessionFetcher
     - lottie-ios
     - NSObject-SafeExpectations
     - "NSURL+IDN"
@@ -105,9 +116,11 @@ SPEC CHECKSUMS:
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
-  GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
+  GoogleSignIn: d9ef55b10f0aa401a5de2747f59b725e4b9732ac
   GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d
   Gridicons: 04261236382e9c62c62c9a104f2f532c1bdf6a78
+  GTMOAuth2: e8b6512c896235149df975c41d9a36c868ab7fba
+  GTMSessionFetcher: 32aeca0aa144acea523e1c8e053089dec2cb98ca
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
   "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
@@ -121,6 +134,6 @@ SPEC CHECKSUMS:
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 220853b585b7b73f8958c30e6f9c1c5760d4c7a3
+PODFILE CHECKSUM: 81ee24d3e673c260c315ab899b9129f9ef5ba1c9
 
 COCOAPODS: 1.5.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -18,8 +18,17 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git", :tag => s.version.to_s }
   s.source_files  = 'WordPressAuthenticator/**/*.{h,m,swift}'
   s.private_header_files = "WordPressAuthenticator/Private/*.h"
-  s.resources     = [ 'WordPressAuthenticator/**/*.{xcassets,storyboard,xib,json}' ]
+  s.resource_bundles = {
+    'WordPressAuthenticatorResources': [
+      'WordPressAuthenticator/Resources/Assets.xcassets',
+      'WordPressAuthenticator/Resources/Animations/*.json'
+    ]
+  }
+  s.resources     = [
+    'WordPressAuthenticator/**/*.{storyboard,xib}'
+  ]
   s.requires_arc  = true
+  s.static_framework = true # This is needed because GoogleSignIn vendors a static framework
   s.header_dir    = 'WordPressAuthenticator'
 
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
@@ -32,7 +41,7 @@ Pod::Spec.new do |s|
   s.dependency 'SVProgressHUD', '2.2.5'
 
   s.dependency 'Gridicons', '~> 0.15'
-  s.dependency 'GoogleSignInRepacked', '4.1.2'
+  s.dependency 'GoogleSignIn', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
   s.dependency 'WordPressKit', '~> 3.1'
   s.dependency 'WordPressShared', '~> 1.4'

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -688,7 +688,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-resources.sh",
-				"${PODS_ROOT}/GoogleSignInRepacked/Resources/GoogleSignIn.bundle",
+				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
@@ -708,7 +708,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator-resources.sh",
-				"${PODS_ROOT}/GoogleSignInRepacked/Resources/GoogleSignIn.bundle",
+				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -770,7 +770,8 @@
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
-				"${PODS_ROOT}/GoogleSignInRepacked/Frameworks/GoogleSignIn.framework",
+				"${BUILT_PRODUCTS_DIR}/GTMOAuth2/GTMOAuth2.framework",
+				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
 				"${BUILT_PRODUCTS_DIR}/Gridicons/Gridicons.framework",
 				"${BUILT_PRODUCTS_DIR}/NSObject-SafeExpectations/NSObject_SafeExpectations.framework",
@@ -793,7 +794,8 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMOAuth2.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Gridicons.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSObject_SafeExpectations.framework",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -133,7 +133,7 @@ import WordPressUI
             trackOpenedLogin()
         }
 
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
         if let controller = storyboard.instantiateInitialViewController() {
             if let childController = controller.children.first as? LoginPrologueViewController {
                 childController.loginFields.restrictToWPCom = restrictToWPCom
@@ -149,7 +149,7 @@ import WordPressUI
             trackOpenedLogin()
         }
 
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? LoginEmailViewController else {
             return
         }
@@ -183,7 +183,7 @@ import WordPressUI
     /// Returns an instance of LoginSiteAddressViewController: allows the user to log into a WordPress.org website.
     ///
     @objc public class func signinForWPOrg() -> UIViewController {
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "siteAddress") as? LoginSiteAddressViewController else {
             fatalError("unable to create wpcom password screen")
         }
@@ -199,7 +199,7 @@ import WordPressUI
         loginFields.emailAddress = dotcomEmailAddress ?? String()
         loginFields.username = dotcomUsername ?? String()
 
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "LoginWPcomPassword") as? LoginWPComViewController else {
             fatalError("unable to create wpcom password screen")
         }
@@ -215,7 +215,7 @@ import WordPressUI
     /// it's features.
     ///
     public class func signinForWPCom() -> LoginEmailViewController {
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? LoginEmailViewController else {
             fatalError()
         }
@@ -256,7 +256,7 @@ import WordPressUI
             return false
         }
 
-        let storyboard = UIStoryboard(name: "EmailMagicLink", bundle: bundle)
+        let storyboard = UIStoryboard(name: "EmailMagicLink", bundle: mainBundle)
         guard let loginController = storyboard.instantiateViewController(withIdentifier: "LinkAuthView") as? NUXLinkAuthViewController else {
             DDLogInfo("App opened with authentication link but couldn't create login screen.")
             return false
@@ -416,12 +416,23 @@ import WordPressUI
         UIApplication.shared.open(forgotPasswordURL)
     }
 
-    /// Returns the WordPressAuthenticator Bundle
+    /// Returns the WordPressAuthenticator main bundle
     ///
-    class var bundle: Bundle {
+    class var mainBundle: Bundle {
         return Bundle(for: WordPressAuthenticator.self)
     }
-
+    
+    /// Returns the WordPressAuthenticatorResouces.bundle
+    ///
+    class var resourcesBundle: Bundle {
+        // If installed with CocoaPods, resources will be in WordPressAuthenticatorResources.bundle
+        if let bundleURL = mainBundle.resourceURL,
+            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPressAuthenticatorResources.bundle")) {
+            return resourceBundle
+        }
+        // Otherwise, the main bundle is used for resources
+        return mainBundle
+    }
 
     // MARK: - 1Password Helper
 

--- a/WordPressAuthenticator/Extensions/UIImage+Assets.swift
+++ b/WordPressAuthenticator/Extensions/UIImage+Assets.swift
@@ -29,6 +29,6 @@ extension UIImage {
     /// Returns WordPressAuthenticator's Bundle
     ///
     private static var bundle: Bundle {
-        return Bundle(for: WordPressAuthenticator.self)
+        return WordPressAuthenticator.resourcesBundle
     }
 }

--- a/WordPressAuthenticator/NUX/NUXButtonView.storyboard
+++ b/WordPressAuthenticator/NUX/NUXButtonView.storyboard
@@ -13,7 +13,7 @@
         <!--Button View Controller-->
         <scene sceneID="Mo4-UQ-zlD">
             <objects>
-                <viewController storyboardIdentifier="ButtonView" id="aOG-7h-6d9" customClass="NUXButtonViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ButtonView" id="aOG-7h-6d9" customClass="NUXButtonViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="d2l-kB-WtE">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="148"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -27,7 +27,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="xzf-f5-7zQ" userLabel="Button Stack View">
                                 <rect key="frame" x="20" y="20" width="335" height="103"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="knN-O6-M86" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="knN-O6-M86" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectSite"/>
                                         <constraints>
@@ -41,7 +41,7 @@
                                             <action selector="secondaryButtonPressed:" destination="aOG-7h-6d9" eventType="touchUpInside" id="UXk-DD-td0"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M7J-a3-klP" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M7J-a3-klP" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="70" width="335" height="33"/>
                                         <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                         <constraints>
@@ -59,7 +59,7 @@
                                             <action selector="primaryButtonPressed:" destination="aOG-7h-6d9" eventType="touchUpInside" id="W8M-wW-PhN"/>
                                         </connections>
                                     </button>
-                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uAF-kU-f7P" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uAF-kU-f7P" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="103" width="335" height="50"/>
                                         <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                         <constraints>

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -169,7 +169,7 @@ extension NUXButtonViewController {
     /// Returns a new NUXButtonViewController Instance
     ///
     public class func instance() -> NUXButtonViewController {
-        let storyboard = UIStoryboard(name: "NUXButtonView", bundle: Bundle(for: self))
+        let storyboard = UIStoryboard(name: "NUXButtonView", bundle: WordPressAuthenticator.mainBundle)
         guard let buttonViewController = storyboard.instantiateViewController(withIdentifier: "ButtonView") as? NUXButtonViewController else {
             fatalError()
         }

--- a/WordPressAuthenticator/Signin/EmailMagicLink.storyboard
+++ b/WordPressAuthenticator/Signin/EmailMagicLink.storyboard
@@ -13,7 +13,7 @@
         <!--Link Auth View Controller-->
         <scene sceneID="SIF-Pr-Kgx">
             <objects>
-                <viewController storyboardIdentifier="LinkAuthView" useStoryboardIdentifierAsRestorationIdentifier="YES" id="VcT-PA-0lj" customClass="NUXLinkAuthViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LinkAuthView" useStoryboardIdentifierAsRestorationIdentifier="YES" id="VcT-PA-0lj" customClass="NUXLinkAuthViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="e8j-zJ-CeU"/>
                         <viewControllerLayoutGuide type="bottom" id="ftd-m3-Cpd"/>
@@ -52,7 +52,7 @@
         <!--Link Mail View Controller-->
         <scene sceneID="zhV-IL-bW4">
             <objects>
-                <viewController storyboardIdentifier="LinkMailView" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="GSd-vy-rpZ" customClass="NUXLinkMailViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LinkMailView" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="GSd-vy-rpZ" customClass="NUXLinkMailViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="s8Z-uG-nj5"/>
                         <viewControllerLayoutGuide type="bottom" id="vKK-Mm-0yR"/>
@@ -91,7 +91,7 @@
                                             </mask>
                                         </variation>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Iy-9H-ykD" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Iy-9H-ykD" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                         <rect key="frame" x="114" y="306.5" width="75" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="tyz-kt-Arb"/>
@@ -122,7 +122,7 @@
                                     </mask>
                                 </variation>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b0O-LO-6ax" customClass="SubheadlineButton" customModule="WordPress" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b0O-LO-6ax" customClass="SubheadlineButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="617" width="375" height="30"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <state key="normal" title="Enter your password instead">

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -607,7 +607,7 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
         cleanupAfterSocialErrors()
 
 
-        let storyboard = UIStoryboard(name: "Signup", bundle: Bundle(for: LoginEmailViewController.self))
+        let storyboard = UIStoryboard(name: "Signup", bundle: WordPressAuthenticator.mainBundle)
         if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
             controller.loginFields = loginFields
             navigationController?.pushViewController(controller, animated: true)

--- a/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
@@ -61,7 +61,7 @@ class LoginProloguePromoViewController: UIViewController {
         headingLabel = UILabel()
         animationHolder = UIView()
 
-        let bundle = Bundle(for: WordPressAuthenticator.self)
+        let bundle = WordPressAuthenticator.resourcesBundle
         animationView = LOTAnimationView(name: type.animationKey, bundle: bundle)
 
         super.init(nibName: nil, bundle: nil)

--- a/WordPressAuthenticator/Signup/Signup.storyboard
+++ b/WordPressAuthenticator/Signup/Signup.storyboard
@@ -14,7 +14,7 @@
         <!--Signup Navigation Controller-->
         <scene sceneID="qmz-tc-K4f">
             <objects>
-                <navigationController id="N83-gK-pDm" customClass="SignupNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController id="N83-gK-pDm" customClass="SignupNavigationController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="hUd-8k-dJs">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -30,7 +30,7 @@
         <!--Signup Email View Controller-->
         <scene sceneID="b2m-u4-I3H">
             <objects>
-                <viewController storyboardIdentifier="emailEntry" id="Opx-rl-H3d" customClass="SignupEmailViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="emailEntry" id="Opx-rl-H3d" customClass="SignupEmailViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="F3A-pe-bcZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -47,7 +47,7 @@
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HTy-KJ-his" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HTy-KJ-his" customClass="LoginTextField" customModule="WordPressAuthenticator" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="58" width="375" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
@@ -85,7 +85,7 @@
                                             <constraint firstAttribute="trailing" secondItem="EYw-oM-W1K" secondAttribute="trailing" constant="20" id="q6O-HJ-f7f"/>
                                         </constraints>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Su-Zc-Omp" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Su-Zc-Omp" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
                                         <rect key="frame" x="319" y="539" width="36" height="44"/>
                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                         <constraints>
@@ -142,7 +142,7 @@
         <!--Signup Google View Controller-->
         <scene sceneID="WBb-bn-nnr">
             <objects>
-                <viewController storyboardIdentifier="googleSignup" id="cgk-WR-8PR" customClass="SignupGoogleViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="googleSignup" id="cgk-WR-8PR" customClass="SignupGoogleViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3UA-HJ-Orw">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/WordPressAuthenticator/UI/SearchTableViewCell.xib
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.xib
@@ -12,14 +12,14 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="54" id="KGk-i7-Jjw" customClass="SearchTableViewCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="54" id="KGk-i7-Jjw" customClass="SearchTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="54"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="53.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="j2G-Mb-TkL" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="j2G-Mb-TkL" customClass="LoginTextField" customModule="WordPressAuthenticator" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>


### PR DESCRIPTION
This change fixes compatibility with recent versions of CocoaPods. Once merged it will be possible to update CocoaPods in all of our projects.

The issue we are seeing is caused by [`GoogleSignInRepacked`](https://github.com/wordpress-mobile/GoogleSignInRepacked). It seems that it is not behaving as a true dynamic framework and some linking changes by CocoaPods mean it doesn't work anymore. The issue is described [here](https://github.com/CocoaPods/CocoaPods/issues/8612#issuecomment-477219241).

The solution is to use the official `GoogleSignIn` pod and add `s.static_framework = true` to the podspec.

Changing to a static framework means that everything gets added to the main bundle. This can lead to conflicts once it is installed in an app. I have made a few changes to mitigate this:

- The podspec now uses `resource_bundles` to create `WordPressAuthenticatorResources.bundle` which contains the `.xcassets` file and the `json` animation files. Storyboards and xibs are still loaded from the main bundle.
- This meant that usages of `Bundle(for: WordPressAuthenticator.self)` needed to be updated for this new bundle.
- The storyboards also needed to be updated to not look for a module named `WordPress` for classes. This was likely left over from extracting the storyboards from WordPress-iOS.

To test:

Since the risk here is that resources won't be correctly loaded, its probably best to test this from within WordPress:

1. Check out this branch. Check out `develop` of WordPress-iOS.
2. Uncomment the line in your WordPress-iOS `Podfile` that says `pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'` and comment the line above.
3. Run `rake dependencies`
4. Build and run the app.
5. Run through a login flow and make sure nothing looks out of place (missing icons, animations etc.).