### PR TITLE
Make remaining colors configurable

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.6.0-beta.1"
+  s.version       = "1.6.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -70,7 +70,7 @@ import WordPressUI
     /// Initializes the WordPressAuthenticator with the specified Configuration.
     ///
     public static func initialize(configuration: WordPressAuthenticatorConfiguration,
-                                  style: WordPressAuthenticatorStyle = .defaultStyle,
+                                  style: WordPressAuthenticatorStyle,
                                   displayStrings: WordPressAuthenticatorDisplayStrings = .defaultStrings) {
         guard privateInstance == nil else {
             fatalError("WordPressAuthenticator is already initialized")

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -82,25 +82,3 @@ public struct WordPressAuthenticatorStyle {
         self.prologueTitleColor = prologueTitleColor
     }
 }
-
-public extension WordPressAuthenticatorStyle {
-    static var defaultStyle: WordPressAuthenticatorStyle {
-        return WordPressAuthenticatorStyle(primaryNormalBackgroundColor: WPStyleGuide.mediumBlue(),
-                                           primaryNormalBorderColor: WPStyleGuide.wordPressBlue(),
-                                           primaryHighlightBackgroundColor: WPStyleGuide.wordPressBlue(),
-                                           primaryHighlightBorderColor: WPStyleGuide.wordPressBlue(),
-                                           secondaryNormalBackgroundColor: UIColor.white,
-                                           secondaryNormalBorderColor: WPStyleGuide.greyLighten20(),
-                                           secondaryHighlightBackgroundColor: WPStyleGuide.greyLighten20(),
-                                           secondaryHighlightBorderColor: WPStyleGuide.greyLighten20(),
-                                           disabledBackgroundColor: UIColor.white,
-                                           disabledBorderColor: WPStyleGuide.greyLighten30(),
-                                           primaryTitleColor: UIColor.white,
-                                           secondaryTitleColor: WPStyleGuide.darkGrey(),
-                                           disabledTitleColor: WPStyleGuide.greyLighten30(),
-                                           subheadlineColor: WPStyleGuide.wordPressBlue(),
-                                           viewControllerBackgroundColor: WPStyleGuide.lightGrey(),
-                                           navBarImage: Gridicon.iconOfType(.mySites)
-        )
-    }
-}

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -39,6 +39,12 @@ public struct WordPressAuthenticatorStyle {
 
     public let disabledTitleColor: UIColor
 
+    /// Style: Text Buttons
+    ///
+    public let textButton: UIColor
+
+    public let textButtonHighlight: UIColor
+
     /// Style: Labels
     ///
     public let instructionColor: UIColor
@@ -63,7 +69,7 @@ public struct WordPressAuthenticatorStyle {
 
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButton: UIColor, textButtonHighlight: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -77,6 +83,8 @@ public struct WordPressAuthenticatorStyle {
         self.primaryTitleColor = primaryTitleColor
         self.secondaryTitleColor = secondaryTitleColor
         self.disabledTitleColor = disabledTitleColor
+        self.textButton = textButton
+        self.textButtonHighlight = textButtonHighlight
         self.instructionColor = instructionColor
         self.subheadlineColor = subheadlineColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -39,8 +39,10 @@ public struct WordPressAuthenticatorStyle {
 
     public let disabledTitleColor: UIColor
 
-    /// Style: Subheadline
+    /// Style: Labels
     ///
+    public let instructionColor: UIColor
+
     public let subheadlineColor: UIColor
 
     /// Style: Login screen background colors
@@ -61,7 +63,7 @@ public struct WordPressAuthenticatorStyle {
 
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, subheadlineColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -75,6 +77,7 @@ public struct WordPressAuthenticatorStyle {
         self.primaryTitleColor = primaryTitleColor
         self.secondaryTitleColor = secondaryTitleColor
         self.disabledTitleColor = disabledTitleColor
+        self.instructionColor = instructionColor
         self.subheadlineColor = subheadlineColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
         self.navBarImage = navBarImage

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -41,9 +41,9 @@ public struct WordPressAuthenticatorStyle {
 
     /// Style: Text Buttons
     ///
-    public let textButton: UIColor
+    public let textButtonColor: UIColor
 
-    public let textButtonHighlight: UIColor
+    public let textButtonHighlightColor: UIColor
 
     /// Style: Labels
     ///
@@ -71,7 +71,7 @@ public struct WordPressAuthenticatorStyle {
 
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButton: UIColor, textButtonHighlight: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -85,8 +85,8 @@ public struct WordPressAuthenticatorStyle {
         self.primaryTitleColor = primaryTitleColor
         self.secondaryTitleColor = secondaryTitleColor
         self.disabledTitleColor = disabledTitleColor
-        self.textButton = textButton
-        self.textButtonHighlight = textButtonHighlight
+        self.textButtonColor = textButtonColor
+        self.textButtonHighlightColor = textButtonHighlightColor
         self.instructionColor = instructionColor
         self.subheadlineColor = subheadlineColor
         self.placeholderColor = placeholderColor

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -51,6 +51,8 @@ public struct WordPressAuthenticatorStyle {
 
     public let subheadlineColor: UIColor
 
+    public let placeholderColor: UIColor
+
     /// Style: Login screen background colors
     ///
     public let viewControllerBackgroundColor: UIColor
@@ -69,7 +71,7 @@ public struct WordPressAuthenticatorStyle {
 
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButton: UIColor, textButtonHighlight: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButton: UIColor, textButtonHighlight: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -87,6 +89,7 @@ public struct WordPressAuthenticatorStyle {
         self.textButtonHighlight = textButtonHighlight
         self.instructionColor = instructionColor
         self.subheadlineColor = subheadlineColor
+        self.placeholderColor = placeholderColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
         self.navBarImage = navBarImage
         self.prologueBackgroundColor = prologueBackgroundColor

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -7,8 +7,8 @@ final class SubheadlineButton: UIButton {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             titleLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
-            setTitleColor(WordPressAuthenticator.shared.style.textButton, for: .normal)
-            setTitleColor(WordPressAuthenticator.shared.style.textButtonHighlight, for: .highlighted)
+            setTitleColor(WordPressAuthenticator.shared.style.textButtonColor, for: .normal)
+            setTitleColor(WordPressAuthenticator.shared.style.textButtonHighlightColor, for: .highlighted)
         }
     }
 }
@@ -104,8 +104,8 @@ extension WPStyleGuide {
     class func googleLoginButton() -> UIButton {
         let baseString =  NSLocalizedString("{G} Log in with Google.", comment: "Label for button to log in using Google. The {G} will be replaced with the Google logo.")
 
-        let attrStrNormal = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButton)
-        let attrStrHighlight = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButtonHighlight)
+        let attrStrNormal = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButtonColor)
+        let attrStrHighlight = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButtonHighlightColor)
 
         let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 
@@ -119,8 +119,8 @@ extension WPStyleGuide {
     class func selfHostedLoginButton() -> UIButton {
         let baseString =  NSLocalizedString("Log in by entering your site address.", comment: "Label for button to log in using your site address.")
 
-        let attrStrNormal = selfHostedButtonString(baseString, linkColor:  WordPressAuthenticator.shared.style.textButton)
-        let attrStrHighlight = selfHostedButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButtonHighlight)
+        let attrStrNormal = selfHostedButtonString(baseString, linkColor:  WordPressAuthenticator.shared.style.textButtonColor)
+        let attrStrHighlight = selfHostedButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButtonHighlightColor)
 
         let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -7,7 +7,8 @@ final class SubheadlineButton: UIButton {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             titleLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
-            setTitleColor(WordPressAuthenticator.shared.style.subheadlineColor, for: .normal)
+            setTitleColor(WordPressAuthenticator.shared.style.textButton, for: .normal)
+            setTitleColor(WordPressAuthenticator.shared.style.textButtonHighlight, for: .highlighted)
         }
     }
 }
@@ -103,8 +104,8 @@ extension WPStyleGuide {
     class func googleLoginButton() -> UIButton {
         let baseString =  NSLocalizedString("{G} Log in with Google.", comment: "Label for button to log in using Google. The {G} will be replaced with the Google logo.")
 
-        let attrStrNormal = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.primaryNormalBorderColor)
-        let attrStrHighlight = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.primaryHighlightBorderColor)
+        let attrStrNormal = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButton)
+        let attrStrHighlight = googleButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButtonHighlight)
 
         let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 
@@ -118,8 +119,8 @@ extension WPStyleGuide {
     class func selfHostedLoginButton() -> UIButton {
         let baseString =  NSLocalizedString("Log in by entering your site address.", comment: "Label for button to log in using your site address.")
 
-        let attrStrNormal = selfHostedButtonString(baseString, linkColor:  WordPressAuthenticator.shared.style.primaryNormalBorderColor)
-        let attrStrHighlight = selfHostedButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.primaryHighlightBorderColor)
+        let attrStrNormal = selfHostedButtonString(baseString, linkColor:  WordPressAuthenticator.shared.style.textButton)
+        let attrStrHighlight = selfHostedButtonString(baseString, linkColor: WordPressAuthenticator.shared.style.textButtonHighlight)
 
         let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -211,7 +211,7 @@ extension WPStyleGuide {
 
         let labelString = NSMutableAttributedString(string: "")
 
-        if let originalDomainsIcon = Gridicon.iconOfType(.domains).imageWithTintColor(WPStyleGuide.greyLighten10()) {
+        if let originalDomainsIcon = Gridicon.iconOfType(.domains).imageWithTintColor(WordPressAuthenticator.shared.style.placeholderColor) {
             var domainsIcon = originalDomainsIcon.cropping(to: CGRect(x: Constants.domainsIconPaddingToRemove,
                                                                       y: Constants.domainsIconPaddingToRemove,
                                                                       width: originalDomainsIcon.size.width - Constants.domainsIconPaddingToRemove * 2,

--- a/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
@@ -73,6 +73,7 @@ class NUXLinkMailViewController: LoginViewController {
                 return NSLocalizedString("We sent you a magic signup link! Check your email on this device, and tap the link in the email to finish signing up.", comment: "Instructional text on how to open the email containing a magic link.")
             }
         }()
+        label?.textColor = WordPressAuthenticator.shared.style.instructionColor
     }
 
     // MARK: - Dynamic type

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
@@ -38,5 +38,6 @@ IB_DESIGNABLE
 @property (nonatomic) UIEdgeInsets contentInsets;
 
 - (instancetype)initWithLeftViewImage:(UIImage *)image;
+- (void)setupPlaceholder;
 
 @end

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
@@ -6,7 +6,6 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable BOOL showTopLineSeparator;
 @property (nonatomic) IBInspectable BOOL showSecureTextEntryToggle;
 @property (nonatomic) IBInspectable UIImage *leftViewImage;
-@property (nonatomic, strong) UIButton *secureTextEntryToggle;
 
 /// Width for the left view. Set to 0 to use the given frame in the view.
 /// Default is: 30
@@ -39,6 +38,5 @@ IB_DESIGNABLE
 @property (nonatomic) UIEdgeInsets contentInsets;
 
 - (instancetype)initWithLeftViewImage:(UIImage *)image;
-- (void)setupPlaceholder;
 
 @end

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
@@ -6,6 +6,7 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable BOOL showTopLineSeparator;
 @property (nonatomic) IBInspectable BOOL showSecureTextEntryToggle;
 @property (nonatomic) IBInspectable UIImage *leftViewImage;
+@property (nonatomic, strong) UIButton *secureTextEntryToggle;
 
 /// Width for the left view. Set to 0 to use the given frame in the view.
 /// Default is: 30

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -8,7 +8,6 @@ NSInteger const LeftImageSpacing = 8;
 @import Gridicons;
 
 @interface WPWalkthroughTextField ()
-@property (nonatomic, strong) UIButton *secureTextEntryToggle;
 @property (nonatomic, strong) UIImage *secureTextEntryImageVisible;
 @property (nonatomic, strong) UIImage *secureTextEntryImageHidden;
 @end

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -8,6 +8,7 @@ NSInteger const LeftImageSpacing = 8;
 @import Gridicons;
 
 @interface WPWalkthroughTextField ()
+@property (nonatomic, strong) UIButton *secureTextEntryToggle;
 @property (nonatomic, strong) UIImage *secureTextEntryImageVisible;
 @property (nonatomic, strong) UIImage *secureTextEntryImageHidden;
 @end
@@ -85,13 +86,9 @@ NSInteger const LeftImageSpacing = 8;
     self.showTopLineSeparator = NO;
     self.showSecureTextEntryToggle = NO;
 
-    [self setupPlaceholder];
-}
-
-- (void)setupPlaceholder
-{
     // Apply styles to the placeholder if one was set in IB.
     if (self.placeholder) {
+        // colors here are overridden in LoginTextField
         NSDictionary *attributes = @{
                                      NSForegroundColorAttributeName : WPStyleGuide.greyLighten10,
                                      NSFontAttributeName : self.font,
@@ -114,6 +111,7 @@ NSInteger const LeftImageSpacing = 8;
 
     self.secureTextEntryToggle = [UIButton buttonWithType:UIButtonTypeCustom];
     self.secureTextEntryToggle.clipsToBounds = true;
+    // colors here are overridden in LoginTextField
     self.secureTextEntryToggle.tintColor = [WPStyleGuide greyLighten10];
     [self.secureTextEntryToggle addTarget:self action:@selector(secureTextEntryToggleAction:) forControlEvents:UIControlEventTouchUpInside];
 

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -86,6 +86,11 @@ NSInteger const LeftImageSpacing = 8;
     self.showTopLineSeparator = NO;
     self.showSecureTextEntryToggle = NO;
 
+    [self setupPlaceholder];
+}
+
+- (void)setupPlaceholder
+{
     // Apply styles to the placeholder if one was set in IB.
     if (self.placeholder) {
         NSDictionary *attributes = @{
@@ -146,7 +151,6 @@ NSInteger const LeftImageSpacing = 8;
     CGContextAddPath(context, path.CGPath);
     CGContextSetStrokeColorWithColor(context, [UIColor colorWithWhite:0.87 alpha:1.0].CGColor);
     CGContextStrokePath(context);
-
 }
 
 

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -470,6 +470,7 @@
                                                         <rect key="frame" x="0.0" y="44" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
+                                                        <nil key="textColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES" textContentType="one-time-code"/>
                                                         <userDefinedRuntimeAttributes>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -194,7 +194,7 @@
                                                             <constraint firstAttribute="height" constant="20" id="nUZ-Ew-0l4"/>
                                                         </constraints>
                                                     </view>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                         <rect key="frame" x="0.0" y="58" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
@@ -279,7 +279,7 @@
                                             <constraint firstItem="JdU-yW-tzf" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" id="yAg-ul-Rff"/>
                                         </constraints>
                                     </view>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="NUXButton" customModule="WordPressAuthenticator" >
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="NUXButton" customModule="WordPressAuthenticator">
                                         <rect key="frame" x="327" y="548" width="36" height="44"/>
                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                         <constraints>
@@ -400,7 +400,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y8j-4r-VXw">
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="539"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wnq-Hk-jIw" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator" >
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wnq-Hk-jIw" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="20" y="191.5" width="343" height="36"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
@@ -449,7 +449,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
                                                 <rect key="frame" x="0.0" y="247.5" width="383" height="88"/>
                                                 <subviews>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                         <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
@@ -466,7 +466,7 @@
                                                             <outlet property="delegate" destination="SZS-o3-1P7" id="NfG-gH-Yct"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                         <rect key="frame" x="0.0" y="44" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
@@ -510,7 +510,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zbk-h0-lpE">
                                         <rect key="frame" x="20" y="539" width="343" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP" customClass="SubheadlineButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="141" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Lost your password?">
@@ -520,7 +520,7 @@
                                                     <action selector="handleForgotPasswordButtonTapped:" destination="SZS-o3-1P7" eventType="touchUpInside" id="YFl-yy-9UR"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SBB-7Z-qWs" customClass="NUXButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SBB-7Z-qWs" customClass="NUXButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="311" y="0.0" width="32" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
@@ -635,7 +635,7 @@
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                         <rect key="frame" x="0.0" y="29" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
@@ -685,7 +685,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
                                         <rect key="frame" x="20" y="539" width="343" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3" customClass="SubheadlineButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="141" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Lost your password?">
@@ -695,7 +695,7 @@
                                                     <action selector="handleForgotPasswordButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="q8s-z9-VIK"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="NUXButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="NUXButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="292" y="0.0" width="51" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
@@ -754,6 +754,7 @@
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="cuz-xK-BSJ" id="fwY-mo-qJg"/>
+                        <outlet property="emailIcon" destination="e88-X2-Rh2" id="OY0-tp-RyM"/>
                         <outlet property="emailLabel" destination="sx0-OR-XAf" id="QG9-cz-Txr"/>
                         <outlet property="emailStackView" destination="Xgi-ZQ-8YL" id="nwq-43-TGi"/>
                         <outlet property="errorLabel" destination="ZqY-I8-yWG" id="dD9-4a-eqs"/>
@@ -792,7 +793,7 @@
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" textAlignment="natural" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" textAlignment="natural" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="243.5" width="383" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
@@ -845,7 +846,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="x1G-Lf-mra">
                                         <rect key="frame" x="20" y="531" width="343" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="309-z3-fPx" customClass="SubheadlineButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="309-z3-fPx" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="0.0" width="131" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="fzI-rH-0f8"/>
@@ -859,7 +860,7 @@
                                                     <action selector="handleSendVerificationButtonTapped:" destination="bAd-Df-IzS" eventType="touchUpInside" id="rvK-YF-gYu"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6eO-V2-a64" customClass="NUXButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6eO-V2-a64" customClass="NUXButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="296" y="0.0" width="47" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="eoc-KU-71N"/>
@@ -943,7 +944,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Mq6-n0-6iO">
                                 <rect key="frame" x="36" y="184.5" width="303" height="258.5"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ukv-qo-ql4" customClass="CircularImageView" customModule="WordPressAuthenticator" >
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ukv-qo-ql4" customClass="CircularImageView" customModule="WordPressAuthenticator">
                                         <rect key="frame" x="101.5" y="0.0" width="100" height="100"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="3wv-b7-gzu"/>
@@ -956,7 +957,7 @@
                                         <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iIy-Sm-1r0" customClass="NUXButton" customModule="WordPressAuthenticator" >
+                                    <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iIy-Sm-1r0" customClass="NUXButton" customModule="WordPressAuthenticator">
                                         <rect key="frame" x="115.5" y="224.5" width="72" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="GRI-y6-q3i"/>
@@ -988,7 +989,7 @@
                                     </mask>
                                 </variation>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6x-b7-hU9" customClass="SubheadlineButton" customModule="WordPressAuthenticator" >
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6x-b7-hU9" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                 <rect key="frame" x="0.0" y="617" width="375" height="30"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <state key="normal" title="Enter your password instead"/>
@@ -1050,7 +1051,7 @@
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="https://example.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="https://example.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="246" width="391" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
@@ -1093,7 +1094,7 @@
                                     <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
                                         <rect key="frame" x="20" y="536" width="351" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n" customClass="SubheadlineButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="250" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
@@ -1104,7 +1105,7 @@
                                                     <action selector="handleSiteAddressHelpButtonTapped:" destination="anK-hg-K4j" eventType="touchUpInside" id="PXe-Yc-xaK"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ltO-hW-mbe" customClass="NUXButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ltO-hW-mbe" customClass="NUXButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="315" y="0.0" width="36" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                                 <constraints>
@@ -1205,7 +1206,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uk6-st-DBG">
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="539"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-HN-aFE" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator" >
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-HN-aFE" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="20" y="27" width="343" height="200.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-b4-JSG">
@@ -1265,7 +1266,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="52R-ls-Jbr">
                                                 <rect key="frame" x="0.0" y="247.5" width="383" height="88"/>
                                                 <subviews>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZUH-Y9-OaY" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZUH-Y9-OaY" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                         <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
@@ -1282,7 +1283,7 @@
                                                             <outlet property="delegate" destination="iMi-vX-AxR" id="gie-WC-jNK"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pHh-Ma-Bb7" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pHh-Ma-Bb7" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                         <rect key="frame" x="0.0" y="44" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
@@ -1326,7 +1327,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hzZ-dr-nAB">
                                         <rect key="frame" x="20" y="539" width="343" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XI0-rr-yUh" customClass="SubheadlineButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XI0-rr-yUh" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="141" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Lost your password?">
@@ -1336,7 +1337,7 @@
                                                     <action selector="handleForgotPasswordButtonTapped:" destination="iMi-vX-AxR" eventType="touchUpInside" id="G3u-gq-3v2"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YGE-OB-HmV" customClass="NUXButton" customModule="WordPressAuthenticator" >
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YGE-OB-HmV" customClass="NUXButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="311" y="0.0" width="32" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
@@ -1414,9 +1415,9 @@
         <image name="icon-username-field" width="18" height="18"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="2Bq-Nv-ZkV"/>
+        <segue reference="qLI-qX-rkG"/>
         <segue reference="0ao-yi-yZI"/>
-        <segue reference="TkG-0R-c3i"/>
+        <segue reference="4SK-mG-U33"/>
         <segue reference="sIC-Hv-FJw"/>
         <segue reference="D3h-Su-Jwk"/>
         <segue reference="swV-lc-6gI"/>

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -226,6 +226,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     private func configureAlternativeLabel() {
         alternativeLoginLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        alternativeLoginLabel?.textColor = WordPressAuthenticator.shared.style.subheadlineColor
     }
 
     /// Configures whether appearance of the submit button.

--- a/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
@@ -56,6 +56,7 @@ class LoginLinkRequestViewController: LoginViewController {
         let format = NSLocalizedString("We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!", comment: "Instructional text for the magic link login flow.")
         label?.text = NSString(format: format as NSString, loginFields.username) as String
         label?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
+        label?.textColor = WordPressAuthenticator.shared.style.instructionColor
         label?.adjustsFontForContentSizeCategory = true
 
         let sendLinkButtonTitle = NSLocalizedString("Send Link", comment: "Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user.")

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -68,7 +68,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
             self?.present(safariViewController, animated: true, completion: nil)
         }
         buttonViewController.stackView?.insertArrangedSubview(termsButton, at: 0)
-        buttonViewController.backgroundColor = WPStyleGuide.lightGrey()
+        buttonViewController.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
     }
 
     @IBAction func dismissTapped() {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -75,7 +75,7 @@ class LoginPrologueViewController: LoginViewController {
                 self?.dismiss(animated: true, completion: nil)
             }
         }
-        buttonViewController.backgroundColor = WPStyleGuide.lightGrey()
+        buttonViewController.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
     }
 
     // MARK: - Actions

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -186,7 +186,7 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         siteHeaderView.subtitleIsHidden = true
 
         siteHeaderView.blavatarBorderIsHidden = true
-        siteHeaderView.blavatarImage = .linkFieldImage
+        siteHeaderView.blavatarImage = UIImage.linkFieldImage.imageWithTintColor(WordPressAuthenticator.shared.style.placeholderColor)
     }
 
 

--- a/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
@@ -81,6 +81,6 @@ open class LoginSocialErrorCell: UITableViewCell {
             descriptionLabel.text = errorDescription
         }
 
-        backgroundColor = WPStyleGuide.greyLighten30()
+        backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
     }
 }

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -57,7 +57,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = WPStyleGuide.greyLighten30()
+        view.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
         addWordPressLogoToNavController()
     }
 
@@ -140,7 +140,7 @@ extension LoginSocialErrorViewController {
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let footer = UIView()
-        footer.backgroundColor = WPStyleGuide.greyLighten20()
+        footer.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
         return footer
     }
 

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -70,6 +70,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     func styleInstructions() {
         instructionLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
         instructionLabel?.adjustsFontForContentSizeCategory = true
+        instructionLabel?.textColor = WordPressAuthenticator.shared.style.instructionColor
     }
 
     func configureViewLoading(_ loading: Bool) {

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -10,6 +10,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     @IBOutlet weak var bottomContentConstraint: NSLayoutConstraint?
     @IBOutlet weak var verticalCenterConstraint: NSLayoutConstraint?
     @objc var onePasswordButton: UIButton!
+    @IBOutlet var emailIcon: UIImageView?
     @IBOutlet var emailLabel: UITextField?
     @IBOutlet var emailStackView: UIStackView?
     override var sourceTag: WordPressSupportSourceTag {
@@ -43,6 +44,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         loginFields.meta.userIsDotCom = true
 
         configureTextFields()
+        configureEmailIcon()
         configureSubmitButton(animating: false)
         configureViewForEditingIfNeeded()
     }
@@ -116,6 +118,14 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         passwordField?.text = loginFields.password
         passwordField?.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
         emailLabel?.text = loginFields.username
+        emailLabel?.textColor = WordPressAuthenticator.shared.style.subheadlineColor
+    }
+
+    func configureEmailIcon() {
+        guard let image = emailIcon?.image else {
+            return
+        }
+        emailIcon?.image = image.imageWithTintColor(WordPressAuthenticator.shared.style.subheadlineColor)
     }
 
     @objc func localizeControls() {

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -3,6 +3,14 @@ import WordPressShared
 
 open class LoginTextField: WPWalkthroughTextField {
 
+    override open func awakeFromNib() {
+        super.awakeFromNib()
+        guard let secureTextEntryToggle = secureTextEntryToggle else {
+            return
+        }
+        secureTextEntryToggle.tintColor = WordPressAuthenticator.shared.style.placeholderColor
+    }
+
     override open func draw(_ rect: CGRect) {
         if showTopLineSeparator {
             guard let context = UIGraphicsGetCurrentContext() else {

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -3,14 +3,6 @@ import WordPressShared
 
 open class LoginTextField: WPWalkthroughTextField {
 
-    override open func awakeFromNib() {
-        super.awakeFromNib()
-        guard let secureTextEntryToggle = secureTextEntryToggle else {
-            return
-        }
-        secureTextEntryToggle.tintColor = WordPressAuthenticator.shared.style.placeholderColor
-    }
-
     override open func draw(_ rect: CGRect) {
         if showTopLineSeparator {
             guard let context = UIGraphicsGetCurrentContext() else {
@@ -22,16 +14,19 @@ open class LoginTextField: WPWalkthroughTextField {
         }
     }
 
-    override open func setupPlaceholder() {
-        guard let placeholder = placeholder,
-            let font = font else {
-            return
+    override open var placeholder: String? {
+        didSet {
+            guard let placeholder = placeholder,
+                let font = font else {
+                return
+            }
+
+            let attributes: [NSAttributedString.Key : Any] = [
+                .foregroundColor: WordPressAuthenticator.shared.style.placeholderColor,
+                .font: font
+            ]
+            attributedPlaceholder = NSAttributedString(string: placeholder, attributes: attributes)
         }
-        let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: WordPressAuthenticator.shared.style.placeholderColor,
-            .font: font
-        ]
-        self.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: attributes)
     }
 
     override open var leftViewImage: UIImage! {

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -14,6 +14,27 @@ open class LoginTextField: WPWalkthroughTextField {
         }
     }
 
+    override open func setupPlaceholder() {
+        guard let placeholder = placeholder else {
+            return
+        }
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: WordPressAuthenticator.shared.style.placeholderColor,
+            .font: font
+        ]
+        self.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: attributes)
+    }
+
+    override open var leftViewImage: UIImage! {
+        set {
+            let newImage = newValue.imageWithTintColor(WordPressAuthenticator.shared.style.placeholderColor)
+            super.leftViewImage = newImage
+        }
+        get {
+            return super.leftViewImage
+        }
+    }
+
     private func drawTopLine(rect: CGRect, context: CGContext) {
         drawBorderLine(from: CGPoint(x: rect.minX, y: rect.minY), to: CGPoint(x: rect.maxX, y: rect.minY), context: context)
     }
@@ -29,7 +50,7 @@ open class LoginTextField: WPWalkthroughTextField {
         path.addLine(to: endPoint)
         path.lineWidth = UIScreen.main.scale / 2.0
         context.addPath(path.cgPath)
-        context.setStrokeColor(WPStyleGuide.greyLighten20().cgColor)
+        context.setStrokeColor(WordPressAuthenticator.shared.style.secondaryNormalBorderColor.cgColor)
         context.strokePath()
     }
 }

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -23,7 +23,8 @@ open class LoginTextField: WPWalkthroughTextField {
     }
 
     override open func setupPlaceholder() {
-        guard let placeholder = placeholder else {
+        guard let placeholder = placeholder,
+            let font = font else {
             return
         }
         let attributes: [NSAttributedString.Key: Any] = [

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -47,7 +47,9 @@ open class SearchTableViewCell: UITableViewCell {
         textField.returnKeyType = .search
         textField.contentInsets = Constants.textInsetsWithIcon
         textField.accessibilityIdentifier = "Search field"
-        textField.leftViewImage = textField?.leftViewImage?.imageWithTintColor(Constants.leftImageTintColor)
+        textField.leftViewImage = textField?.leftViewImage?.imageWithTintColor(WordPressAuthenticator.shared.style.placeholderColor)
+
+        contentView.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
     }
 }
 
@@ -57,7 +59,6 @@ open class SearchTableViewCell: UITableViewCell {
 private extension SearchTableViewCell {
     enum Constants {
         static let textInsetsWithIcon = WPStyleGuide.edgeInsetForLoginTextFields()
-        static let leftImageTintColor = WPStyleGuide.grey()
     }
 }
 

--- a/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
+++ b/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
@@ -113,9 +113,9 @@ private extension SiteInfoHeaderView {
             blavatarImageView.layer.borderWidth = 0
             blavatarImageView.tintColor = .clear
         } else {
-            blavatarImageView.layer.borderColor = WPStyleGuide.greyLighten20().cgColor
+            blavatarImageView.layer.borderColor = WordPressAuthenticator.shared.style.instructionColor.cgColor
             blavatarImageView.layer.borderWidth = 1
-            blavatarImageView.tintColor = WPStyleGuide.greyLighten10()
+            blavatarImageView.tintColor = WordPressAuthenticator.shared.style.instructionColor
         }
     }
 }

--- a/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
+++ b/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
@@ -115,7 +115,7 @@ private extension SiteInfoHeaderView {
         } else {
             blavatarImageView.layer.borderColor = WordPressAuthenticator.shared.style.instructionColor.cgColor
             blavatarImageView.layer.borderWidth = 1
-            blavatarImageView.tintColor = WordPressAuthenticator.shared.style.instructionColor
+            blavatarImageView.tintColor = WordPressAuthenticator.shared.style.placeholderColor
         }
     }
 }


### PR DESCRIPTION
To finish my efforts to use the new WPiOS color scheme during login, this PR makes the remaining colors from the old WPiOS color palette configurable. It also removes the default `WordPressAuthenticatorStyle`, and makes the `style` argument mandatory.

This will have compatibility implications for the other projects that use this pod.

### Examples:

![image](https://user-images.githubusercontent.com/517257/61255422-b8f1e580-a725-11e9-9a4e-287d95cbe393.png)
![image](https://user-images.githubusercontent.com/517257/61255431-c60ed480-a725-11e9-808a-5b49b69a9b06.png)
