### PR TITLE
Log In: show login options after site address validated.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.1"
+  s.version       = "1.8.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -51,6 +51,11 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let showNewLoginFlow: Bool
 
+    /// Flag indicating if the login options button view should be displayed in the site address flow.
+    /// If enabled, the options button view will be displayed after the site address has been entered
+    /// and verified.
+    ///
+    let showLoginOptionsFromSiteAddress: Bool
 
     /// Designated Initializer
     ///
@@ -64,7 +69,8 @@ public struct WordPressAuthenticatorConfiguration {
                  googleLoginServerClientId: String,
                  googleLoginScheme: String,
                  userAgent: String,
-                 showNewLoginFlow: Bool = false) {
+                 showNewLoginFlow: Bool = false,
+                 showLoginOptionsFromSiteAddress: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -77,5 +83,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginScheme = googleLoginScheme
         self.userAgent = userAgent
         self.showNewLoginFlow = showNewLoginFlow
+        self.showLoginOptionsFromSiteAddress = showLoginOptionsFromSiteAddress
     }
 }

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -15,7 +15,7 @@
                 <viewControllerPlaceholder storyboardIdentifier="Signup" storyboardName="Signup" referencedIdentifier="googleSignup" id="MEg-KS-Afs" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bjg-XU-5Rh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="646" y="-153"/>
+            <point key="canvasLocation" x="1384" y="-231"/>
         </scene>
         <!--Login Prologue Page View Controller-->
         <scene sceneID="Jbm-5H-sqY">
@@ -409,23 +409,23 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf" userLabel="Icon">
-                                                                <rect key="frame" x="0.0" y="7" width="18" height="22"/>
+                                                                <rect key="frame" x="0.0" y="10" width="16" height="16"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="F6S-wN-1Jp"/>
                                                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="Z7H-Ud-llZ"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uN1-Al-ygf">
-                                                                <rect key="frame" x="28" y="0.0" width="315" height="36"/>
+                                                                <rect key="frame" x="26" y="0.0" width="317" height="36"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehh-92-XG8" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="315" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="317" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6" userLabel="Subtitle">
-                                                                        <rect key="frame" x="0.0" y="18" width="315" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="18" width="317" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -625,10 +625,10 @@
                                                         <rect key="frame" x="20" y="0.0" width="343" height="21"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
-                                                                <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
+                                                                <rect key="frame" x="0.0" y="2.5" width="16" height="16"/>
                                                             </imageView>
                                                             <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sx0-OR-XAf">
-                                                                <rect key="frame" x="28" y="0.0" width="315" height="21"/>
+                                                                <rect key="frame" x="26" y="0.0" width="317" height="21"/>
                                                                 <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <textInputTraits key="textInputTraits" textContentType="username"/>
@@ -1177,6 +1177,8 @@
                         <outlet property="submitButton" destination="ltO-hW-mbe" id="wwr-D5-5kK"/>
                         <segue destination="SZS-o3-1P7" kind="show" identifier="showURLUsernamePassword" id="TkG-0R-c3i"/>
                         <segue destination="iMi-vX-AxR" kind="show" identifier="showWPUsernamePassword" id="dtm-iK-PLb"/>
+                        <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="5hL-j3-eMs"/>
+                        <segue destination="MEg-KS-Afs" kind="show" identifier="showGoogle" id="pe1-D0-Mpg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WlT-Oa-AoS" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1206,127 +1208,6 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O9q-gs-qUh">
                                 <rect key="frame" x="-4" y="64" width="383" height="603"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uk6-st-DBG">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="539"/>
