### PR TITLE
Remove unused call to WPStyleGuide.configureColors

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.5.4-beta.1"
+  s.version       = "1.5.4-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -44,7 +44,6 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        WPStyleGuide.configureColors(for: view, andTableView: nil)
         localizeControls()
         WordPressAuthenticator.track(.createAccountInitiated)
     }


### PR DESCRIPTION
This method will be removed from the Shared pod.

See https://github.com/wordpress-mobile/WordPress-iOS/pull/11967