### PR TITLE
[SIWA] Fix SIWA button style type

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.13"
+  s.version       = "1.8.0-beta.14"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -125,7 +125,7 @@ extension WPStyleGuide {
         #if XCODE11
         if #available(iOS 13.0, *) {
             let traits = UITraitCollection.current
-            let buttonStyle: ASAuthorizationAppleIDButton.Style = (traits.userInterfaceStyle == .dark) ? .white : .black
+            let buttonStyle: ButtonStyle = (traits.userInterfaceStyle == .dark) ? .white : .black
 
             let appleButton = ASAuthorizationAppleIDButton(authorizationButtonType: .continue, authorizationButtonStyle: buttonStyle)
             appleButton.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
This change fixes this error. It was using the incorrect button style property.

<img width="266" alt="style_error" src="https://user-images.githubusercontent.com/1816888/64207031-04d52700-ce59-11e9-88bb-c35a133c184d.png">

For reference, the initial change was made here https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/120/files#diff-2fbc2965b69e2afac9a948c1c9587e3a.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12460