-                                        <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-HN-aFE" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="20" y="27" width="343" height="200.5"/>
-                                                <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-b4-JSG">
-                                                        <rect key="frame" x="8" y="98.5" width="327" height="94"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in with your WordPress.com account to manage your WooCommerce stores" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au1-mY-r58">
-                                                                <rect key="frame" x="0.0" y="0.0" width="327" height="38"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="IMk-aA-1GF" userLabel="Header Stack View">
-                                                                <rect key="frame" x="0.0" y="58" width="327" height="36"/>
-                                                                <subviews>
-                                                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Gak-2q-wul" userLabel="Icon">
-                                                                        <rect key="frame" x="0.0" y="7" width="18" height="22"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="c8o-Eq-kBi"/>
-                                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="r0G-JB-SfD"/>
-                                                                        </constraints>
-                                                                    </imageView>
-                                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DWy-yy-er4">
-                                                                        <rect key="frame" x="28" y="0.0" width="299" height="36"/>
-                                                                        <subviews>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCX-uI-ruO" userLabel="Title">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="299" height="18"/>
-                                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                                <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                                                <nil key="highlightedColor"/>
-                                                                            </label>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUi-aQ-0SQ" userLabel="Subtitle">
-                                                                                <rect key="frame" x="0.0" y="18" width="299" height="18"/>
-                                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                                <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                                                <nil key="highlightedColor"/>
-                                                                            </label>
-                                                                        </subviews>
-                                                                    </stackView>
-                                                                </subviews>
-                                                            </stackView>
-                                                        </subviews>
-                                                    </stackView>
-                                                </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstItem="Ak2-b4-JSG" firstAttribute="top" secondItem="vkO-HN-aFE" secondAttribute="topMargin" constant="90.5" id="2y2-1S-Mz7"/>
-                                                    <constraint firstAttribute="trailingMargin" secondItem="Ak2-b4-JSG" secondAttribute="trailing" id="QqO-mA-5h2"/>
-                                                    <constraint firstItem="Ak2-b4-JSG" firstAttribute="leading" secondItem="vkO-HN-aFE" secondAttribute="leadingMargin" id="Vxa-nk-4aC"/>
-                                                    <constraint firstAttribute="bottomMargin" secondItem="Ak2-b4-JSG" secondAttribute="bottom" id="qz8-VS-Xcz"/>
-                                                </constraints>
-                                                <connections>
-                                                    <outlet property="blavatarImageView" destination="Gak-2q-wul" id="YyT-uQ-DI9"/>
-                                                    <outlet property="subtitleLabel" destination="hUi-aQ-0SQ" id="jha-9H-O81"/>
-                                                    <outlet property="titleLabel" destination="cCX-uI-ruO" id="DsQ-dr-c9H"/>
-                                                </connections>
-                                            </view>
-                                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="52R-ls-Jbr">
-                                                <rect key="frame" x="0.0" y="247.5" width="383" height="88"/>
-                                                <subviews>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZUH-Y9-OaY" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                                                        <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
-                                                        <nil key="textColor"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES" smartInsertDeleteType="no" textContentType="one-time-code"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleTextFieldDidChange:" destination="iMi-vX-AxR" eventType="editingChanged" id="zzV-Da-bfZ"/>
-                                                            <outlet property="delegate" destination="iMi-vX-AxR" id="gie-WC-jNK"/>
-                                                        </connections>
-                                                    </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pHh-Ma-Bb7" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                                                        <rect key="frame" x="0.0" y="44" width="383" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES" textContentType="one-time-code"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
-                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleTextFieldDidChange:" destination="iMi-vX-AxR" eventType="editingChanged" id="hz1-Hm-jRQ"/>
-                                                            <outlet property="delegate" destination="iMi-vX-AxR" id="hQu-Qv-n6b"/>
-                                                        </connections>
-                                                    </textField>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="88" id="N1i-gb-9vt"/>
-                                                </constraints>
-                                            </stackView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vpd-vq-FQH">
-                                                <rect key="frame" x="20" y="355.5" width="343" height="0.0"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="Vpd-vq-FQH" firstAttribute="top" secondItem="52R-ls-Jbr" secondAttribute="bottom" constant="20" id="4mB-cH-fk7"/>
-                                            <constraint firstItem="ZUH-Y9-OaY" firstAttribute="centerY" secondItem="Uk6-st-DBG" secondAttribute="centerY" priority="900" id="5q6-Af-ael"/>
-                                            <constraint firstAttribute="trailing" secondItem="52R-ls-Jbr" secondAttribute="trailing" id="DOF-Ld-jxa"/>
-                                            <constraint firstAttribute="trailing" secondItem="Vpd-vq-FQH" secondAttribute="trailing" constant="20" id="Huy-UV-byK"/>
-                                            <constraint firstAttribute="trailing" secondItem="vkO-HN-aFE" secondAttribute="trailing" constant="20" id="LkX-1H-0YL"/>
-                                            <constraint firstItem="Vpd-vq-FQH" firstAttribute="leading" secondItem="Uk6-st-DBG" secondAttribute="leading" constant="20" id="SND-PR-mWo"/>
-                                            <constraint firstItem="52R-ls-Jbr" firstAttribute="leading" secondItem="Uk6-st-DBG" secondAttribute="leading" id="UNx-1T-LLd"/>
-                                            <constraint firstItem="vkO-HN-aFE" firstAttribute="leading" secondItem="Uk6-st-DBG" secondAttribute="leading" constant="20" id="beb-Tp-Lo9"/>
-                                            <constraint firstItem="vkO-HN-aFE" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uk6-st-DBG" secondAttribute="top" constant="20" id="pUG-mO-AGI"/>
-                                            <constraint firstItem="52R-ls-Jbr" firstAttribute="top" secondItem="vkO-HN-aFE" secondAttribute="bottom" constant="20" id="qoc-lH-muK"/>
-                                        </constraints>
-                                    </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hzZ-dr-nAB">
                                         <rect key="frame" x="20" y="539" width="343" height="44"/>
                                         <subviews>
