### PR TITLE
Merge Release/1.3.1 into master

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.3.0"
+  s.version       = "1.3.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -419,7 +419,7 @@ import WordPressUI
     /// If installed via CocoaPods, this will be WordPressAuthenticator.bundle,
     /// otherwise it will be the framework bundle.
     ///
-    class var bundle: Bundle {
+    public class var bundle: Bundle {
         let defaultBundle = Bundle(for: WordPressAuthenticator.self)
         // If installed with CocoaPods, resources will be in WordPressAuthenticator.bundle
         if let bundleURL = defaultBundle.resourceURL,


### PR DESCRIPTION
Merge Release/1.3.1 into master.

1.3.1 is a patch version that includes the changes from https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/78.