### PR TITLE
 Xcode 10.2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,20 +2,20 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.23
+  ios: wordpress-mobile/ios@0.0.24
 
 workflows:
   test_and_validate:
     jobs:
       - ios/test:
           name: Test
-          xcode-version: "10.1.0"
+          xcode-version: "10.2.0"
           workspace: WordPressAuthenticator.xcworkspace
           scheme: WordPressAuthenticator
           device: iPhone XS
-          ios-version: "12.1"
+          ios-version: "12.2"
       - ios/validate-podspec:
           name: Validate Podspec
-          xcode-version: "10.1.0"
+          xcode-version: "10.2.0"
           podspec-path: WordPressAuthenticator.podspec
           update-specs-repo: true

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  pod 'WordPressKit', '~> 3.1'
+  pod 'WordPressKit', '~> 3.2.2.beta'
   pod 'WordPressShared', '~> 1.4'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (3.1.1):
+  - WordPressKit (3.2.2.beta-1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -81,7 +81,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 3.1)
+  - WordPressKit (~> 3.2.2.beta)
   - WordPressShared (~> 1.4)
   - WordPressUI (~> 1.0)
 
@@ -129,11 +129,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 9af12361492d12c6c5512d3d7de594aa415ad670
+  WordPressKit: 64abfa026368c51366048ef839f8a510d7284942
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 9855cfe19e69c98a6349fe0923600666486ce1d1
+PODFILE CHECKSUM: 6e6ee68c087322b45df83a787321f0a10ddb52b3
 
 COCOAPODS: 1.6.1

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -41,6 +41,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
-  s.dependency 'WordPressKit', '~> 3.1'
+  s.dependency 'WordPressKit', '~> 3.2.2.beta'
   s.dependency 'WordPressShared', '~> 1.4'
 end

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -642,6 +642,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = B5ED78EA207E976500A8FD8C;
 			productRefGroup = B5ED78F5207E976500A8FD8C /* Products */;

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -22,7 +22,7 @@ public struct WordPressAuthenticatorDisplayStrings {
 }
 
 public extension WordPressAuthenticatorDisplayStrings {
-    public static var defaultStrings: WordPressAuthenticatorDisplayStrings {
+    static var defaultStrings: WordPressAuthenticatorDisplayStrings {
         return WordPressAuthenticatorDisplayStrings(emailLoginInstructions: NSLocalizedString("Log in to WordPress.com using an email address to manage all your WordPress sites.", comment: "Instruction text on the login's email address screen."),
                                                  jetpackLoginInstructions: NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.", comment: "Instruction text on the login's email address screen."),
                                                  siteLoginInstructions: NSLocalizedString("Enter the address of your WordPress site you'd like to connect.", comment: "Instruction text on the login's site addresss screen."))

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -73,7 +73,7 @@ public struct WordPressAuthenticatorStyle {
 }
 
 public extension WordPressAuthenticatorStyle {
-    public static var defaultStyle: WordPressAuthenticatorStyle {
+    static var defaultStyle: WordPressAuthenticatorStyle {
         return WordPressAuthenticatorStyle(primaryNormalBackgroundColor: WPStyleGuide.mediumBlue(),
                                            primaryNormalBorderColor: WPStyleGuide.wordPressBlue(),
                                            primaryHighlightBackgroundColor: WPStyleGuide.wordPressBlue(),

--- a/WordPressAuthenticator/NUX/NUXSegueHandler.swift
+++ b/WordPressAuthenticator/NUX/NUXSegueHandler.swift
@@ -6,7 +6,7 @@ public protocol NUXSegueHandler {
 }
 
 extension NUXSegueHandler where Self: NUXViewController {
-    public func performSegue(withIdentifier identifier: SegueIdentifier, sender: AnyObject?) {
+    public func performSegue(withIdentifier identifier: NUXViewController.SegueIdentifier, sender: AnyObject?) {
         performSegue(withIdentifier: identifier.rawValue, sender: sender)
     }
 }

--- a/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
@@ -1,5 +1,5 @@
 #import "WordPressXMLRPCAPIFacade.h"
-#import <wpxmlrpc/WPXMLRPC.h>
+#import <WPXMLRPC/WPXMLRPC.h>
 #import <WordPressAuthenticator/WordPressAuthenticator-Swift.h>
 #import "WPAuthenticatorLoggingPrivate.h"
 


### PR DESCRIPTION
Following https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/67 and https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/68, this PR fixes compatibility with Xcode 10.2 and updates CircleCI to use it. Xcode 10.1 will still work fine.