### PR TITLE
Add accessibility identifiers needed for UI tests

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.5.3-beta.1"
+  s.version       = "1.5.3-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -76,16 +76,19 @@ open class NUXButtonViewController: UIViewController {
     ///
     /// - Parameters:
     ///   - primary: Title string for primary button. Required.
+    ///   - primaryAccessibilityId: Accessibility identifier string for primary button. Optional.
     ///   - secondary: Title string for secondary button. Optional.
+    ///   - secondaryAccessibilityId: Accessibility identifier string for secondary button. Optional.
     ///   - tertiary: Title string for the tertiary button. Optional.
+    ///   - tertiaryAccessibilityId: Accessibility identifier string for tertiary button. Optional.
     ///
-    public func setButtonTitles(primary: String, secondary: String? = nil, tertiary: String? = nil) {
-        bottomButtonConfig = NUXButtonConfig(title: primary, isPrimary: true, callback: nil)
+    public func setButtonTitles(primary: String, primaryAccessibilityId: String? = nil, secondary: String? = nil, secondaryAccessibilityId: String? = nil, tertiary: String? = nil, tertiaryAccessibilityId: String? = nil) {
+        bottomButtonConfig = NUXButtonConfig(title: primary, isPrimary: true, accessibilityIdentifier: primaryAccessibilityId, callback: nil)
         if let secondaryTitle = secondary {
-            topButtonConfig = NUXButtonConfig(title: secondaryTitle, isPrimary: false, callback: nil)
+            topButtonConfig = NUXButtonConfig(title: secondaryTitle, isPrimary: false, accessibilityIdentifier: secondaryAccessibilityId, callback: nil)
         }
         if let tertiaryTitle = tertiary {
-            tertiaryButtonConfig = NUXButtonConfig(title: tertiaryTitle, isPrimary: false, callback: nil)
+            tertiaryButtonConfig = NUXButtonConfig(title: tertiaryTitle, isPrimary: false, accessibilityIdentifier: tertiaryAccessibilityId, callback: nil)
         }
     }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -38,7 +38,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
 
         let loginTitle = NSLocalizedString("Sign up with Email", comment: "Button title. Tapping begins our normal sign up process.")
         let createTitle = NSLocalizedString("Sign up with Google", comment: "Button title. Tapping begins sign up using Google.")
-        buttonViewController.setupTopButton(title: loginTitle, isPrimary: false) { [weak self] in
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Sign up with Email Button") { [weak self] in
             defer {
                 WordPressAuthenticator.track(.signupEmailButtonTapped)
             }
@@ -46,7 +46,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
             self?.emailTapped?()
         }
 
-        buttonViewController.setupBottomButton(title: createTitle, isPrimary: false) { [weak self] in
+        buttonViewController.setupBottomButton(title: createTitle, isPrimary: false, accessibilityIdentifier: "Sign up with Google Button") { [weak self] in
             defer {
                 WordPressAuthenticator.track(.signupSocialButtonTapped)
             }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -66,7 +66,7 @@ class LoginPrologueViewController: LoginViewController {
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
             self?.loginTapped()
         }
-        buttonViewController.setupBottomButton(title: createTitle, isPrimary: false) { [weak self] in
+        buttonViewController.setupBottomButton(title: createTitle, isPrimary: false, accessibilityIdentifier: "Prologue Signup Button") { [weak self] in
             self?.signupTapped()
         }
         if showCancel {


### PR DESCRIPTION
Adds accessibility identifiers to the prologue screen needed for signup flow UI tests (see https://github.com/wordpress-mobile/WordPress-iOS/pull/11931). Also adds more options for setting accessibility identifiers to UI buttons.

In the future we may want to improve how accessibility identifiers are set on buttons, to avoid/prevent using localized strings (since these identifiers are not exposed to users and should be the same regardless of UI language, for use in tests). However, the change in this PR will make it possible to set the necessary identifiers for existing tests with minimal changes to existing buttons.

To test:
* Follow the test steps in wordpress-mobile/WordPress-iOS#11931 to test these changes in the WordPress iOS tests.