### PR TITLE
CircleCI: Add job for publishing podspec to trunk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,3 +19,12 @@ workflows:
           xcode-version: "11.0"
           podspec-path: WordPressAuthenticator.podspec
           update-specs-repo: true
+      - ios/publish-podspec:
+          name: Publish to Trunk
+          xcode-version: "10.2.0"
+          podspec-path: WordPressAuthenticator.podspec
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
           update-specs-repo: true
       - ios/publish-podspec:
           name: Publish to Trunk
-          xcode-version: "10.2.0"
+          xcode-version: "11.0"
           podspec-path: WordPressAuthenticator.podspec
           filters:
             tags:


### PR DESCRIPTION
Adding a CircleCI job that will run `pod trunk push` on the podspec whenever the repo is tagged.