### PR TITLE
Reordering the SIWA buttons to de-emphasize it

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.1-beta.2"
+  s.version       = "1.8.1-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -63,7 +63,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
             if #available(iOS 13.0, *) {
                 let appleButton = WPStyleGuide.appleLoginButton()
                 appleButton.addTarget(self, action: #selector(handleAppleButtonTapped), for: .touchDown)
-                buttonViewController.stackView?.insertArrangedSubview(appleButton, at: 0)
+                buttonViewController.stackView?.insertArrangedSubview(appleButton, at: 2)
             }
             #endif
         }

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -75,7 +75,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
             if #available(iOS 13.0, *) {
                 let appleButton = WPStyleGuide.appleLoginButton()
                 appleButton.addTarget(self, action: #selector(handleAppleButtonTapped), for: .touchDown)
-                buttonViewController.stackView?.insertArrangedSubview(appleButton, at: 1)
+                buttonViewController.stackView?.insertArrangedSubview(appleButton, at: 3)
             }
             #endif
         }


### PR DESCRIPTION
Reordering the sign in/sign up buttons to not have Apple be the first one seen by the user.

cc: @mattmiklic 

![Simulator Screen Shot - iPhone Xʀ - 2019-09-14 at 11 57 43](https://user-images.githubusercontent.com/373903/64910797-9742b980-d6e8-11e9-9a62-809bc6217317.png)
![Simulator Screen Shot - iPhone Xʀ - 2019-09-14 at 11 57 41](https://user-images.githubusercontent.com/373903/64910798-97db5000-d6e8-11e9-9647-4110cde09477.png)

