### PR TITLE
[SIWA] Show new account epilogue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,8 +12,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.3'
-  #pod 'WordPressKit', '~> 4.5.0-beta.1'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/add_apple_social_service'
+  pod 'WordPressKit', '~> 4.5.0-beta.2'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.3'
-  pod 'WordPressKit', '~> 4.5.0-beta.1'
+  #pod 'WordPressKit', '~> 4.5.0-beta.1'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/add_apple_social_service'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (4.5.0-beta.1):
+  - WordPressKit (4.5.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.5.0-beta.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/add_apple_social_service`)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.3)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: feature/add_apple_social_service
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 7ff68231765d7ffa1cb24bf704c3babf2e818020
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -117,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: bfb5e77a32e66b19ee304bdffd5b7128a7fe4ede
+  WordPressKit: 5ed53b26dd09d78eb3630a13970d28a5ecf5d137
   WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: e2a10fcbbc81f9e30af60797f89b8315a6819211
+PODFILE CHECKSUM: 09124cfb499823c15907958c6cc8cf64d8dadf38
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressKit:
-    :commit: f38cb66852fa03d5f98c14659ed37a9edd477063
+    :commit: 09674890a824042946cf15b77fdebb0197d2e1e3
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressKit:
-    :commit: 7ff68231765d7ffa1cb24bf704c3babf2e818020
+    :commit: f38cb66852fa03d5f98c14659ed37a9edd477063
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/add_apple_social_service`)
+  - WordPressKit (~> 4.5.0-beta.2)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.3)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: feature/add_apple_social_service
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 09674890a824042946cf15b77fdebb0197d2e1e3
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -126,11 +117,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 5ed53b26dd09d78eb3630a13970d28a5ecf5d137
+  WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 09124cfb499823c15907958c6cc8cf64d8dadf38
+PODFILE CHECKSUM: 066779a8741fbd6f8205a5d3469e19c8c80682b7
 
 COCOAPODS: 1.6.1

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.6"
+  s.version       = "1.8.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,6 +39,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.3'
-  s.dependency 'WordPressKit', '~> 4.5.0-beta.1'
+  s.dependency 'WordPressKit', '~> 4.5.0-beta.2'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -116,4 +116,6 @@ public class LoginFieldsMeta: NSObject {
     @objc public var socialServiceIDToken: String?
 
     var googleUser: GIDGoogleUser?
+
+    var appleUser: AppleUser?
 }

--- a/WordPressAuthenticator/Services/SocialService.swift
+++ b/WordPressAuthenticator/Services/SocialService.swift
@@ -7,4 +7,14 @@ public enum SocialService {
     /// Google's Signup Linked Account
     ///
     case google(user: GIDGoogleUser)
+    
+    /// Apple's Signup Linked Account
+    ///
+    case apple(user: AppleUser)
+}
+
+// Struct to contain information relevant to an Apple ID account.
+public struct AppleUser {
+    public var email: String
+    public var fullName: String
 }

