### PR TITLE
[SIWA] Add Continue with Apple to Sign Up

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.13"
+  s.version       = "1.8.0-beta.14"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -638,7 +638,7 @@ extension LoginEmailViewController: GIDSignInUIDelegate {
 }
 
 #if XCODE11
-extension LoginPrologueViewController: AppleAuthenticatorDelegate {
+extension LoginEmailViewController: AppleAuthenticatorDelegate {
     func showWPComLogin(loginFields: LoginFields) {
         self.loginFields = loginFields
          performSegue(withIdentifier: .showWPComLogin, sender: self)

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -453,6 +453,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             vc.googleTapped = { [weak self] in
                 self?.performSegue(withIdentifier: NUXViewController.SegueIdentifier.showGoogle.rawValue, sender: self)
             }
+            vc.appleTapped = { [weak self] in
+                self?.appleTapped()
+            }
             vc.modalPresentationStyle = .custom
         }
     }
@@ -540,6 +543,13 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             }
         }
     }
+
+    private func appleTapped() {
+        #if XCODE11
+        AppleAuthenticator.sharedInstance.delegate = self
+        AppleAuthenticator.sharedInstance.showFrom(viewController: self)
+        #endif
+    }
 }
 
 // LoginFacadeDelegate methods for Google Google Sign In
@@ -626,3 +636,12 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
 /// This is needed to set self as uiDelegate, even though none of the methods are called
 extension LoginEmailViewController: GIDSignInUIDelegate {
 }
+
+#if XCODE11
+extension LoginPrologueViewController: AppleAuthenticatorDelegate {
+    func showWPComLogin(loginFields: LoginFields) {
+        self.loginFields = loginFields
+         performSegue(withIdentifier: .showWPComLogin, sender: self)
+    }
+}
+#endif

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -12,6 +12,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
 
     open var emailTapped: (() -> Void)?
     open var googleTapped: (() -> Void)?
+    open var appleTapped: (() -> Void)?
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
@@ -68,11 +69,27 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
             self?.present(safariViewController, animated: true, completion: nil)
         }
         buttonViewController.stackView?.insertArrangedSubview(termsButton, at: 0)
+
+        if WordPressAuthenticator.shared.configuration.enableSignInWithApple {
+            #if XCODE11
+            if #available(iOS 13.0, *) {
+                let appleButton = WPStyleGuide.appleLoginButton()
+                appleButton.addTarget(self, action: #selector(handleAppleButtonTapped), for: .touchDown)
+                buttonViewController.stackView?.insertArrangedSubview(appleButton, at: 1)
+            }
+            #endif
+        }
+
         buttonViewController.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
     }
 
     @IBAction func dismissTapped() {
         WordPressAuthenticator.track(.signupCancelled)
         dismiss(animated: true)
+    }
+
+    @objc func handleAppleButtonTapped() {
+        dismiss(animated: true)
+        appleTapped?()
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -51,6 +51,9 @@ class LoginPrologueViewController: LoginViewController {
             vc.googleTapped = { [weak self] in
                 self?.performSegue(withIdentifier: .showGoogle, sender: self)
             }
+            vc.appleTapped = { [weak self] in
+                self?.appleTapped()
+            }
             vc.modalPresentationStyle = .custom
         }
             


### PR DESCRIPTION
Refs. [WP iOS #12447](https://github.com/wordpress-mobile/WordPress-iOS/pull/12447)

This PR adds the SIWA _Continue with Apple_ button in the Sign Up buttons list

## To Test:
• Run [WP iOS #12447](https://github.com/wordpress-mobile/WordPress-iOS/pull/12447)