### PR TITLE
`WordPressComSiteInfo`: update setting `hasJetpack` from remote response

### DIFF
--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -37,7 +37,7 @@ public class WordPressComSiteInfo {
         name        = remote["name"] as? String         ?? ""
         tagline     = remote["description"] as? String  ?? ""
         url         = remote["URL"] as? String          ?? ""
-        hasJetpack  = remote["jetpack"] as? Bool        ?? false
+        hasJetpack  = remote["hasJetpack"] as? Bool     ?? false
         icon        = remote["icon.img"] as? String     ?? ""
         isWPCom     = remote["isWordPressDotCom"] as? Bool ?? false
         


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/1113

- WCiOS PR branch for testing: https://github.com/woocommerce/woocommerce-ios/pull/1118
- WPiOS PR branch for testing: https://github.com/wordpress-mobile/WordPress-iOS/pull/12170

## Background

In [this PR](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/98/files), we switched the API call to fetch site info during site address sign in flow from `fetchSiteInfo` to `fetchUnauthenticatedSiteInfoForAddress` in order to accommodate both public and private sites (`fetchSiteInfo` only works for public sites). However, the responses from these two calls are very different.

With `fetchSiteInfo` (what we called before for WP.com sites), the response is like:
```
{
    "ID": 161199960,
    "name": "fun testing",
    "description": "",
    "URL": "https://funtestingusa.wpcomstaging.com",
    "jetpack": true,
    ...
}
```

And with `fetchUnauthenticatedSiteInfoForAddress`, the response looks like:
```
{
    "urlAfterRedirects": "https://funtestingusa.wpcomstaging.com",
    "isWordPress": true,
    "hasJetpack": true,
    "isWordPressDotCom": true
    ...
}
```

Originally, the site info’s `hasJetpack` is decoded from the response’s `jetpack` field, but now this info lives in the response's `hasJetpack` field. Thus, site info’s `hasJetpack` field is always false.

This is not a problem in WPiOS because WPiOS [does not check any other fields in the site info ](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift#L184) before proceeding to the next screen vs. WCiOS [only continues when site info's `hasJetpack` field is true](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L138) in the authenticator delegate method. That’s why the site address is not considered valid and stuck on the site address screen in WCiOS.

## Changes

- Updated how we populate `hasJetpack` field in `WordPressComSiteInfo` from remote response's `jetpack` field to `hasJetpack` field
- Notes: there are more fields that are not populated correctly with the new API response (e.g. `name`, `url`, `icon`), but I'd like to keep this PR small to just fix the sign in issue in WCiOS

## Testing

In [WCiOS branch](https://github.com/woocommerce/woocommerce-ios/pull/1118)
- Sign in with site address --> should be able to complete the flow to enter a WC store

In [WPiOS branch](https://github.com/wordpress-mobile/WordPress-iOS/pull/12170)
- Sign in with site address --> should work as before