### PR TITLE
Make WordPress.com URLs configurable through WordPressAuthenticatorConfiguration

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.4.1"
+  s.version       = "1.5.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A21EE9822832BC300C940C6 /* WordPressComOAuthClientFacade+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A21EE9722832BC200C940C6 /* WordPressComOAuthClientFacade+Swift.swift */; };
 		1A4095182271AEFC009AA86D /* WPAuthenticator-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7A7A9B9CD2D81959F9AB9AF6 /* Pods_WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C736FF243DE333FCAB1C2614 /* Pods_WordPressAuthenticator.framework */; };
 		98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */; };
@@ -139,6 +140,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A21EE9722832BC200C940C6 /* WordPressComOAuthClientFacade+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressComOAuthClientFacade+Swift.swift"; sourceTree = "<group>"; };
 		1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPAuthenticator-Swift.h"; sourceTree = "<group>"; };
 		276354F054C34AD36CA32AB6 /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33FEF45B466FF8EAAE5F3923 /* Pods-WordPressAuthenticator.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release.xcconfig"; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				B56090FC208A54F700399AE4 /* WordPressComBlogService.swift */,
 				B56090FD208A54F700399AE4 /* WordPressComOAuthClientFacade.h */,
 				B5609101208A54F800399AE4 /* WordPressComOAuthClientFacade.m */,
+				1A21EE9722832BC200C940C6 /* WordPressComOAuthClientFacade+Swift.swift */,
 				B5609106208A54F800399AE4 /* WordPressXMLRPCAPIFacade.h */,
 				B5609102208A54F800399AE4 /* WordPressXMLRPCAPIFacade.m */,
 			);
@@ -864,6 +867,7 @@
 				B5609119208A555600399AE4 /* SiteInfoHeaderView.swift in Sources */,
 				B560913E208A563800399AE4 /* SigninEditingState.swift in Sources */,
 				B56090CF208A4F5400399AE4 /* NUXCollectionViewController.swift in Sources */,
+				1A21EE9822832BC300C940C6 /* WordPressComOAuthClientFacade+Swift.swift in Sources */,
 				B5ED7920207E993E00A8FD8C /* WPAuthenticatorLogging.m in Sources */,
 				B5609138208A563800399AE4 /* LoginSiteAddressViewController.swift in Sources */,
 				B560910B208A54F800399AE4 /* LoginFacade.m in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -1,4 +1,5 @@
 import GoogleSignIn
+import WordPressKit
 
 // MARK: - WordPressAuthenticator Configuration
 //
@@ -19,6 +20,14 @@ public struct WordPressAuthenticatorConfiguration {
     /// WordPress.com Terms of Service URL
     ///
     let wpcomTermsOfServiceURL: String
+    
+    /// WordPress.com Base URL for OAuth
+    ///
+    let wpcomBaseURL: String
+    
+    /// WordPress.com API Base URL
+    ///
+    let wpcomAPIBaseURL: String
 
     /// GoogleLogin Client ID
     ///
@@ -42,6 +51,8 @@ public struct WordPressAuthenticatorConfiguration {
                  wpcomSecret: String,
                  wpcomScheme: String,
                  wpcomTermsOfServiceURL: String,
+                 wpcomBaseURL: String = WordPressComOAuthClient.WordPressComOAuthDefaultBaseUrl,
+                 wpcomAPIBaseURL: String = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl,
                  googleLoginClientId: String,
                  googleLoginServerClientId: String,
                  googleLoginScheme: String,
@@ -51,6 +62,8 @@ public struct WordPressAuthenticatorConfiguration {
         self.wpcomSecret = wpcomSecret
         self.wpcomScheme = wpcomScheme
         self.wpcomTermsOfServiceURL = wpcomTermsOfServiceURL
+        self.wpcomBaseURL = wpcomBaseURL
+        self.wpcomAPIBaseURL = wpcomAPIBaseURL
         self.googleLoginClientId =  googleLoginClientId
         self.googleLoginServerClientId = googleLoginServerClientId
         self.googleLoginScheme = googleLoginScheme

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacade+Swift.swift
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacade+Swift.swift
@@ -1,0 +1,13 @@
+import Foundation
+import WordPressKit
+
+// MARK: - This extension is needed because WordPressComOAuthClientFacade cannot access the WordPressAuthenticatorConfiguration struct.
+//
+extension WordPressComOAuthClientFacade {
+    @objc public static func initializeOAuthClient(clientID: String, secret: String) -> WordPressComOAuthClient {
+        return WordPressComOAuthClient(clientID: clientID,
+                                       secret: secret,
+                                       wordPressComBaseUrl: WordPressAuthenticator.shared.configuration.wpcomBaseURL,
+                                       wordPressComApiBaseUrl: WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL)
+    }
+}

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
@@ -21,7 +21,7 @@
     NSParameterAssert(secret);
     self = [super init];
     if (self) {
-        self.client = [WordPressComOAuthClient clientWithClientID:client secret:secret];
+        self.client = [WordPressComOAuthClientFacade initializeOAuthClientWithClientID:client secret:secret];
     }
 
     return self;


### PR DESCRIPTION
I recently made changes to WordPressKit to allow WP.com urls to be configured for testing purposes (https://github.com/wordpress-mobile/WordPressKit-iOS/pull/141). This is the corresponding changes to WordPressAuthenticator to take advantage of that.

I have added two new items to `WordPressAuthenticatorConfiguration`: `wpcomBaseURL` and `wpcomAPIBaseURL`. They default to the correct values so that existing installations will not break.

I have also updated the `.podspec` version since this includes API changes.

### Testing Details

- All tests pass and the podspec validates.
- (Optional) Check out my corresponding WPiOS branch (`try/configure-base-urls`) and do a smoke test of the login flow. Draft PR is here: https://github.com/wordpress-mobile/WordPress-iOS/pull/11655.

- [x] Please check here if your pull request includes additional test coverage.


