### PR TITLE
Update WordPressKit version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.0'
-  pod 'WordPressKit', '~> 3.2.2.beta'
+  pod 'WordPressKit', '~> 4.0.0-beta'
   pod 'WordPressShared', '~> 1.4'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (3.2.2.beta-1):
+  - WordPressKit (4.0.0-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -81,7 +81,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 3.2.2.beta)
+  - WordPressKit (~> 4.0.0-beta)
   - WordPressShared (~> 1.4)
   - WordPressUI (~> 1.0)
 
@@ -129,11 +129,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 64abfa026368c51366048ef839f8a510d7284942
+  WordPressKit: eba19968587a2e088b6eb097c309710a1be11869
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 6e6ee68c087322b45df83a787321f0a10ddb52b3
+PODFILE CHECKSUM: 848201f7ff6e344d19066be1a6cb86eaddd1ab9e
 
 COCOAPODS: 1.6.1

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.3.0"
+  s.version       = "1.3.1-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -41,6 +41,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '4.1.2'
   s.dependency 'WordPressUI', '~> 1.0'
-  s.dependency 'WordPressKit', '~> 3.2.2'
+  s.dependency 'WordPressKit', '~> 4.0.0-beta'
   s.dependency 'WordPressShared', '~> 1.4'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.3.1-beta.1"
+  s.version       = "1.4.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
_WordPressKit_ has been updated to the [major version](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/145) 4.0.0-beta.
This PR update the podspec and WordPressKit versions.
I also updatetd the Podfile and run a bundle exec pod install. 