### PR TITLE
Fix iOS 13 presentation style.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.2"
+  s.version       = "1.8.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -139,6 +139,7 @@ import WordPressUI
                 childController.loginFields.restrictToWPCom = restrictToWPCom
                 childController.showCancel = showCancel
             }
+            controller.modalPresentationStyle = .fullScreen
             presenter.present(controller, animated: animated, completion: nil)
         }
     }
@@ -165,6 +166,7 @@ import WordPressUI
         }
 
         let navController = LoginNavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .fullScreen
         presenter.present(navController, animated: true, completion: nil)
     }
 
@@ -176,7 +178,7 @@ import WordPressUI
 
         let controller = signinForWPOrg()
         let navController = LoginNavigationController(rootViewController: controller)
-
+        navController.modalPresentationStyle = .fullScreen
         presenter.present(navController, animated: true, completion: nil)
     }
 
@@ -274,6 +276,7 @@ import WordPressUI
         }
 
         let navController = LoginNavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .fullScreen
 
         // The way the magic link flow works some view controller might
         // still be presented when the app is resumed by tapping on the auth link.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -71,9 +71,13 @@ public struct WordPressAuthenticatorStyle {
     ///
     public let prologueTitleColor: UIColor
 
+    /// Style: status bar style
+    ///
+    public let statusBarStyle: UIStatusBarStyle
+
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, navBarBadgeColor: UIColor, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, navBarBadgeColor: UIColor, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white, statusBarStyle: UIStatusBarStyle = .lightContent) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -97,5 +101,6 @@ public struct WordPressAuthenticatorStyle {
         self.navBarBadgeColor = navBarBadgeColor
         self.prologueBackgroundColor = prologueBackgroundColor
         self.prologueTitleColor = prologueTitleColor
+        self.statusBarStyle = statusBarStyle
     }
 }

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -424,6 +424,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
             socialErrorVC.delegate = self
             socialErrorVC.loginFields = loginFields
+            socialErrorVC.modalPresentationStyle = .fullScreen
             present(socialErrorNav, animated: true) {}
         } else {
             errorToPresent = error

--- a/WordPressAuthenticator/Signin/LoginNavigationController.swift
+++ b/WordPressAuthenticator/Signin/LoginNavigationController.swift
@@ -4,4 +4,7 @@ import WordPressUI
 
 
 public class LoginNavigationController: RotationAwareNavigationViewController {
+    public override var preferredStatusBarStyle: UIStatusBarStyle {
+        return WordPressAuthenticator.shared.style.statusBarStyle
+    }
 }


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/12211.

In iOS 13 the default modal presentation style changes to `UIModalPresentationAutomatic`, which resolves as `pageSheet`. This results in the login views being dismissible. I've updated this to `fullScreen`, restoring the previous behaviour.

![before-after-nux](https://user-images.githubusercontent.com/4780/63217326-461cc580-c13c-11e9-9a38-62e0388fa697.png)

Please check out the WPiOS branch at https://github.com/wordpress-mobile/WordPress-iOS/pull/12335 to test this PR.