### PR TITLE
[SIWA] Show email address on WP password entry view

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,8 +12,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.3'
-  # pod 'WordPressKit', '~> 4.5.1-beta.1'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/12556-siwa_add_data_to_error'
+  pod 'WordPressKit', '~> 4.5.1-beta.1'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.3'
-  pod 'WordPressKit', '~> 4.5.0-beta.2'
+  # pod 'WordPressKit', '~> 4.5.1-beta.1'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/12556-siwa_add_data_to_error'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressKit:
-    :commit: 9941f7b8cbcfd2842d8a16ca94716b1761f10b24
+    :commit: a60a06e6fbda33b413ab104f9d0d500b89dcf655
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (4.5.0-beta.2):
+  - WordPressKit (4.5.1-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.5.0-beta.2)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/12556-siwa_add_data_to_error`)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.3)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: issue/12556-siwa_add_data_to_error
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 9941f7b8cbcfd2842d8a16ca94716b1761f10b24
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -117,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
+  WordPressKit: bab738886bfd6efe52e1d9d0d82d7fb46e30fa58
   WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 066779a8741fbd6f8205a5d3469e19c8c80682b7
+PODFILE CHECKSUM: 7ef6695fcdf68b83b2dedcee5a97c9ab3d1b1d01
 
 COCOAPODS: 1.7.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/12556-siwa_add_data_to_error`)
+  - WordPressKit (~> 4.5.1-beta.1)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.3)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: issue/12556-siwa_add_data_to_error
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: a60a06e6fbda33b413ab104f9d0d500b89dcf655
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -131,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 7ef6695fcdf68b83b2dedcee5a97c9ab3d1b1d01
+PODFILE CHECKSUM: 54eac1537fd4ae3b816f763cc2d73e9d3189bf05
 
 COCOAPODS: 1.7.5

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,6 +39,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.3'
-  s.dependency 'WordPressKit', '~> 4.5.0'
+  s.dependency 'WordPressKit', '~> 4.5.1-beta.1'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.0-beta.3"
+  s.version       = "1.10.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -71,10 +71,13 @@ class SignupService {
                                     success(createdAccount, false, username, bearer_token)
         }, failure: { error in
             if let error = (error as NSError?) {
-                
+
+                // If an account already exists, the account email should be returned in the Error response.
+                // Extract it and return it.
                 var existingEmail = ""
-                if let errorData = error.userInfo[WordPressComRestApi.ErrorKeyErrorData] as? [String: String],
-                    let email = errorData.first?.value {
+                if let errorData = error.userInfo[WordPressComRestApi.ErrorKeyErrorData] as? [String: String] {
+                    let emailDict = errorData.first { $0.key == "email" }
+                    let email = emailDict?.value ?? ""
                     existingEmail = email
                 }
 

--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -76,7 +76,7 @@ class SignupService {
                 // Extract it and return it.
                 var existingEmail = ""
                 if let errorData = error.userInfo[WordPressComRestApi.ErrorKeyErrorData] as? [String: String] {
-                    let emailDict = errorData.first { $0.key == "email" }
+                    let emailDict = errorData.first { $0.key == WordPressComRestApi.ErrorKeyErrorDataEmail }
                     let email = emailDict?.value ?? ""
                     existingEmail = email
                 }

--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -71,9 +71,16 @@ class SignupService {
                                     success(createdAccount, false, username, bearer_token)
         }, failure: { error in
             if let error = (error as NSError?) {
+                
+                var existingEmail = ""
+                if let errorData = error.userInfo[WordPressComRestApi.ErrorKeyErrorData] as? [String: String],
+                    let email = errorData.first?.value {
+                    existingEmail = email
+                }
+
                 let existingNonSocialAccount = (error.userInfo[ErrorKeys.errorCode] as? String ?? "") == ErrorKeys.existingNonSocialUser
                 if existingNonSocialAccount {
-                    success(false, true, "", "")
+                    success(false, true, existingEmail, "")
                     return
                 }
             }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -81,6 +81,7 @@ private extension AppleAuthenticator {
                                             self?.authenticationDelegate.userAuthenticatedWithAppleUserID(appleCredentials.user)
                                             
                                             guard !existingNonSocialAccount else {
+                                                self?.updateLoginEmail(wpcomUsername)
                                                 self?.logInInstead()
                                                 return
                                             }
@@ -157,10 +158,14 @@ private extension AppleAuthenticator {
     }
     
     func updateLoginFields(email: String, fullName: String, token: String) {
-        loginFields.emailAddress = email
-        loginFields.username = email
+        updateLoginEmail(email)
         loginFields.meta.socialServiceIDToken = token
         loginFields.meta.appleUser = AppleUser(email: email, fullName: fullName)
+    }
+
+    func updateLoginEmail(_ email: String) {
+        loginFields.emailAddress = email
+        loginFields.username = email
     }
 
 }


### PR DESCRIPTION
Ref WPiOS issue #https://github.com/wordpress-mobile/WordPress-iOS/issues/12556
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/183

This uses the changes in WPKit to capture the existing account's email address for display on the WP password entry view.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12606

(ping @ctarda )