### PR TITLE
NUXButtonView.storyboard: Remove references to beveled-blue-button-down

### DIFF
--- a/WordPressAuthenticator/NUX/NUXButtonView.storyboard
+++ b/WordPressAuthenticator/NUX/NUXButtonView.storyboard
@@ -51,8 +51,7 @@
                                         <state key="normal" title="Primary Button">
                                             <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                         </state>
-                                        <state key="selected" backgroundImage="beveled-blue-button-down"/>
-                                        <state key="highlighted" backgroundImage="beveled-blue-button-down">
+                                        <state key="highlighted">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
                                         <connections>
@@ -69,8 +68,7 @@
                                         <state key="normal" title="Cancel Button">
                                             <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                         </state>
-                                        <state key="selected" backgroundImage="beveled-blue-button-down"/>
-                                        <state key="highlighted" backgroundImage="beveled-blue-button-down">
+                                        <state key="highlighted">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
                                         <connections>
@@ -108,7 +106,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="beveled-blue-button-down" width="18" height="19"/>
         <image name="darkgrey-shadow" width="10" height="10"/>
     </resources>
 </document>


### PR DESCRIPTION
Fixes #38.

`beveled-blue-button-down` is an image that exists in WordPress-iOS, likely left over from the extraction from there. It is not used by WordPressAutheticator since backgrounds are [set in code](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/develop/WordPressAuthenticator/NUX/NUXButton.swift#L96).

This removes the erroneous references to fix the console warning.
