### PR TITLE
[SIWA] Send Apple credential state to host app

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.0-beta.2"
+  s.version       = "1.10.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -4,7 +4,7 @@ import NSURL_IDN
 import GoogleSignIn
 import WordPressShared
 import WordPressUI
-
+import AuthenticationServices
 
 // MARK: - WordPressAuthenticator: Public API to deal with WordPress.com and WordPress.org authentication.
 //
@@ -469,11 +469,11 @@ import WordPressUI
 
 @available(iOS 13.0, *)
 public extension WordPressAuthenticator {
-    
-    func checkAppleIDCredentialState(for userID: String, completion:  @escaping (Bool, Error?) -> Void) {
-        AppleAuthenticator.sharedInstance.checkAppleIDCredentialState(for: userID) { (state, error) in
+
+    func getAppleIDCredentialState(for userID: String, completion:  @escaping (ASAuthorizationAppleIDProvider.CredentialState, Error?) -> Void) {
+        AppleAuthenticator.sharedInstance.getAppleIDCredentialState(for: userID) { (state, error) in
             // If credentialState == .notFound, error will have a value.
-            completion(state != .revoked, error)
+            completion(state, error)
         }
     }
 

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -199,8 +199,8 @@ extension AppleAuthenticator: ASAuthorizationControllerPresentationContextProvid
 
 @available(iOS 13.0, *)
 extension AppleAuthenticator {
-    func checkAppleIDCredentialState(for userID: String,
-                                     completion: @escaping (ASAuthorizationAppleIDProvider.CredentialState, Error?) -> Void) {
+    func getAppleIDCredentialState(for userID: String,
+                                   completion: @escaping (ASAuthorizationAppleIDProvider.CredentialState, Error?) -> Void) {
         ASAuthorizationAppleIDProvider().getCredentialState(forUserID: userID, completion: completion)
     }
 }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -77,6 +77,9 @@ private extension AppleAuthenticator {
                                          success: { [weak self] accountCreated, existingNonSocialAccount, wpcomUsername, wpcomToken in
                                             SVProgressHUD.dismiss()
 
+                                            // Notify host app of successful Apple authentication
+                                            self?.authenticationDelegate.userAuthenticatedWithAppleUserID(appleCredentials.user)
+                                            
                                             guard !existingNonSocialAccount else {
                                                 self?.logInInstead()
                                                 return
@@ -168,7 +171,6 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let credentials as ASAuthorizationAppleIDCredential:
-            authenticationDelegate.userAuthenticatedWithAppleUserID(credentials.user)
             createWordPressComUser(appleCredentials: credentials)
         default:
             break


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/12399

This changes checking the Apple ID credential state:
- Instead of deciding if a credential is valid, simply send the state back to the host app.
- Instead of _immediately_ notifying the host app when an Apple account has been successfully authenticated, that call is now made is the `success` block of the `createWPComUserWithApple` call.

The main point here is to let the host app decide how to handle the `CredentialState`s.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12585

(ping @ctarda )