### PR TITLE
Change copy per Editorial and to reflect Android app

### DIFF
--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -156,7 +156,7 @@ extension WPStyleGuide {
             
             button = textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: alignment)
         } else {
-            let baseString = NSLocalizedString("Log in by entering your site address.", comment: "Label for button to log in using your site address.")
+            let baseString = NSLocalizedString("Enter the address of the WordPress site you'd like to connect.", comment: "Label for button to log in using your site address.")
             
             let attrStrNormal = selfHostedButtonString(baseString, linkColor:  style.textButtonColor)
             let attrStrHighlight = selfHostedButtonString(baseString, linkColor: style.textButtonHighlightColor)

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -27,7 +27,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     // MARK: - URL Validation
     
     private lazy var urlErrorDebouncer = Debouncer(delay: 2) { [weak self] in
-        let errorMessage = NSLocalizedString("Enter a valid URL eg. example.com.", comment: "Error message shown when a URL is invalid.")
+        let errorMessage = NSLocalizedString("Please enter a complete website address, like example.com.", comment: "Error message shown when a URL is invalid.")
         
         self?.displayError(message: errorMessage)
     }


### PR DESCRIPTION
To address wordpress-mobile/WordPress-iOS#12188

Test by logging out and then attempting to log in by using an invalid URL (such as %$#), error text should be "Please enter a complete website address, like example.com." and title text should be "Enter the address of the WordPress site you'd like to connect."