### PR TITLE
Use wpcomAPIBaseURL in all WordPressComRestApi instances

### DIFF
--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -47,7 +47,9 @@ class SignupService {
 private extension SignupService {
 
     var anonymousAPI: WordPressComRestApi {
-        return WordPressComRestApi(oAuthToken: nil, userAgent: configuration.userAgent)
+        return WordPressComRestApi(oAuthToken: nil,
+                                   userAgent: configuration.userAgent,
+                                   baseUrlString: configuration.wpcomAPIBaseURL)
     }
 
     var configuration: WordPressAuthenticatorConfiguration {

--- a/WordPressAuthenticator/Services/WordPressComAccountService.swift
+++ b/WordPressAuthenticator/Services/WordPressComAccountService.swift
@@ -22,7 +22,9 @@ class WordPressComAccountService {
     /// Connects a WordPress.com account with the specified Social Service.
     ///
     func connect(wpcomAuthToken: String, serviceName: SocialServiceName, serviceToken: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
-        let loggedAPI  = WordPressComRestApi(oAuthToken: wpcomAuthToken, userAgent: configuration.userAgent)
+        let loggedAPI  = WordPressComRestApi(oAuthToken: wpcomAuthToken,
+                                             userAgent: configuration.userAgent,
+                                             baseUrlString: configuration.wpcomAPIBaseURL)
         let remote = AccountServiceRemoteREST(wordPressComRestApi: loggedAPI)
 
         remote.connectToSocialService(serviceName,
@@ -70,7 +72,9 @@ class WordPressComAccountService {
     /// Returns an anonymous WordPressComRestApi Instance.
     ///
     private var anonymousAPI: WordPressComRestApi {
-        return WordPressComRestApi(oAuthToken: nil, userAgent: configuration.userAgent)
+        return WordPressComRestApi(oAuthToken: nil,
+                                   userAgent: configuration.userAgent,
+                                   baseUrlString: configuration.wpcomAPIBaseURL)
     }
 
     /// Returns the current WordPressAuthenticatorConfiguration Instance.

--- a/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -10,7 +10,8 @@ class WordPressComBlogService {
     ///
     private var anonymousAPI: WordPressComRestApi {
         let userAgent = WordPressAuthenticator.shared.configuration.userAgent
-        return WordPressComRestApi(oAuthToken: nil, userAgent: userAgent)
+        let baseUrl = WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL
+        return WordPressComRestApi(oAuthToken: nil, userAgent: userAgent, baseUrlString: baseUrl)
     }
 
 

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -140,7 +140,8 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     private func checkEmailAvailability(completion:@escaping (Bool) -> ()) {
 
-        let remote = AccountServiceRemoteREST(wordPressComRestApi: WordPressComRestApi(baseUrlString: WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL))
+        let remote = AccountServiceRemoteREST(
+            wordPressComRestApi: WordPressComRestApi(baseUrlString: WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL))
 
         remote.isEmailAvailable(loginFields.emailAddress, success: { available in
             if !available {

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -140,7 +140,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     private func checkEmailAvailability(completion:@escaping (Bool) -> ()) {
 
-        let remote = AccountServiceRemoteREST(wordPressComRestApi: WordPressComRestApi())
+        let remote = AccountServiceRemoteREST(wordPressComRestApi: WordPressComRestApi(baseUrlString: WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL))
 
         remote.isEmailAvailable(loginFields.emailAddress, success: { available in
             if !available {


### PR DESCRIPTION
As I have been developing networking mocking, I have discovered a few places that the WP.com API URL needs to be injected which I missed in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/93.

This PR makes sure every instance of `WordPressComRestApi` in WordPressAutheticator uses the injectable `wpcomAPIBaseURL`.