@@ -1362,13 +1243,9 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="383" id="0Do-uX-Nzd"/>
-                                    <constraint firstItem="hzZ-dr-nAB" firstAttribute="top" secondItem="Uk6-st-DBG" secondAttribute="bottom" id="5Nv-Zl-nd0"/>
-                                    <constraint firstItem="Uk6-st-DBG" firstAttribute="top" secondItem="O9q-gs-qUh" secondAttribute="top" id="OUA-Ro-sTe"/>
-                                    <constraint firstAttribute="trailing" secondItem="Uk6-st-DBG" secondAttribute="trailing" id="VoH-Rr-Ljy"/>
                                     <constraint firstItem="hzZ-dr-nAB" firstAttribute="leading" secondItem="O9q-gs-qUh" secondAttribute="leading" constant="20" id="gqO-Ez-aez"/>
                                     <constraint firstAttribute="trailing" secondItem="hzZ-dr-nAB" secondAttribute="trailing" constant="20" id="jms-n2-emz"/>
                                     <constraint firstAttribute="bottom" secondItem="hzZ-dr-nAB" secondAttribute="bottom" constant="20" id="oL3-gk-TGp"/>
-                                    <constraint firstItem="Uk6-st-DBG" firstAttribute="leading" secondItem="O9q-gs-qUh" secondAttribute="leading" id="onE-Dw-ZBy"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -1381,12 +1258,137 @@
                                     </mask>
                                 </variation>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uk6-st-DBG">
