### PR TITLE
[SIWA] Observe Apple Credential Revoked notification

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.0-beta.1"
+  s.version       = "1.10.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -14,6 +14,10 @@ import WordPressUI
     ///
     private static var privateInstance: WordPressAuthenticator?
 
+    /// Observer for AppleID Credential State
+    ///
+    private var appleIDCredentialObserver: NSObjectProtocol?
+
     /// Shared Instance.
     ///
     @objc public static var shared: WordPressAuthenticator {
@@ -465,10 +469,25 @@ import WordPressUI
 
 @available(iOS 13.0, *)
 public extension WordPressAuthenticator {
+    
     func checkAppleIDCredentialState(for userID: String, completion:  @escaping (Bool, Error?) -> Void) {
         AppleAuthenticator.sharedInstance.checkAppleIDCredentialState(for: userID) { (state, error) in
             // If credentialState == .notFound, error will have a value.
             completion(state == .authorized, error)
         }
     }
+
+    func startObservingAppleIDCredentialRevoked(completion:  @escaping () -> Void) {
+        appleIDCredentialObserver = NotificationCenter.default.addObserver(forName: AppleAuthenticator.credentialRevokedNotification, object: nil, queue: nil) { (notification) in
+            completion()
+        }
+    }
+    
+    func stopObservingAppleIDCredentialRevoked() {
+        if let observer = appleIDCredentialObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        appleIDCredentialObserver = nil
+    }
+
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -473,7 +473,7 @@ public extension WordPressAuthenticator {
     func checkAppleIDCredentialState(for userID: String, completion:  @escaping (Bool, Error?) -> Void) {
         AppleAuthenticator.sharedInstance.checkAppleIDCredentialState(for: userID) { (state, error) in
             // If credentialState == .notFound, error will have a value.
-            completion(state == .authorized, error)
+            completion(state != .revoked, error)
         }
     }
 

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -17,6 +17,9 @@ class AppleAuthenticator: NSObject {
     private var showFromViewController: UIViewController?
     private let loginFields = LoginFields()
     weak var delegate: AppleAuthenticatorDelegate?
+    
+    @available(iOS 13.0, *)
+    static let credentialRevokedNotification = ASAuthorizationAppleIDProvider.credentialRevokedNotification
 
     private var authenticationDelegate: WordPressAuthenticatorDelegate {
         guard let delegate = WordPressAuthenticator.shared.delegate else {


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/12535

This adds methods for the host apps to start/stop listening to Apple's `credentialRevokedNotification`. 

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12552

(ping @ctarda )