### PR TITLE
Add accessibility identifiers for UI tests

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.4.1"
+  s.version       = "1.4.2-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.4.2-beta.1"
+  s.version       = "1.5.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
@@ -51,11 +51,13 @@ class NUXLinkMailViewController: LoginViewController {
         let openMailButtonTitle = NSLocalizedString("Open Mail", comment: "Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device.")
         openMailButton?.setTitle(openMailButtonTitle, for: .normal)
         openMailButton?.setTitle(openMailButtonTitle, for: .highlighted)
+        openMailButton?.accessibilityIdentifier = "Open Mail Button"
 
         let usePasswordTitle = NSLocalizedString("Enter your password instead.", comment: "Title of a button on the magic link screen.")
         usePasswordButton?.setTitle(usePasswordTitle, for: .normal)
         usePasswordButton?.setTitle(usePasswordTitle, for: .highlighted)
         usePasswordButton?.titleLabel?.numberOfLines = 0
+        usePasswordButton?.accessibilityIdentifier = "Use Password"
 
         guard let emailMagicLinkSource = emailMagicLinkSource else {
             return

--- a/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
@@ -61,6 +61,7 @@ class LoginLinkRequestViewController: LoginViewController {
         let sendLinkButtonTitle = NSLocalizedString("Send Link", comment: "Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user.")
         sendLinkButton?.setTitle(sendLinkButtonTitle, for: .normal)
         sendLinkButton?.setTitle(sendLinkButtonTitle, for: .highlighted)
+        sendLinkButton?.accessibilityIdentifier = "Send Link Button"
 
         let usePasswordTitle = NSLocalizedString("Enter your password instead.", comment: "Title of a button. ")
         usePasswordButton?.setTitle(usePasswordTitle, for: .normal)


### PR DESCRIPTION
Adds three new accessibility identifiers for use in UI tests (to support running tests with the device UI set to any language).

To test:

* Build the project and confirm the unit tests pass.
* Optional: Try out the draft PR integrating these changes with the WPiOS UI tests (https://github.com/wordpress-mobile/WordPress-iOS/pull/11665 - test steps in that PR).