### PR TITLE
[SIWA] Show error alert when authentication fails

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.14"
+  s.version       = "1.8.0-beta.15"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
@@ -27,6 +27,9 @@ extension WordPressSupportSourceTag {
     public static var loginEmail: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "loginEmail", origin: "origin:login-email")
     }
+    public static var loginApple: WordPressSupportSourceTag {
+        return WordPressSupportSourceTag(name: "loginApple", origin: "origin:login-apple")
+    }
     public static var login2FA: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "login2FA", origin: "origin:login-2fa")
     }
@@ -57,4 +60,8 @@ extension WordPressSupportSourceTag {
     public static var wpComSignupMagicLink: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "wpComSignupMagicLink", origin: "origin:signup-magic-link")
     }
+    public static var wpComSignupApple: WordPressSupportSourceTag {
+        return WordPressSupportSourceTag(name: "wpComSignupApple", origin: "origin:signup-apple")
+    }
+
 }

--- a/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -131,25 +131,33 @@ extension FancyAlertViewController {
     }
 
 
-    /// Shows a generic error message. The view
-    /// is configured so the user can open Support for assistance.
+    /// Shows a generic error message.
+    /// If Support is enabled, the view is configured so the user can open Support for assistance.
     ///
     /// - Parameter message: The error message to show.
     /// - Parameter sourceTag: tag of the source of the error
     ///
     static func alertForGenericErrorMessageWithHelpButton(_ message: String, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
-        let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
-            controller.dismiss(animated: true) {
-                // Find the topmost view controller that we can present from
-                guard let appDelegate = UIApplication.shared.delegate,
-                    let window = appDelegate.window,
-                    let viewController = window?.topmostPresentedViewController,
-                    WordPressAuthenticator.shared.delegate?.supportEnabled == true
-                else {
-                    return
-                }
 
-                WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag)
+        // If support is not enabled, don't add a Help Button since it won't do anything.
+        var moreHelpButton: ButtonConfig? = nil
+
+        if WordPressAuthenticator.shared.delegate?.supportEnabled == false {
+            DDLogInfo("Error Alert: Support not enabled. Hiding Help button.")
+        } else {
+            moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
+                controller.dismiss(animated: true) {
+                    // Find the topmost view controller that we can present from
+                    guard let appDelegate = UIApplication.shared.delegate,
+                        let window = appDelegate.window,
+                        let viewController = window?.topmostPresentedViewController,
+                        WordPressAuthenticator.shared.delegate?.supportEnabled == true
+                        else {
+                            return
+                    }
+                    
+                    WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag)
+                }
             }
         }
 
@@ -162,6 +170,7 @@ extension FancyAlertViewController {
                                                      moreInfoButton: moreHelpButton,
                                                      titleAccessoryButton: nil,
                                                      dismissAction: nil)
+
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
     }
 

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -7,6 +7,7 @@ import SVProgressHUD
 
 @objc protocol AppleAuthenticatorDelegate {
     func showWPComLogin(loginFields: LoginFields)
+    func authFailedWithError(message: String)
 }
 
 class AppleAuthenticator: NSObject {
@@ -174,7 +175,16 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        DDLogError("Apple Authenticator: didCompleteWithError: \(error)")
+
+        // Don't show error if user cancelled authentication.
+        if let authorizationError = error as? ASAuthorizationError,
+        authorizationError.code == .canceled {
+            return
+        }
+        
+        DDLogError("Apple Authenticator: didCompleteWithError: \(error.localizedDescription)")
+        let message = NSLocalizedString("Apple authentication failed.", comment: "Message shown when Apple authentication fails.")
+        delegate?.authFailedWithError(message: message)
     }
 
 }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -84,20 +84,16 @@ private extension AppleAuthenticator {
                                             let wpcom = WordPressComCredentials(authToken: wpcomToken, isJetpackLogin: false, multifactor: false, siteURL: self?.loginFields.siteAddress ?? "")
                                             let credentials = AuthenticatorCredentials(wpcom: wpcom)
 
-                                            // New WP Account
+                                            self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
+
                                             if accountCreated {
-                                                self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
                                                 self?.signupSuccessful(with: credentials)
-                                                return
                                             } else {
-                                                self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
-                                                self?.signinSuccessful(with: credentials)
-                                                return
+                                                self?.loginSuccessful(with: credentials)
                                             }
-                                            
+
             }, failure: { [weak self] error in
                 SVProgressHUD.dismiss()
-                
                 self?.signupFailed(with: error)
         })
     }
@@ -108,7 +104,7 @@ private extension AppleAuthenticator {
         showSignupEpilogue(for: credentials)
     }
     
-    func signinSuccessful(with credentials: AuthenticatorCredentials) {
+    func loginSuccessful(with credentials: AuthenticatorCredentials) {
         // TODO: Tracks events for login
         showSigninEpilogue(for: credentials)
     }
@@ -134,8 +130,9 @@ private extension AppleAuthenticator {
     }
     
     func signupFailed(with error: Error) {
+        DDLogError("Apple Authenticator: Signup failed. error: \(error.localizedDescription)")
         WPAnalytics.track(.signupSocialFailure)
-        DDLogError("Apple Authenticator: signup failed. error: \(error)")
+        delegate?.authFailedWithError(message: error.localizedDescription)
     }
     
     func logInInstead() {

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -639,9 +639,15 @@ extension LoginEmailViewController: GIDSignInUIDelegate {
 
 #if XCODE11
 extension LoginEmailViewController: AppleAuthenticatorDelegate {
+
     func showWPComLogin(loginFields: LoginFields) {
         self.loginFields = loginFields
          performSegue(withIdentifier: .showWPComLogin, sender: self)
     }
+   
+    func authFailedWithError(message: String) {
+        displayErrorAlert(message, sourceTag: .wpComSignupApple)
+    }
+    
 }
 #endif

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -128,9 +128,15 @@ class LoginPrologueViewController: LoginViewController {
 
 #if XCODE11
 extension LoginPrologueViewController: AppleAuthenticatorDelegate {
+
     func showWPComLogin(loginFields: LoginFields) {
         self.loginFields = loginFields
          performSegue(withIdentifier: .showWPComLogin, sender: self)
     }
+
+    func authFailedWithError(message: String) {
+        displayErrorAlert(message, sourceTag: .loginApple)
+    }
+    
 }
 #endif

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -370,9 +370,14 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
 
 #if XCODE11
 extension LoginSiteAddressViewController: AppleAuthenticatorDelegate {
+
     func showWPComLogin(loginFields: LoginFields) {
         self.loginFields = loginFields
         performSegue(withIdentifier: .showWPComLogin, sender: self)
+    }
+    
+    func authFailedWithError(message: String) {
+        displayErrorAlert(message, sourceTag: .loginApple)
     }
 }
 #endif


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/12442

When signing up / logging in with Apple and something goes wrong, an alert is now displayed.
- If Apple authentication fails, a generic `Apple authentication failed.` message is displayed.
- If the API fails, the alert will show the API specific error message.

<img width="378" alt="apple_fail" src="https://user-images.githubusercontent.com/1816888/64289715-f868d100-cf21-11e9-9895-23c0b03e0577.png">

**NOTE**: The alert now checks the `supportEnabled` state of the host app before adding the help link. If Zendesk is disabled in the host app (as it is in WPiOS, for example), the help link is not displayed. However, once ZD is enabled, the link will appear.

<img width="378" alt="help_link" src="https://user-images.githubusercontent.com/1816888/64289827-29490600-cf22-11e9-83c4-b264ad7705e2.png">

This can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12468