### PR TITLE
Removes the Jetpack error override.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (4.1.0-beta.1):
+  - WordPressKit (4.1.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -117,7 +117,7 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: ab450fc37b54d8fe6839fb6e4074962980480cc0
+  WordPressKit: 9c4aca3f59ee47eb54bb58f5cb710795869ecf05
   WordPressShared: ac9ddc5b04d012cf7920867c2a269bce232d4dd8
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.4.1-beta.2"
+  s.version       = "1.4.1-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -168,10 +168,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
 
             let err = self.originalErrorOrError(error: error as NSError)
 
-            if self.errorDiscoveringJetpackSite(error: err) {
-                self.displayError(error as NSError, sourceTag: .jetpackLogin)
-
-            } else if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
+            if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
                 self.displayError(message: xmlrpcValidatorError.localizedDescription)
 
             } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
@@ -272,15 +269,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             return error
         }
         return err
-    }
-
-
-    @objc func errorDiscoveringJetpackSite(error: NSError) -> Bool {
-        if let _ = error.userInfo[WordPressOrgXMLRPCValidator.UserInfoHasJetpackKey] {
-            return true
-        }
-
-        return false
     }
 
     /// Here we will continue with the self-hosted flow.


### PR DESCRIPTION
## Description:

This PR removes a Jetpack error override we were using, that [seemed to cause quite some confusion for our users and HEs](https://github.com/wordpress-mobile/WordPress-iOS/issues/11505).

## Scope:

This PR does not aim to improve the error messaging in general, just to remove the override that was forcing the lib to show the Jetpack errors instead of letting the real errors be shown.

## Testing:

This PR can be tested through this WPiOS branch: `issue/11505-remove-jetpack-error`

1. Run WPiOS and login in by site address.
2. Enter `therealnews.altervista.org` in the site address.

You should see the following error message:

<img width="397" alt="Screen Shot 2019-05-01 at 11 25 17 AM" src="https://user-images.githubusercontent.com/1836005/57022374-50ef3100-6c05-11e9-981f-299a5e0c0837.png">