### PR TITLE
[SIWA] Add methods to create WP account

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.3'
-  pod 'WordPressKit', '~> 4.1'
+#  pod 'WordPressKit', '~> 4.1'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/create_account_with_apple'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -12,8 +12,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.3'
-#  pod 'WordPressKit', '~> 4.1'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/create_account_with_apple'
+  pod 'WordPressKit', '~> 4.5.0-beta.1'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressKit:
-    :commit: 1baa2f730cbf436a765d9efd7c97fd43af962de1
+    :commit: 16c7d184a8e086e7b67a96cfc3624ef88faab69b
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -131,6 +131,6 @@ SPEC CHECKSUMS:
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 1d6e808b640088ca91414184ea1b53247265bf5c
+PODFILE CHECKSUM: 83ebaa465d8c91a7fa86f20d35aaced3de4303a6
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (4.1.2):
+  - WordPressKit (4.5.0-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/create_account_with_apple`)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.3)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: feature/create_account_with_apple
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 753a2c899a9fc7474f8f0f4f69584dba5bfbdb45
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -117,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 09a28afc17dc63d35b6bd76c69fa94a7049183eb
+  WordPressKit: 13d75d648c76a490974386e782e5463ff89d6b68
   WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 23e5845cc72e0e7b189449e9da19a8473b5f60b0
+PODFILE CHECKSUM: 6e6704aa7168b09a7b8e9367700dd2a4eef9e932
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/create_account_with_apple`)
+  - WordPressKit (~> 4.5.0-beta.1)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.3)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: feature/create_account_with_apple
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 16c7d184a8e086e7b67a96cfc3624ef88faab69b
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -126,11 +117,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 13d75d648c76a490974386e782e5463ff89d6b68
+  WordPressKit: bfb5e77a32e66b19ee304bdffd5b7128a7fe4ede
   WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 83ebaa465d8c91a7fa86f20d35aaced3de4303a6
+PODFILE CHECKSUM: e2a10fcbbc81f9e30af60797f89b8315a6819211
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressKit:
-    :commit: 753a2c899a9fc7474f8f0f4f69584dba5bfbdb45
+    :commit: 1baa2f730cbf436a765d9efd7c97fd43af962de1
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -131,6 +131,6 @@ SPEC CHECKSUMS:
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 6e6704aa7168b09a7b8e9367700dd2a4eef9e932
+PODFILE CHECKSUM: 1d6e808b640088ca91414184ea1b53247265bf5c
 
 COCOAPODS: 1.6.1

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,7 +39,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.3'
-#  s.dependency 'WordPressKit', '~> 4.1'
-  s.dependency 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/create_account_with_apple'
+  s.dependency 'WordPressKit', '~> 4.5'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,6 +39,7 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.3'
-  s.dependency 'WordPressKit', '~> 4.5'
+  #s.dependency 'WordPressKit', '~> 4.1'
+  s.dependency 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/create_account_with_apple'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,6 +39,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.3'
-  s.dependency 'WordPressKit', '~> 4.1'
+  s.dependency 'WordPressKit', '~> 4.5.0-beta.1'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.5"
+  s.version       = "1.8.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,7 +39,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.3'
-  #s.dependency 'WordPressKit', '~> 4.1'
-  s.dependency 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/create_account_with_apple'
+  s.dependency 'WordPressKit', '~> 4.1'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,6 +39,7 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.3'
-  s.dependency 'WordPressKit', '~> 4.1'
+#  s.dependency 'WordPressKit', '~> 4.1'
+  s.dependency 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/create_account_with_apple'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -1081,7 +1081,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = WordPressAuthenticator/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticator;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1105,7 +1105,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = WordPressAuthenticator/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticator;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1215,7 +1215,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = WordPressAuthenticator/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticator;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1310,7 +1310,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = WordPressAuthenticator/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticator;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -44,20 +44,20 @@ class SignupService {
     /// - Parameters:
     ///   - token:      Token provided by Apple.
     ///   - email:      Email provided by Apple.
