### PR TITLE
[SIWA] Check Apple User state

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.9.0"
+  s.version       = "1.10.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -462,3 +462,13 @@ import WordPressUI
         })
     }
 }
+
+@available(iOS 13.0, *)
+public extension WordPressAuthenticator {
+    func checkAppleIDCredentialState(for userID: String, completion:  @escaping (Bool, Error?) -> Void) {
+        AppleAuthenticator.sharedInstance.checkAppleIDCredentialState(for: userID) { (state, error) in
+            // If credentialState == .notFound, error will have a value.
+            completion(state == .authorized, error)
+        }
+    }
+}

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -28,9 +28,15 @@ public protocol WordPressAuthenticatorDelegate: class {
     /// - Parameters:
     ///     - username: WordPress.com Username.
     ///     - authToken: WordPress.com Bearer Token.
-    ///     - onCompletion: Closure to be executed on completion.
     ///
     func createdWordPressComAccount(username: String, authToken: String)
+
+    /// Signals the Host App that the user has successfully authenticated with an Apple account.
+    ///
+    /// - Parameters:
+    ///     - appleUserID: User ID received in the Apple credentials.
+    ///
+    func userAuthenticatedWithAppleUserID(_ appleUserID: String)
 
     /// Presents the Support new request, from a given ViewController, with a specified SourceTag.
     ///

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -106,7 +106,7 @@ private extension AppleAuthenticator {
     func loginSuccessful(with credentials: AuthenticatorCredentials) {
         WordPressAuthenticator.track(.signedIn, properties: ["source": "apple"])
         WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "apple"])
-        showSigninEpilogue(for: credentials)
+        showLoginEpilogue(for: credentials)
     }
     
     func showSignupEpilogue(for credentials: AuthenticatorCredentials) {
@@ -121,7 +121,7 @@ private extension AppleAuthenticator {
         authenticationDelegate.presentSignupEpilogue(in: navigationController, for: credentials, service: service)
     }
     
-    func showSigninEpilogue(for credentials: AuthenticatorCredentials) {
+    func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
         guard let navigationController = showFromViewController?.navigationController else {
             fatalError()
         }
@@ -190,5 +190,13 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
 extension AppleAuthenticator: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return showFromViewController?.view.window ?? UIWindow()
+    }
+}
+
+@available(iOS 13.0, *)
+extension AppleAuthenticator {
+    func checkAppleIDCredentialState(for userID: String,
+                                     completion: @escaping (ASAuthorizationAppleIDProvider.CredentialState, Error?) -> Void) {
+        ASAuthorizationAppleIDProvider().getCredentialState(forUserID: userID, completion: completion)
     }
 }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -165,6 +165,7 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let credentials as ASAuthorizationAppleIDCredential:
+            authenticationDelegate.userAuthenticatedWithAppleUserID(credentials.user)
             createWordPressComUser(appleCredentials: credentials)
         default:
             break


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/12399

This adds functionality:
- For host apps to check the state of an Apple User.
- Informs host apps with the Apple User when an Apple account has been successfully authenticated.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12549