### PR TITLE
Update nav bar badge color

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.7.0-beta.1"
+  s.version       = "1.7.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -57,9 +57,11 @@ public struct WordPressAuthenticatorStyle {
     ///
     public let viewControllerBackgroundColor: UIColor
 
-    /// Style: nav bar logo
+    /// Style: nav bar
     ///
     public let navBarImage: UIImage
+
+    public let navBarBadgeColor: UIColor
 
     /// Style: prologue background colors
     ///
@@ -71,7 +73,7 @@ public struct WordPressAuthenticatorStyle {
 
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, navBarBadgeColor: UIColor, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -92,6 +94,7 @@ public struct WordPressAuthenticatorStyle {
         self.placeholderColor = placeholderColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
         self.navBarImage = navBarImage
+        self.navBarBadgeColor = navBarBadgeColor
         self.prologueBackgroundColor = prologueBackgroundColor
         self.prologueTitleColor = prologueTitleColor
     }

--- a/WordPressAuthenticator/NUX/WPHelpIndicatorView.swift
+++ b/WordPressAuthenticator/NUX/WPHelpIndicatorView.swift
@@ -5,7 +5,7 @@ open class WPHelpIndicatorView: UIView {
 
     struct Constants {
         static let defaultInsets = UIEdgeInsets.zero
-        static let defaultBackgroundColor = WPStyleGuide.jazzyOrange()
+        static let defaultBackgroundColor = WordPressAuthenticator.shared.style.navBarBadgeColor
     }
     
     var insets: UIEdgeInsets = Constants.defaultInsets {


### PR DESCRIPTION
This PR updates the color of the dot on the nav bar that's used to indicate if there is a message in the help system.

<img width="464" alt="image" src="https://user-images.githubusercontent.com/517257/61413479-d7341e80-a8a8-11e9-9ca3-5d2506f18ebb.png">
