### PR TITLE
Dark mode: text and button fixes

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.12"
+  s.version       = "1.8.0-beta.13"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -190,12 +190,15 @@ extension WPStyleGuide {
     /// - Returns: A properly styled UIButton
     ///
     class func termsButton() -> UIButton {
+        let style = WordPressAuthenticator.shared.style
+
         let baseString =  NSLocalizedString("By signing up, you agree to our _Terms of Service_.", comment: "Legal disclaimer for signup buttons, the underscores _..._ denote underline")
 
-        let labelString = baseString.underlined()
+        let attrStrNormal = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonColor)
+        let attrStrHighlight = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonHighlightColor)
+        let font = WPStyleGuide.mediumWeightFont(forStyle: .footnote)
 
-        let font = WPStyleGuide.mediumWeightFont(forStyle: .caption2)
-        return textButton(normal: labelString, highlighted: labelString, font: font, alignment: .center)
+        return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: .center)
     }
 
     private class func textButton(normal normalString: NSAttributedString, highlighted highlightString: NSAttributedString, font: UIFont, alignment: UIControl.NaturalContentHorizontalAlignment = .leading) -> UIButton {

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -10,6 +10,7 @@ import WordPressUI
 
     @objc let activityIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(style: .white)
+        indicator.color = WordPressAuthenticator.shared.style.primaryTitleColor
         indicator.hidesWhenStopped = true
         return indicator
     }()

--- a/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
@@ -60,10 +60,11 @@ open class LoginSocialErrorCell: UITableViewCell {
         labelStack.axis = .vertical
         labelStack.spacing = Constants.labelSpacing
 
+        let style = WordPressAuthenticator.shared.style
         titleLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
-        titleLabel.textColor = WPStyleGuide.greyDarken30()
+        titleLabel.textColor = style.instructionColor
         descriptionLabel.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
-        descriptionLabel.textColor = WPStyleGuide.darkGrey()
+        descriptionLabel.textColor = style.subheadlineColor
         descriptionLabel.numberOfLines = 0
         descriptionLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.descriptionMinHeight).isActive = true
 


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/12320.

This PR fixes some dark mode issues with the authenticator:

* The terms and conditions text when you tap sign in is now easier to read and a better size.

![Simulator Screen Shot - iPhone Xs - 2019-08-30 at 10 46 35](https://user-images.githubusercontent.com/4780/64013830-9ae71580-cb18-11e9-9930-74c7140875f1.png)

* The Next button now shows a white loading indicator in dark mode.

![Simulator Screen Shot - iPhone Xs - 2019-08-30 at 11 15 31](https://user-images.githubusercontent.com/4780/64013856-ab978b80-cb18-11e9-9945-5ca1891e1558.png)

* The username instruction cell used in WPiOS now has a better text color.

![Simulator Screen Shot - iPhone Xs - 2019-08-30 at 11 08 34](https://user-images.githubusercontent.com/4780/64013888-bf42f200-cb18-11e9-96af-549a65f8c275.png)

**To test**

* You can use this branch of WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/create?base=wordpress-mobile%3Arelease%2F13.2&head=wordpress-mobile%3Afix%2Fnux-epilogue-dark-mode
* Do a fresh install of the app and tap Sign up. Check you can read the terms and conditions text.
* Sign up a new account and check the epilogue looks okay (these changes are in the WPiOS branch).
* When logged in, navigate to Me > Account Settings > Username and check the instructional text.
* Log out, tap Log in > Continue with WordPress.com > Enter your email address. When you tap next, check the activity indicator color.