--- a/WordPressAuthenticator/Services/WordPressComAccountService.swift
+++ b/WordPressAuthenticator/Services/WordPressComAccountService.swift
@@ -24,7 +24,7 @@ class WordPressComAccountService {
     func connect(wpcomAuthToken: String,
                  serviceName: SocialServiceName,
                  serviceToken: String,
-                 appleConnectParameters: [String:AnyObject]? = nil,
+                 connectParameters: [String:AnyObject]? = nil,
                  success: @escaping () -> Void,
                  failure: @escaping (Error) -> Void) {
         let loggedAPI  = WordPressComRestApi(oAuthToken: wpcomAuthToken,
@@ -34,7 +34,7 @@ class WordPressComAccountService {
 
         remote.connectToSocialService(serviceName,
                                       serviceIDToken: serviceToken,
-                                      appleConnectParameters: appleConnectParameters,
+                                      connectParameters: connectParameters,
                                       oAuthClientID: configuration.wpcomClientId,
                                       oAuthClientSecret: configuration.wpcomSecret,
                                       success: success,

--- a/WordPressAuthenticator/Services/WordPressComAccountService.swift
+++ b/WordPressAuthenticator/Services/WordPressComAccountService.swift
@@ -24,8 +24,7 @@ class WordPressComAccountService {
     func connect(wpcomAuthToken: String,
                  serviceName: SocialServiceName,
                  serviceToken: String,
-                 appleEmail: String? = nil,
-                 appleFullName: String? = nil,
+                 appleConnectParameters: [String:AnyObject]? = nil,
                  success: @escaping () -> Void,
                  failure: @escaping (Error) -> Void) {
         let loggedAPI  = WordPressComRestApi(oAuthToken: wpcomAuthToken,
@@ -35,8 +34,7 @@ class WordPressComAccountService {
 
         remote.connectToSocialService(serviceName,
                                       serviceIDToken: serviceToken,
-                                      appleEmail: appleEmail,
-                                      appleFullName: appleFullName,
+                                      appleConnectParameters: appleConnectParameters,
                                       oAuthClientID: configuration.wpcomClientId,
                                       oAuthClientSecret: configuration.wpcomSecret,
                                       success: success,

--- a/WordPressAuthenticator/Services/WordPressComAccountService.swift
+++ b/WordPressAuthenticator/Services/WordPressComAccountService.swift
@@ -21,7 +21,13 @@ class WordPressComAccountService {
 
     /// Connects a WordPress.com account with the specified Social Service.
     ///
-    func connect(wpcomAuthToken: String, serviceName: SocialServiceName, serviceToken: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    func connect(wpcomAuthToken: String,
+                 serviceName: SocialServiceName,
+                 serviceToken: String,
+                 appleEmail: String? = nil,
+                 appleFullName: String? = nil,
+                 success: @escaping () -> Void,
+                 failure: @escaping (Error) -> Void) {
         let loggedAPI  = WordPressComRestApi(oAuthToken: wpcomAuthToken,
                                              userAgent: configuration.userAgent,
                                              baseUrlString: configuration.wpcomAPIBaseURL)
@@ -29,6 +35,8 @@ class WordPressComAccountService {
 
         remote.connectToSocialService(serviceName,
                                       serviceIDToken: serviceToken,
+                                      appleEmail: appleEmail,
+                                      appleFullName: appleFullName,
                                       oAuthClientID: configuration.wpcomClientId,
                                       oAuthClientSecret: configuration.wpcomSecret,
                                       success: success,

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -262,20 +262,33 @@ extension LoginViewController {
         guard let serviceName = loginFields.meta.socialService, let serviceToken = loginFields.meta.socialServiceIDToken else {
             return
         }
-
-        linkSocialService(serviceName: serviceName, serviceToken: serviceToken, wpcomAuthToken: wpcomAuthToken)
+        
+        linkSocialService(serviceName: serviceName,
+                          serviceToken: serviceToken,
+                          wpcomAuthToken: wpcomAuthToken,
+                          appleEmail: loginFields.meta.appleUser?.email,
+                          appleFullName: loginFields.meta.appleUser?.fullName)
     }
 
     /// Links the current WordPress Account to a Social Service.
     ///
-    func linkSocialService(serviceName: SocialServiceName, serviceToken: String, wpcomAuthToken: String) {
-        guard serviceName == .google else {
+    func linkSocialService(serviceName: SocialServiceName,
+                           serviceToken: String,
+                           wpcomAuthToken: String,
+                           appleEmail: String? = nil,
+                           appleFullName: String? = nil) {
+        guard serviceName == .google || serviceName == .apple else {
             DDLogError("Error: Unsupported Social Service")
             return
         }
 
         let service = WordPressComAccountService()
-        service.connect(wpcomAuthToken: wpcomAuthToken, serviceName: serviceName, serviceToken: serviceToken, success: {
+        service.connect(wpcomAuthToken: wpcomAuthToken,
+                        serviceName: serviceName,
+                        serviceToken: serviceToken,
+                        appleEmail: appleEmail,
+                        appleFullName: appleFullName,
+                        success: {
             WordPressAuthenticator.track(.loginSocialConnectSuccess)
             WordPressAuthenticator.track(.loginSocialSuccess)
         }, failure: { error in

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -286,7 +286,7 @@ extension LoginViewController {
         service.connect(wpcomAuthToken: wpcomAuthToken,
                         serviceName: serviceName,
                         serviceToken: serviceToken,
-                        appleConnectParameters: appleConnectParameters,
+                        connectParameters: appleConnectParameters,
                         success: {
                             WordPressAuthenticator.track(.loginSocialConnectSuccess)
                             WordPressAuthenticator.track(.loginSocialSuccess)

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -263,11 +263,17 @@ extension LoginViewController {
             return
         }
         
+        let appleConnectParameters:[String:AnyObject]? = {
+            if let appleUser = loginFields.meta.appleUser {
+                return AccountServiceRemoteREST.appleSignInParameters(email: appleUser.email, fullName: appleUser.fullName)
+            }
+            return nil
+        }()
+        
         linkSocialService(serviceName: serviceName,
                           serviceToken: serviceToken,
                           wpcomAuthToken: wpcomAuthToken,
-                          appleEmail: loginFields.meta.appleUser?.email,
-                          appleFullName: loginFields.meta.appleUser?.fullName)
+                          appleConnectParameters: appleConnectParameters)
     }
 
     /// Links the current WordPress Account to a Social Service.
@@ -275,8 +281,7 @@ extension LoginViewController {
     func linkSocialService(serviceName: SocialServiceName,
                            serviceToken: String,
                            wpcomAuthToken: String,
-                           appleEmail: String? = nil,
-                           appleFullName: String? = nil) {
+                           appleConnectParameters: [String:AnyObject]? = nil) {
         guard serviceName == .google || serviceName == .apple else {
             DDLogError("Error: Unsupported Social Service")
             return
@@ -286,11 +291,10 @@ extension LoginViewController {
         service.connect(wpcomAuthToken: wpcomAuthToken,
                         serviceName: serviceName,
                         serviceToken: serviceToken,
-                        appleEmail: appleEmail,
-                        appleFullName: appleFullName,
+                        appleConnectParameters: appleConnectParameters,
                         success: {
-            WordPressAuthenticator.track(.loginSocialConnectSuccess)
-            WordPressAuthenticator.track(.loginSocialSuccess)
+                            WordPressAuthenticator.track(.loginSocialConnectSuccess)
+                            WordPressAuthenticator.track(.loginSocialSuccess)
         }, failure: { error in
             DDLogError("Social Link Error: \(error)")
             WordPressAuthenticator.track(.loginSocialConnectFailure, error: error)

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -282,11 +282,6 @@ extension LoginViewController {
                            serviceToken: String,
                            wpcomAuthToken: String,
                            appleConnectParameters: [String:AnyObject]? = nil) {
-        guard serviceName == .google || serviceName == .apple else {
-            DDLogError("Error: Unsupported Social Service")
-            return
-        }
-
         let service = WordPressComAccountService()
         service.connect(wpcomAuthToken: wpcomAuthToken,
                         serviceName: serviceName,


### PR DESCRIPTION
This adds logic to show the account created epilogue after a WP account is created with an Apple ID. To note, the endpoint doesn't yet support Apple, so account creation will fail, thus the epilogue won't actually show yet.

This also passes Apple specific parameters to the social connect endpoint in WPKit, although it's not used yet.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12360
Ref WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/182