-    ///   - userName:   Formatted fullname provided by Apple.
+    ///   - fullName:   Formatted full name provided by Apple.
     ///   - success:    Block called when account is created successfully.
     ///   - failure:    Block called when account creation fails.
     ///
     func createWPComUserWithApple(token: String,
                                   email: String,
-                                  userName: String?,
+                                  fullName: String?,
                                   success: @escaping (_ newAccount: Bool, _ username: String, _ wpcomToken: String) -> Void,
                                   failure: @escaping (_ error: Error) -> Void) {
         let remote = WordPressComServiceRemote(wordPressComRestApi: anonymousAPI)
         
         remote.createWPComAccount(withApple: token,
                                   andEmail: email,
-                                  andUserName: userName,
+                                  andFullName: fullName,
                                   andClientID: configuration.wpcomClientId,
                                   andClientSecret: configuration.wpcomSecret,
                                   success: { response in

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -50,7 +50,7 @@ private extension AppleAuthenticator {
         let service = SignupService()
         service.createWPComUserWithApple(token: identityToken.base64EncodedString(),
                                          email: email,
-                                         userName: userName(from: appleCredentials.fullName),
+                                         fullName: fullName(from: appleCredentials.fullName),
                                          success: { [weak self] accountCreated, wpcomUsername, wpcomToken in
                                             NSLog("Apple Authenticator: createWPComUserWithApple success. accountCreated: ", accountCreated)
             }, failure: { [weak self] error in
@@ -60,7 +60,7 @@ private extension AppleAuthenticator {
 
     // MARK: - Helpers
     
-    func userName(from components: PersonNameComponents?) -> String {
+    func fullName(from components: PersonNameComponents?) -> String {
         guard let name = components else {
             return ""
         }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -1,6 +1,8 @@
 import Foundation
 import AuthenticationServices
 
+#if XCODE11
+
 class AppleAuthenticator: NSObject {
 
     // MARK: - Properties
@@ -21,7 +23,6 @@ class AppleAuthenticator: NSObject {
 private extension AppleAuthenticator {
 
     func requestAuthorization() {
-        #if XCODE11
         if #available(iOS 13.0, *) {
             let provider = ASAuthorizationAppleIDProvider()
             let request = provider.createRequest()
@@ -34,26 +35,54 @@ private extension AppleAuthenticator {
             controller.performRequests()
             
         }
-        #endif
+    }
+
+    /// Creates a WordPress.com account with the Apple ID
+    ///
+    @available(iOS 13.0, *)
+    func createWordPressComUser(appleCredentials: ASAuthorizationAppleIDCredential) {
+        guard let identityToken = appleCredentials.identityToken,
+            let email = appleCredentials.email else {
+                DDLogError("Apple Authenticator: invalid Apple credentials.")
+                return
+        }
+        
+        let service = SignupService()
+        service.createWPComUserWithApple(token: identityToken.base64EncodedString(),
+                                         email: email,
+                                         userName: userName(from: appleCredentials.fullName),
+                                         success: { [weak self] accountCreated, wpcomUsername, wpcomToken in
+                                            NSLog("Apple Authenticator: createWPComUserWithApple success. accountCreated: ", accountCreated)
+            }, failure: { [weak self] error in
+                DDLogError("Apple Authenticator: createWPComUserWithApple failure. error: \(error)")
+        })
+    }
+
+    // MARK: - Helpers
+    
+    func userName(from components: PersonNameComponents?) -> String {
+        guard let name = components else {
+            return ""
+        }
+        return PersonNameComponentsFormatter().string(from: name)
     }
 
 }
 
-#if XCODE11
 @available(iOS 13.0, *)
 extension AppleAuthenticator: ASAuthorizationControllerDelegate {
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let credentials as ASAuthorizationAppleIDCredential:
-            NSLog("Apple Authenticator credentials: \(String(describing: credentials.email)), \(String(describing: credentials.fullName))")
+            createWordPressComUser(appleCredentials: credentials)
         default:
             break
         }
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        NSLog("Apple Authenticator didCompleteWithError: \(error)")
+        DDLogError("Apple Authenticator: didCompleteWithError: \(error)")
     }
 
 }
@@ -64,4 +93,5 @@ extension AppleAuthenticator: ASAuthorizationControllerPresentationContextProvid
         return showFromViewController?.view.window ?? UIWindow()
     }
 }
+
 #endif

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -115,7 +115,9 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func appleTapped() {
+        #if XCODE11
         AppleAuthenticator.sharedInstance.showFrom(viewController: self)
+        #endif
     }
 
 }

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -286,7 +286,9 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 
     private func appleTapped() {
+        #if XCODE11
         AppleAuthenticator.sharedInstance.showFrom(viewController: self)
+        #endif
     }
 
     /// Whether the form can be submitted.


### PR DESCRIPTION
Related WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/181

This adds methods to create a WordPress account by sending Apple ID credentials to the method added in the above WPKit PR.

This can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12350