### PR TITLE
Make WordPressAuthenticator.bundle public

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -419,7 +419,7 @@ import WordPressUI
     /// If installed via CocoaPods, this will be WordPressAuthenticator.bundle,
     /// otherwise it will be the framework bundle.
     ///
-    class var bundle: Bundle {
+    public class var bundle: Bundle {
         let defaultBundle = Bundle(for: WordPressAuthenticator.self)
         // If installed with CocoaPods, resources will be in WordPressAuthenticator.bundle
         if let bundleURL = defaultBundle.resourceURL,


### PR DESCRIPTION
This makes the `bundle` var in `WordPressAuthenticator` public so that the bundle can be accessed from outside the framework.

This will allow https://github.com/wordpress-mobile/WordPress-iOS/issues/11444 to be fixed.