### PR TITLE
Allowing to continue login flow for self hosted sites that have Jetpack.

### DIFF
--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -17,7 +17,7 @@ public class WordPressComSiteInfo {
     ///
     public let url: String
 
-    /// Indicates if Jetpack is available, or not,
+    /// Indicates if Jetpack is available, or not.
     ///
     public let hasJetpack: Bool
 
@@ -25,6 +25,8 @@ public class WordPressComSiteInfo {
     ///
     public let icon: String
     
+    /// Indicates whether the site is WordPressDotCom, or not.
+    ///
     public let isWPCom: Bool
 
 

--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -24,6 +24,8 @@ public class WordPressComSiteInfo {
     /// URL of the Site's Blavatar.
     ///
     public let icon: String
+    
+    public let isWPCom: Bool
 
 
 
@@ -35,5 +37,7 @@ public class WordPressComSiteInfo {
         url         = remote["URL"] as? String          ?? ""
         hasJetpack  = remote["jetpack"] as? Bool        ?? false
         icon        = remote["icon.img"] as? String     ?? ""
+        isWPCom     = remote["isWordPressDotCom"] as? Bool ?? false
+        
     }
 }

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -197,16 +197,12 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                 return
             }
             self.configureViewLoading(false)
-            if siteInfo.isWPCom {
-                if WordPressAuthenticator.shared.delegate?.allowWPComLogin == true {
-                    self.presentNextControllerIfPossible(siteInfo: siteInfo)
-                } else {
-                    // Hey, you have to log out of your existing WP.com account before logging into another one.
-                    self.promptUserToLogoutBeforeConnectingWPComSite()
-                }
-            } else {
-                self.presentNextControllerIfPossible(siteInfo: siteInfo)
+            if siteInfo.isWPCom && WordPressAuthenticator.shared.delegate?.allowWPComLogin == false {
+                // Hey, you have to log out of your existing WP.com account before logging into another one.
+                self.promptUserToLogoutBeforeConnectingWPComSite()
+                return
             }
+            self.presentNextControllerIfPossible(siteInfo: siteInfo)
         }
         service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] error in
             self?.configureViewLoading(false)

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -188,68 +188,35 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             }
         })
     }
-
-
+    
     @objc func fetchSiteInfo() {
         let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: loginFields.siteAddress)
+        let service = WordPressComBlogService()
         let successBlock: (WordPressComSiteInfo) -> Void = { [weak self] siteInfo in
-            self?.loginFields.meta.siteInfo = siteInfo
-            if WordPressAuthenticator.shared.delegate?.allowWPComLogin == false && !siteInfo.hasJetpack {
-                // Hey, you have to log out of your existing WP.com account before logging into another one.
-                self?.promptUserToLogoutBeforeConnectingWPComSite()
-                self?.configureViewLoading(false)
-            } else {
-                self?.configureViewLoading(false)
-                guard let self = self else {
-                    return
+            guard let self = self else {
+                return
+            }
+            self.configureViewLoading(false)
+            if siteInfo.isWPCom {
+                if WordPressAuthenticator.shared.delegate?.allowWPComLogin == true {
+                    self.presentNextControllerIfPossible(siteInfo: siteInfo)
+                } else {
+                    // Hey, you have to log out of your existing WP.com account before logging into another one.
+                    self.promptUserToLogoutBeforeConnectingWPComSite()
                 }
+            } else {
                 self.presentNextControllerIfPossible(siteInfo: siteInfo)
             }
         }
-
-        // Is this a WP.com site address?
-        if let siteAddress = baseSiteUrl.components(separatedBy: "://").last {
-            let service = WordPressComBlogService()
-            // Yes. Then let's attempt to grab the site info.
-            service.fetchSiteInfo(for: siteAddress, success: successBlock, failure: { [weak self] (error) in
-                // If fetchSiteInfo failed because the site is private (errorCode == .authorizationRequired),
-                // then we try to fetch the site info with a call to the `connect/site-info` endpoint.
-                // If this call succeeds, we check if login is allowed.
-                let originalError = error as NSError
-                let errorCode = WordPressComRestApiError(rawValue: originalError.code)
-                if errorCode == .authorizationRequired {
-                    service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { error in
-                        // The un-authed site info request failed.
-                        self?.configureViewLoading(false)
-                        guard let self = self else {
-                            return
-                        }
-
-                        self.presentNextControllerIfPossible(siteInfo: nil)
-                    })
-                } else {
-                    // Failed to get the site info.
-                    self?.configureViewLoading(false)
-                    guard let self = self else {
-                        return
-                    }
-
-                    self.presentNextControllerIfPossible(siteInfo: nil)
-                }
-            })
-        } else {
-            // Not a WP.com site. Let's make an un-authenticated site info request.
-            let service = WordPressComBlogService()
-            service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] error in
-                self?.configureViewLoading(false)
-                guard let self = self else {
-                    return
-                }
-
-                self.presentNextControllerIfPossible(siteInfo: nil)
-            })
-        }
+        service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] error in
+            self?.configureViewLoading(false)
+            guard let self = self else {
+                return
+            }
+            self.presentNextControllerIfPossible(siteInfo: nil)
+        })
     }
+
 
     func presentNextControllerIfPossible(siteInfo: WordPressComSiteInfo?) {
         WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (error, isSelfHosted) in

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -194,7 +194,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: loginFields.siteAddress)
         let successBlock: (WordPressComSiteInfo) -> Void = { [weak self] siteInfo in
             self?.loginFields.meta.siteInfo = siteInfo
-            if WordPressAuthenticator.shared.delegate?.allowWPComLogin == false {
+            if WordPressAuthenticator.shared.delegate?.allowWPComLogin == false && !siteInfo.hasJetpack {
                 // Hey, you have to log out of your existing WP.com account before logging into another one.
                 self?.promptUserToLogoutBeforeConnectingWPComSite()
                 self?.configureViewLoading(false)


### PR DESCRIPTION
Self hosted sites that have jet pack return with a successful response from the fetch site so we don't show the "logout" prompt for those sites.

**Before**:
![self_hosted_jetpack1](https://user-images.githubusercontent.com/1335657/58297517-cb3a4d80-7d8c-11e9-8221-88fbb17249df.gif)

**After**:
![self_hosted_jetpack](https://user-images.githubusercontent.com/1335657/58297530-df7e4a80-7d8c-11e9-8ea6-4d47635e3039.gif)


