### PR TITLE
[SIWA] Sync account with host app for existing accounts

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.0-beta.15"
+  s.version       = "1.8.0-beta.16"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -84,12 +84,13 @@ private extension AppleAuthenticator {
                                             let wpcom = WordPressComCredentials(authToken: wpcomToken, isJetpackLogin: false, multifactor: false, siteURL: self?.loginFields.siteAddress ?? "")
                                             let credentials = AuthenticatorCredentials(wpcom: wpcom)
 
-                                            self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
-
                                             if accountCreated {
+                                                self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
                                                 self?.signupSuccessful(with: credentials)
                                             } else {
-                                                self?.loginSuccessful(with: credentials)
+                                                self?.authenticationDelegate.sync(credentials: credentials) {
+                                                    self?.loginSuccessful(with: credentials)
+                                                }
                                             }
 
             }, failure: { [weak self] error in


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/12434

The incorrect delegate method was being called with existing accounts. Now, if logging into an existing account, the `sync` method is called (instead of `createdWordPressComAccount`).

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12471