### PR TITLE
Dark mode improvements

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.9"
+  s.version       = "1.8.0-beta.10"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.8"
+  s.version       = "1.8.0-beta.9"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -57,6 +57,8 @@ public struct WordPressAuthenticatorStyle {
     ///
     public let viewControllerBackgroundColor: UIColor
 
+    public let textFieldBackgroundColor: UIColor
+
     /// Style: nav bar
     ///
     public let navBarImage: UIImage
@@ -77,7 +79,7 @@ public struct WordPressAuthenticatorStyle {
 
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, navBarImage: UIImage, navBarBadgeColor: UIColor, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white, statusBarStyle: UIStatusBarStyle = .lightContent) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, textFieldBackgroundColor: UIColor, navBarImage: UIImage, navBarBadgeColor: UIColor, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white, statusBarStyle: UIStatusBarStyle = .lightContent) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -97,6 +99,7 @@ public struct WordPressAuthenticatorStyle {
         self.subheadlineColor = subheadlineColor
         self.placeholderColor = placeholderColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
+        self.textFieldBackgroundColor = textFieldBackgroundColor
         self.navBarImage = navBarImage
         self.navBarBadgeColor = navBarBadgeColor
         self.prologueBackgroundColor = prologueBackgroundColor

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -124,7 +124,10 @@ extension WPStyleGuide {
     class func appleLoginButton() -> UIControl {
         #if XCODE11
         if #available(iOS 13.0, *) {
-            let appleButton = ASAuthorizationAppleIDButton(authorizationButtonType: .continue, authorizationButtonStyle: .black)
+            let traits = UITraitCollection.current
+            let buttonStyle: ASAuthorizationAppleIDButton.Style = (traits.userInterfaceStyle == .dark) ? .white : .black
+
+            let appleButton = ASAuthorizationAppleIDButton(authorizationButtonType: .continue, authorizationButtonStyle: buttonStyle)
             appleButton.translatesAutoresizingMaskIntoConstraints = false
             appleButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.buttonMinHeight).isActive = true
             return appleButton

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -95,6 +95,10 @@ NSInteger const LeftImageSpacing = 8;
                                      };
         self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholder attributes:attributes];
     }
+
+    if (@available(iOS 13.0, *)) {
+        self.leadingViewInsets = UIEdgeInsetsMake(0, 0, 0, LeftImageSpacing);
+    }
 }
 
 - (void)awakeFromNib {

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -3,6 +3,12 @@ import WordPressShared
 
 open class LoginTextField: WPWalkthroughTextField {
 
+    open override func awakeFromNib() {
+        super.awakeFromNib()
+
+        backgroundColor = WordPressAuthenticator.shared.style.textFieldBackgroundColor
+    }
+
     override open func draw(_ rect: CGRect) {
         if showTopLineSeparator {
             guard let context = UIGraphicsGetCurrentContext() else {


### PR DESCRIPTION
Refs #12320. This PR implements some improvements to the appearance of the login flow for dark mode.

![dark-before-after](https://user-images.githubusercontent.com/4780/63635519-7cd26e80-c65b-11e9-8420-f315621974a1.png)

For full description and testing steps, see https://github.com/wordpress-mobile/WordPress-iOS/pull/12386. These PRs should be tested together.