+                                <rect key="frame" x="-4" y="64" width="383" height="539"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-HN-aFE" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
+                                        <rect key="frame" x="20" y="27" width="343" height="200.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-b4-JSG">
+                                                <rect key="frame" x="8" y="98.5" width="327" height="94"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in with your WordPress.com account to manage your WooCommerce stores" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au1-mY-r58">
+                                                        <rect key="frame" x="0.0" y="0.0" width="327" height="38"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="IMk-aA-1GF" userLabel="Header Stack View">
+                                                        <rect key="frame" x="0.0" y="58" width="327" height="36"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Gak-2q-wul" userLabel="Icon">
+                                                                <rect key="frame" x="0.0" y="10" width="16" height="16"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="c8o-Eq-kBi"/>
+                                                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="r0G-JB-SfD"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DWy-yy-er4">
+                                                                <rect key="frame" x="26" y="0.0" width="301" height="36"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCX-uI-ruO" userLabel="Title">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="301" height="18"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                        <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUi-aQ-0SQ" userLabel="Subtitle">
+                                                                        <rect key="frame" x="0.0" y="18" width="301" height="18"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                        <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="Ak2-b4-JSG" firstAttribute="top" secondItem="vkO-HN-aFE" secondAttribute="topMargin" constant="90.5" id="2y2-1S-Mz7"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="Ak2-b4-JSG" secondAttribute="trailing" id="QqO-mA-5h2"/>
+                                            <constraint firstItem="Ak2-b4-JSG" firstAttribute="leading" secondItem="vkO-HN-aFE" secondAttribute="leadingMargin" id="Vxa-nk-4aC"/>
+                                            <constraint firstAttribute="bottomMargin" secondItem="Ak2-b4-JSG" secondAttribute="bottom" id="qz8-VS-Xcz"/>
+                                        </constraints>
+                                        <connections>
+                                            <outlet property="blavatarImageView" destination="Gak-2q-wul" id="YyT-uQ-DI9"/>
+                                            <outlet property="subtitleLabel" destination="hUi-aQ-0SQ" id="jha-9H-O81"/>
+                                            <outlet property="titleLabel" destination="cCX-uI-ruO" id="DsQ-dr-c9H"/>
+                                        </connections>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="52R-ls-Jbr">
+                                        <rect key="frame" x="0.0" y="247.5" width="383" height="88"/>
+                                        <subviews>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZUH-Y9-OaY" customClass="LoginTextField" customModule="WordPressAuthenticator">
+                                                <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES" smartInsertDeleteType="no" textContentType="one-time-code"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleTextFieldDidChange:" destination="iMi-vX-AxR" eventType="editingChanged" id="zzV-Da-bfZ"/>
+                                                    <outlet property="delegate" destination="iMi-vX-AxR" id="gie-WC-jNK"/>
+                                                </connections>
+                                            </textField>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pHh-Ma-Bb7" customClass="LoginTextField" customModule="WordPressAuthenticator">
+                                                <rect key="frame" x="0.0" y="44" width="383" height="44"/>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES" textContentType="one-time-code"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
+                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleTextFieldDidChange:" destination="iMi-vX-AxR" eventType="editingChanged" id="hz1-Hm-jRQ"/>
+                                                    <outlet property="delegate" destination="iMi-vX-AxR" id="hQu-Qv-n6b"/>
+                                                </connections>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="88" id="N1i-gb-9vt"/>
+                                        </constraints>
+                                    </stackView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vpd-vq-FQH">
+                                        <rect key="frame" x="20" y="355.5" width="343" height="0.0"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="Vpd-vq-FQH" firstAttribute="top" secondItem="52R-ls-Jbr" secondAttribute="bottom" constant="20" id="4mB-cH-fk7"/>
+                                    <constraint firstItem="ZUH-Y9-OaY" firstAttribute="centerY" secondItem="Uk6-st-DBG" secondAttribute="centerY" priority="900" id="5q6-Af-ael"/>
+                                    <constraint firstAttribute="trailing" secondItem="52R-ls-Jbr" secondAttribute="trailing" id="DOF-Ld-jxa"/>
+                                    <constraint firstAttribute="trailing" secondItem="Vpd-vq-FQH" secondAttribute="trailing" constant="20" id="Huy-UV-byK"/>
+                                    <constraint firstAttribute="trailing" secondItem="vkO-HN-aFE" secondAttribute="trailing" constant="20" id="LkX-1H-0YL"/>
+                                    <constraint firstItem="Vpd-vq-FQH" firstAttribute="leading" secondItem="Uk6-st-DBG" secondAttribute="leading" constant="20" id="SND-PR-mWo"/>
+                                    <constraint firstItem="52R-ls-Jbr" firstAttribute="leading" secondItem="Uk6-st-DBG" secondAttribute="leading" id="UNx-1T-LLd"/>
+                                    <constraint firstItem="vkO-HN-aFE" firstAttribute="leading" secondItem="Uk6-st-DBG" secondAttribute="leading" constant="20" id="beb-Tp-Lo9"/>
+                                    <constraint firstItem="vkO-HN-aFE" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uk6-st-DBG" secondAttribute="top" constant="20" id="pUG-mO-AGI"/>
+                                    <constraint firstItem="52R-ls-Jbr" firstAttribute="top" secondItem="vkO-HN-aFE" secondAttribute="bottom" constant="20" id="qoc-lH-muK"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="Uk6-st-DBG" firstAttribute="top" secondItem="UzI-Qm-mc3" secondAttribute="top" constant="64" id="44S-kD-jiI"/>
+                            <constraint firstAttribute="trailing" secondItem="Uk6-st-DBG" secondAttribute="trailing" constant="-4" id="BUj-C9-330"/>
+                            <constraint firstItem="Uk6-st-DBG" firstAttribute="leading" secondItem="UzI-Qm-mc3" secondAttribute="leading" constant="-4" id="CHK-h1-clN"/>
                             <constraint firstItem="O9q-gs-qUh" firstAttribute="centerX" secondItem="UzI-Qm-mc3" secondAttribute="centerX" id="Js8-40-RJM"/>
                             <constraint firstItem="O9q-gs-qUh" firstAttribute="top" secondItem="De3-R2-Sm2" secondAttribute="bottom" id="Lk3-FN-7c1"/>
                             <constraint firstItem="NPl-SI-4X2" firstAttribute="top" secondItem="O9q-gs-qUh" secondAttribute="bottom" id="RM5-Rp-H2z"/>
                             <constraint firstItem="O9q-gs-qUh" firstAttribute="leading" secondItem="UzI-Qm-mc3" secondAttribute="leadingMargin" constant="-20" id="SIn-Gk-ZB8"/>
