### PR TITLE
Compatibility with both CocoaPods dynamic and static frameworks

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A4095182271AEFC009AA86D /* WPAuthenticator-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7A7A9B9CD2D81959F9AB9AF6 /* Pods_WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C736FF243DE333FCAB1C2614 /* Pods_WordPressAuthenticator.framework */; };
 		98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */; };
 		B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */; };
@@ -138,6 +139,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPAuthenticator-Swift.h"; sourceTree = "<group>"; };
 		276354F054C34AD36CA32AB6 /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33FEF45B466FF8EAAE5F3923 /* Pods-WordPressAuthenticator.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release.xcconfig"; sourceTree = "<group>"; };
 		37AFD4EF492B00CA7AEC11A3 /* Pods-WordPressAuthenticatorTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -276,6 +278,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1A4095132271AEFC009AA86D /* Private */ = {
+			isa = PBXGroup;
+			children = (
+				1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */,
+			);
+			path = Private;
+			sourceTree = "<group>";
+		};
 		6205895375D954F46B1DFE53 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -501,6 +511,7 @@
 				B5ED7917207E993E00A8FD8C /* Logging */,
 				B5609098208A4EAF00399AE4 /* Model */,
 				B5609097208A4EAF00399AE4 /* NUX */,
+				1A4095132271AEFC009AA86D /* Private */,
 				B560909A208A4EAF00399AE4 /* Services */,
 				B5609095208A4EAF00399AE4 /* Signin */,
 				B5609096208A4EAF00399AE4 /* Signup */,
@@ -569,6 +580,7 @@
 				B56090E5208A4F9D00399AE4 /* WPWalkthroughTextField.h in Headers */,
 				B560910E208A54F800399AE4 /* LoginFacade.h in Headers */,
 				B56090E7208A4F9D00399AE4 /* WPNUXSecondaryButton.h in Headers */,
+				1A4095182271AEFC009AA86D /* WPAuthenticator-Swift.h in Headers */,
 				B56090E0208A4F9D00399AE4 /* WPWalkthroughOverlayView.h in Headers */,
 				B5ED7905207E976500A8FD8C /* WordPressAuthenticator.h in Headers */,
 				B56090E3208A4F9D00399AE4 /* WPNUXMainButton.h in Headers */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Gridicons
+import WordPressShared
 
 // MARK: - WordPress Authenticator Styles
 //

--- a/WordPressAuthenticator/Private/WPAuthenticator-Swift.h
+++ b/WordPressAuthenticator/Private/WPAuthenticator-Swift.h
@@ -1,0 +1,8 @@
+// Import this header instead of <WordPressAuthenticator/WordPressAuthenticator-Swift.h>
+// This allows the pod to be built as a static or dynamic framework
+// See https://github.com/CocoaPods/CocoaPods/issues/7594
+#if __has_include("WordPressAuthenticator-Swift.h")
+    #import "WordPressAuthenticator-Swift.h"
+#else
+    #import <WordPressAuthenticator/WordPressAuthenticator-Swift.h>
+#endif

--- a/WordPressAuthenticator/Services/LoginFacade.m
+++ b/WordPressAuthenticator/Services/LoginFacade.m
@@ -3,7 +3,7 @@
 #import "WordPressComOAuthClientFacade.h"
 #import "WordPressXMLRPCAPIFacade.h"
 #import <CocoaLumberjack/CocoaLumberjack.h>
-#import <WordPressAuthenticator/WordPressAuthenticator-Swift.h>
+#import "WPAuthenticator-Swift.h"
 #import "WPAuthenticatorLoggingPrivate.h"
 
 @import WordPressKit;

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
@@ -1,5 +1,5 @@
 #import "WordPressComOAuthClientFacade.h"
-#import <WordPressAuthenticator/WordPressAuthenticator-Swift.h>
+#import "WPAuthenticator-Swift.h"
 
 @import WordPressKit;
 

--- a/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
@@ -1,6 +1,6 @@
 #import "WordPressXMLRPCAPIFacade.h"
 #import <WPXMLRPC/WPXMLRPC.h>
-#import <WordPressAuthenticator/WordPressAuthenticator-Swift.h>
+#import "WPAuthenticator-Swift.h"
 #import "WPAuthenticatorLoggingPrivate.h"
 
 @import WordPressKit;

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -1,5 +1,6 @@
 import GoogleSignIn
 import SVProgressHUD
+import WordPressShared
 
 /// View controller that handles the google signup code
 class SignupGoogleViewController: LoginViewController {

--- a/WordPressAuthenticatorTests/Services/LoginFacadeTests.m
+++ b/WordPressAuthenticatorTests/Services/LoginFacadeTests.m
@@ -5,7 +5,7 @@
 #import "LoginFacade.h"
 #import "WordPressComOAuthClientFacade.h"
 #import "WordPressXMLRPCAPIFacade.h"
-#import <WordPressAuthenticator/WordPressAuthenticator-Swift.h>
+#import "WPAuthenticator-Swift.h"
 
 
 SpecBegin(LoginFacade)


### PR DESCRIPTION
This makes the changes needed for the WordPressAuthenticator pod to be installed as a static or dynamic framework (with or without `use_frameworks!`). Currently, it does not work correctly when installed statically. Even though `static_framework` is set to true, these changes are needed to ensure it works without `use_frameworks!`.

The changes are as follows:

- Use `#import "WPKit-Swift.h` instead of `#import <WordPressKit/WordPressKit-Swift.h>` to avoid the issue described in https://github.com/CocoaPods/CocoaPods/issues/7594.

You can see that the tests still build and pass with the changes I've made.

Related to https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/203 and https://github.com/wordpress-mobile/WordPressKit-iOS/pull/151