### PR TITLE
Podspec: Bump version to 1.9.0-beta.1 for SIWA release

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.8.1-beta.3"
+  s.version       = "1.9.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
This is a version bump for the SIWA release. Since Xcode 10 support was dropped in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/130, I have gone to 1.9.