+                            <constraint firstItem="hzZ-dr-nAB" firstAttribute="top" secondItem="Uk6-st-DBG" secondAttribute="bottom" id="iyI-wY-Cx0"/>
                             <constraint firstAttribute="trailingMargin" secondItem="O9q-gs-qUh" secondAttribute="trailing" constant="-20" id="ujU-1G-20s"/>
                         </constraints>
                         <variation key="heightClass=regular-widthClass=regular">
@@ -1409,7 +1411,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mOF-Ry-81y" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-185" y="1946"/>
+            <point key="canvasLocation" x="-569" y="1984"/>
         </scene>
         <!--Login Prologue Login Method View Controller-->
         <scene sceneID="4ov-Vw-tga">
@@ -1453,7 +1455,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Rrd-X3-roK" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-162" y="1124"/>
+            <point key="canvasLocation" x="-460" y="1248"/>
         </scene>
     </scenes>
     <resources>
@@ -1462,14 +1464,15 @@
         <image name="icon-username-field" width="18" height="18"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="bK1-J1-hfT"/>
-        <segue reference="kRR-qz-Hu2"/>
+        <segue reference="5hL-j3-eMs"/>
+        <segue reference="Njv-lY-Lyi"/>
+        <segue reference="2Bq-Nv-ZkV"/>
         <segue reference="ySQ-EM-6JI"/>
         <segue reference="TkG-0R-c3i"/>
-        <segue reference="sIC-Hv-FJw"/>
+        <segue reference="nCA-u7-fKm"/>
         <segue reference="D3h-Su-Jwk"/>
         <segue reference="swV-lc-6gI"/>
-        <segue reference="EmH-Av-vhT"/>
-        <segue reference="HMT-Z5-QHr"/>
+        <segue reference="gD5-d0-X3t"/>
+        <segue reference="pe1-D0-Mpg"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -51,8 +51,8 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
             self?.dismiss(animated: true)
             self?.googleTapped?()
         }
