### PR TITLE
Add storyboards and xibs to the resource_bundle

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -19,14 +19,12 @@ Pod::Spec.new do |s|
   s.source_files  = 'WordPressAuthenticator/**/*.{h,m,swift}'
   s.private_header_files = "WordPressAuthenticator/Private/*.h"
   s.resource_bundles = {
-    'WordPressAuthenticatorResources': [
+    'WordPressAuthenticator': [
       'WordPressAuthenticator/Resources/Assets.xcassets',
-      'WordPressAuthenticator/Resources/Animations/*.json'
+      'WordPressAuthenticator/Resources/Animations/*.json',
+      'WordPressAuthenticator/**/*.{storyboard,xib}'
     ]
   }
-  s.resources     = [
-    'WordPressAuthenticator/**/*.{storyboard,xib}'
-  ]
   s.requires_arc  = true
   s.static_framework = true # This is needed because GoogleSignIn vendors a static framework
   s.header_dir    = 'WordPressAuthenticator'

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -133,7 +133,7 @@ import WordPressUI
             trackOpenedLogin()
         }
 
-        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
         if let controller = storyboard.instantiateInitialViewController() {
             if let childController = controller.children.first as? LoginPrologueViewController {
                 childController.loginFields.restrictToWPCom = restrictToWPCom
@@ -149,7 +149,7 @@ import WordPressUI
             trackOpenedLogin()
         }
 
-        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? LoginEmailViewController else {
             return
         }
@@ -183,7 +183,7 @@ import WordPressUI
     /// Returns an instance of LoginSiteAddressViewController: allows the user to log into a WordPress.org website.
     ///
     @objc public class func signinForWPOrg() -> UIViewController {
-        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "siteAddress") as? LoginSiteAddressViewController else {
             fatalError("unable to create wpcom password screen")
         }
@@ -199,7 +199,7 @@ import WordPressUI
         loginFields.emailAddress = dotcomEmailAddress ?? String()
         loginFields.username = dotcomUsername ?? String()
 
-        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "LoginWPcomPassword") as? LoginWPComViewController else {
             fatalError("unable to create wpcom password screen")
         }
@@ -215,7 +215,7 @@ import WordPressUI
     /// it's features.
     ///
     public class func signinForWPCom() -> LoginEmailViewController {
-        let storyboard = UIStoryboard(name: "Login", bundle: mainBundle)
+        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
         guard let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? LoginEmailViewController else {
             fatalError()
         }
@@ -256,7 +256,7 @@ import WordPressUI
             return false
         }
 
-        let storyboard = UIStoryboard(name: "EmailMagicLink", bundle: mainBundle)
+        let storyboard = UIStoryboard(name: "EmailMagicLink", bundle: bundle)
         guard let loginController = storyboard.instantiateViewController(withIdentifier: "LinkAuthView") as? NUXLinkAuthViewController else {
             DDLogInfo("App opened with authentication link but couldn't create login screen.")
             return false
@@ -416,22 +416,19 @@ import WordPressUI
         UIApplication.shared.open(forgotPasswordURL)
     }
 
-    /// Returns the WordPressAuthenticator main bundle
+    /// Returns the WordPressAuthenticator Bundle
+    /// If installed via CocoaPods, this will be WordPressAuthenticator.bundle,
+    /// otherwise it will be the framework bundle.
     ///
-    class var mainBundle: Bundle {
-        return Bundle(for: WordPressAuthenticator.self)
-    }
-    
-    /// Returns the WordPressAuthenticatorResouces.bundle
-    ///
-    class var resourcesBundle: Bundle {
-        // If installed with CocoaPods, resources will be in WordPressAuthenticatorResources.bundle
-        if let bundleURL = mainBundle.resourceURL,
-            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPressAuthenticatorResources.bundle")) {
+    class var bundle: Bundle {
+        let defaultBundle = Bundle(for: WordPressAuthenticator.self)
+        // If installed with CocoaPods, resources will be in WordPressAuthenticator.bundle
+        if let bundleURL = defaultBundle.resourceURL,
+            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPressAuthenticator.bundle")) {
             return resourceBundle
         }
-        // Otherwise, the main bundle is used for resources
-        return mainBundle
+        // Otherwise, the default bundle is used for resources
+        return defaultBundle
     }
 
     // MARK: - 1Password Helper

--- a/WordPressAuthenticator/Extensions/UIImage+Assets.swift
+++ b/WordPressAuthenticator/Extensions/UIImage+Assets.swift
@@ -29,6 +29,6 @@ extension UIImage {
     /// Returns WordPressAuthenticator's Bundle
     ///
     private static var bundle: Bundle {
-        return WordPressAuthenticator.resourcesBundle
+        return WordPressAuthenticator.bundle
     }
 }

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -169,7 +169,7 @@ extension NUXButtonViewController {
     /// Returns a new NUXButtonViewController Instance
     ///
     public class func instance() -> NUXButtonViewController {
-        let storyboard = UIStoryboard(name: "NUXButtonView", bundle: WordPressAuthenticator.mainBundle)
+        let storyboard = UIStoryboard(name: "NUXButtonView", bundle: WordPressAuthenticator.bundle)
         guard let buttonViewController = storyboard.instantiateViewController(withIdentifier: "ButtonView") as? NUXButtonViewController else {
             fatalError()
         }

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -607,7 +607,7 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
         cleanupAfterSocialErrors()
 
 
-        let storyboard = UIStoryboard(name: "Signup", bundle: WordPressAuthenticator.mainBundle)
+        let storyboard = UIStoryboard(name: "Signup", bundle: WordPressAuthenticator.bundle)
         if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
             controller.loginFields = loginFields
             navigationController?.pushViewController(controller, animated: true)

--- a/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
@@ -61,7 +61,7 @@ class LoginProloguePromoViewController: UIViewController {
         headingLabel = UILabel()
         animationHolder = UIView()
 
-        let bundle = WordPressAuthenticator.resourcesBundle
+        let bundle = WordPressAuthenticator.bundle
         animationView = LOTAnimationView(name: type.animationKey, bundle: bundle)
 
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/67, as part of converting to a static framework, I moved images and assets to `WordPressAuthenticatorResources.bundle`. `.storyboard` and `.xib` files remained in the main bundle.

This mostly worked fine for WordPress-iOS, but has proved to be problematic in some cases there and in all cases for WooCommerce-iOS. Image references in storyboards were not resoving, with errors like this:

```
2018-12-11 09:21:31.650079-0800 WordPress[91387:1155878] Could not load the "beveled-blue-button-down" image referenced from a nib in the bundle with identifier "org.cocoapods.WordPressAuthenticator"
``` 

Fixes https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/38.

The solution I have implemented is as follows:

- Move `.xib` and `.storyboard` files into the `resource_bundle`. This means images will be loaded from the same bundle and it will find them correctly.
- Rename `WordPressAuthenticatorResources.bundle` to `WordPressAuthenticator.bundle`. This is a surprising quirk of CocoaPods to ensure they are all in the same target. More info [here](https://muyexi.im/switch-resource-to-resource_bundle/).
- Related code changes to load the right bundle. It's simpler now.

To test:

- Point WordPress-iOS to this branch (I have made a branch [here](https://github.com/wordpress-mobile/WordPress-iOS/tree/try/wpauthenticator-resources) to save some effort).
    - Smoke test the login flow, making sure images are loaded correctly.
- Point WooCommerce-iOS to this branch (I have made a branch [here](https://github.com/woocommerce/woocommerce-ios/tree/try/wpauthenticator-resources) to save some effort).
    - Smoke test the login flow, making sure images are loaded correctly.


