### PR TITLE
Enable Xcode 11 for all builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ workflows:
           xcode-version: "11.0"
           workspace: WordPressAuthenticator.xcworkspace
           scheme: WordPressAuthenticator
-          device: iPhone XS
-          ios-version: "12.2"
+          device: iPhone 11
+          ios-version: "13.0"
       - ios/validate-podspec:
           name: Validate Podspec
           xcode-version: "11.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,20 +2,20 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.24
+  ios: wordpress-mobile/ios@0.0.31
 
 workflows:
   test_and_validate:
     jobs:
       - ios/test:
           name: Test
-          xcode-version: "10.2.0"
+          xcode-version: "11.0"
           workspace: WordPressAuthenticator.xcworkspace
           scheme: WordPressAuthenticator
           device: iPhone XS
           ios-version: "12.2"
       - ios/validate-podspec:
           name: Validate Podspec
-          xcode-version: "10.2.0"
+          xcode-version: "11.0"
           podspec-path: WordPressAuthenticator.podspec
           update-specs-repo: true

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -122,7 +122,6 @@ extension WPStyleGuide {
     ///
     
     class func appleLoginButton() -> UIControl {
-        #if XCODE11
         if #available(iOS 13.0, *) {
             let traits = UITraitCollection.current
             let buttonStyle: ASAuthorizationAppleIDButton.Style = (traits.userInterfaceStyle == .dark) ? .white : .black
@@ -132,7 +131,6 @@ extension WPStyleGuide {
             appleButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.buttonMinHeight).isActive = true
             return appleButton
         }
-        #endif
         
         return UIControl()
     }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -3,8 +3,6 @@ import AuthenticationServices
 import WordPressKit
 import SVProgressHUD
 
-#if XCODE11
-
 @objc protocol AppleAuthenticatorDelegate {
     func showWPComLogin(loginFields: LoginFields)
     func authFailedWithError(message: String)
@@ -193,5 +191,3 @@ extension AppleAuthenticator: ASAuthorizationControllerPresentationContextProvid
         return showFromViewController?.view.window ?? UIWindow()
     }
 }
-
-#endif

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -545,10 +545,8 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     }
 
     private func appleTapped() {
-        #if XCODE11
         AppleAuthenticator.sharedInstance.delegate = self
         AppleAuthenticator.sharedInstance.showFrom(viewController: self)
-        #endif
     }
 }
 
@@ -637,7 +635,6 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
 extension LoginEmailViewController: GIDSignInUIDelegate {
 }
 
-#if XCODE11
 extension LoginEmailViewController: AppleAuthenticatorDelegate {
 
     func showWPComLogin(loginFields: LoginFields) {
@@ -650,4 +647,3 @@ extension LoginEmailViewController: AppleAuthenticatorDelegate {
     }
     
 }
-#endif

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -59,13 +59,11 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
         }
 
         if WordPressAuthenticator.shared.configuration.enableSignInWithApple {
-            #if XCODE11
             if #available(iOS 13.0, *) {
                 let appleButton = WPStyleGuide.appleLoginButton()
                 appleButton.addTarget(self, action: #selector(handleAppleButtonTapped), for: .touchDown)
                 buttonViewController.stackView?.insertArrangedSubview(appleButton, at: 0)
             }
-            #endif
         }
         
         buttonViewController.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -71,13 +71,11 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         buttonViewController.stackView?.insertArrangedSubview(termsButton, at: 0)
 
         if WordPressAuthenticator.shared.configuration.enableSignInWithApple {
-            #if XCODE11
             if #available(iOS 13.0, *) {
                 let appleButton = WPStyleGuide.appleLoginButton()
                 appleButton.addTarget(self, action: #selector(handleAppleButtonTapped), for: .touchDown)
                 buttonViewController.stackView?.insertArrangedSubview(appleButton, at: 1)
             }
-            #endif
         }
 
         buttonViewController.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -118,15 +118,12 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func appleTapped() {
-        #if XCODE11
         AppleAuthenticator.sharedInstance.delegate = self
         AppleAuthenticator.sharedInstance.showFrom(viewController: self)
-        #endif
     }
 
 }
 
-#if XCODE11
 extension LoginPrologueViewController: AppleAuthenticatorDelegate {
 
     func showWPComLogin(loginFields: LoginFields) {
@@ -139,4 +136,3 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
     }
     
 }
-#endif

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -286,10 +286,8 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 
     private func appleTapped() {
-        #if XCODE11
         AppleAuthenticator.sharedInstance.delegate = self
         AppleAuthenticator.sharedInstance.showFrom(viewController: self)
-        #endif
     }
 
     /// Whether the form can be submitted.
@@ -368,7 +366,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 }
 
-#if XCODE11
 extension LoginSiteAddressViewController: AppleAuthenticatorDelegate {
 
     func showWPComLogin(loginFields: LoginFields) {
@@ -380,4 +377,3 @@ extension LoginSiteAddressViewController: AppleAuthenticatorDelegate {
         displayErrorAlert(message, sourceTag: .loginApple)
     }
 }
-#endif


### PR DESCRIPTION
This removes all `#if XCODE11` checks and updates the CircleCI config to build with Xcode 11. It enables the code for Sign In With Apple.