-        
-        if !LoginFields().restrictToWPCom {
+
+        if !LoginFields().restrictToWPCom && selfHostedTapped != nil {
             let selfHostedLoginButton = WPStyleGuide.selfHostedLoginButton(alignment: .center)
             buttonViewController.stackView?.addArrangedSubview(selfHostedLoginButton)
             selfHostedLoginButton.addTarget(self, action: #selector(handleSelfHostedButtonTapped), for: .touchUpInside)


### PR DESCRIPTION
This change allows displaying a login options button view after a site address has been validated. As this change is specifically for Woo, it should be tested with the Woo app.

(Related discussion can be found [here](https://wp.me/pauD4L-li-p2/#comment-268).)

**Disclaimers**: 
- Woo has not adopted the latest WPAuth pod, and there are several colors `WordPressAuthenticatorStyle` now requires. I picked some to get it working, but they're obviously incorrect. Please ignore the colors in these examples as this PR is specific to the flow, and I assume those colors will be set correctly when Woo updates WPAuth.
- This change assumes in the future Woo will start the login process from the site address view. So there have been no changes to the initial login view (i.e. the email entry).

---
**Prerequisite** - required to get Woo working with the latest WPAuth pod:
- In `AuthenticationManager`, add the missing `WordPressAuthenticatorStyle` parameters. If it helps, you can simply replace the entire init with this, which includes my stub colors.

```
let style = WordPressAuthenticatorStyle(primaryNormalBackgroundColor: StyleManager.buttonPrimaryColor,
                                        primaryNormalBorderColor: StyleManager.buttonPrimaryHighlightedColor,
                                        primaryHighlightBackgroundColor: StyleManager.buttonPrimaryHighlightedColor,
                                        primaryHighlightBorderColor: StyleManager.buttonPrimaryHighlightedColor,
                                        secondaryNormalBackgroundColor: StyleManager.buttonSecondaryColor,
                                        secondaryNormalBorderColor: StyleManager.buttonSecondaryHighlightedColor,
                                        secondaryHighlightBackgroundColor: StyleManager.buttonSecondaryHighlightedColor,
                                        secondaryHighlightBorderColor: StyleManager.buttonSecondaryHighlightedColor,
                                        disabledBackgroundColor: StyleManager.buttonDisabledColor,
                                        disabledBorderColor: StyleManager.buttonDisabledHighlightedColor,
                                        primaryTitleColor: StyleManager.buttonPrimaryTitleColor,
                                        secondaryTitleColor: StyleManager.buttonSecondaryTitleColor,
                                        disabledTitleColor: StyleManager.buttonDisabledTitleColor,
                                        textButtonColor: StyleManager.buttonPrimaryColor,
                                        textButtonHighlightColor: StyleManager.buttonPrimaryHighlightedColor,
                                        instructionColor: StyleManager.defaultTextColor,
                                        subheadlineColor: StyleManager.wooCommerceBrandColor,
                                        placeholderColor: StyleManager.defaultTextColor,
                                        viewControllerBackgroundColor: StyleManager.wooGreyLight,
                                        navBarImage: StyleManager.navBarImage,
                                        navBarBadgeColor: StyleManager.defaultTextColor,
                                        prologueBackgroundColor: StyleManager.wooCommerceBrandColor,
                                        prologueTitleColor: StyleManager.wooSecondary
                                        )
```                                                

---
**Prepare for testing** - in the Woo app:
- Change `WordPressAuthenticator` pod to use this branch (`feature/new_login_flow_site_address`).
- In `AuthenticationManager`, add `showLoginOptionsFromSiteAddress: true` as the last parameter to the `WordPressAuthenticatorConfiguration` init.

---
**Testing**:
- Run the app. Log out if necessary.
- Select 'Log in with Jetpack'. 
- Select 'Log in by entering your site address.'
- Enter a site address and select 'Next'. After the site is validated:
  - If it's a self-hosted site, the existing self-hosted flow is displayed.
  - If it's a WP site, the new options are shown.

---
**For WP sites**:
- A button view is displayed with login options. (Again, please ignore the colors.)

![login_options](https://user-images.githubusercontent.com/1816888/63067230-2b8fe580-becb-11e9-87e0-2fb802143db6.png)

- 'Continue with WordPress.com' launches the existing WP login flow.

![wp_login](https://user-images.githubusercontent.com/1816888/63067253-3e0a1f00-becb-11e9-9787-6e3d9d345d98.png)

- 'Continue with Google' launches the Google authentication flow.

![google](https://user-images.githubusercontent.com/1816888/63067081-7e1cd200-beca-11e9-8a41-b54aedc4b23f.png)

---
cc @astralbodies , @frosty 