### PR TITLE
Apple Sign In: Decode identity token to string

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.7"
+  s.version       = "1.8.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -52,12 +52,12 @@ private extension AppleAuthenticator {
     @available(iOS 13.0, *)
     func createWordPressComUser(appleCredentials: ASAuthorizationAppleIDCredential) {
         guard let identityToken = appleCredentials.identityToken,
+            let token = String(data: identityToken, encoding: .utf8),
             let email = appleCredentials.email else {
                 DDLogError("Apple Authenticator: invalid Apple credentials.")
                 return
         }
         
-        let token = identityToken.base64EncodedString()
         let name = fullName(from: appleCredentials.fullName)
 
         updateLoginFields(email: email, fullName: name, token: token)


### PR DESCRIPTION
Just a small tweak to decode the SIWA identity token before we use it, instead of using just the base64 representation.

**To test**

* Use this branch with WPiOS and try to Sign in with Apple. Without this change, you'd get an error:

```
2019-08-23 16:21:26:757 WordPress[47394:19742393] Apple Authenticator: signup failed. error: Error Domain=WordPressKit.WordPressComRestApiError Code=7 "Invalid authentication token (JWT)." UserInfo={WordPressComRestApiErrorMessageKey=Invalid authentication token (JWT)., NSLocalizedDescription=Invalid authentication token (JWT)., WordPressComRestApiErrorCodeKey=jwt-authentication}
```

With this change, you won't get that error (you'll get a different one, but we'll hopefully fix that soon too!)