### PR TITLE
Adds missing signin events for SIWA

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.9.0-beta.1"
+  s.version       = "1.9.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -99,12 +99,13 @@ private extension AppleAuthenticator {
 
     func signupSuccessful(with credentials: AuthenticatorCredentials) {
         WordPressAuthenticator.track(.createdAccount, properties: ["source": "apple"])
-        WordPressAuthenticator.track(.signupSocialSuccess)
+        WordPressAuthenticator.track(.signupSocialSuccess, properties: ["source": "apple"])
         showSignupEpilogue(for: credentials)
     }
     
     func loginSuccessful(with credentials: AuthenticatorCredentials) {
-        // TODO: Tracks events for login
+        WordPressAuthenticator.track(.signedIn, properties: ["source": "apple"])
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "apple"])
         showSigninEpilogue(for: credentials)
     }
     
@@ -130,13 +131,13 @@ private extension AppleAuthenticator {
     
     func signupFailed(with error: Error) {
         DDLogError("Apple Authenticator: Signup failed. error: \(error.localizedDescription)")
-        WPAnalytics.track(.signupSocialFailure)
+        WordPressAuthenticator.track(.signupSocialFailure, properties: ["source": "apple"])
         delegate?.authFailedWithError(message: error.localizedDescription)
     }
     
     func logInInstead() {
-        WordPressAuthenticator.track(.signupSocialToLogin)
-        WordPressAuthenticator.track(.loginSocialSuccess)
+        WordPressAuthenticator.track(.signupSocialToLogin, properties: ["source": "apple"])
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "apple"])
         delegate?.showWPComLogin(loginFields: loginFields)
     }
     


### PR DESCRIPTION
WordPress-iOS branch to test: https://github.com/wordpress-mobile/WordPress-iOS/pull/12522

Adds a missing event to track signin with Sign in with Apple and several source parameters that did not include `apple`.