### PR TITLE
[Dark Mode] Update activity indicator color when button is disabled

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.0-beta.2"
+  s.version       = "1.10.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.0-beta.3"
+  s.version       = "1.10.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -20,14 +20,6 @@ import WordPressUI
         return indicator
     }()
 
-    open override var isEnabled: Bool {
-        didSet {
-            if #available(iOS 13, *) {
-                activityIndicator.color = isEnabled ? style.primaryTitleColor : style.secondaryTitleColor
-            }
-        }
-    }
-
     override open func layoutSubviews() {
         super.layoutSubviews()
 

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -129,6 +129,10 @@ import WordPressUI
         setTitleColor(titleColorNormal, for: .normal)
         setTitleColor(titleColorNormal, for: .highlighted)
         setTitleColor(style.disabledTitleColor, for: .disabled)
+
+        if #available(iOS 13, *) {
+            activityIndicator.color = titleColorNormal
+        }
     }
 
     /// Setup: TitleLabel

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -9,7 +9,12 @@ import WordPressUI
     }
 
     @objc let activityIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .white)
+        let indicator: UIActivityIndicatorView
+        if #available(iOS 13, *) {
+            indicator = UIActivityIndicatorView(style: .medium)
+        } else {
+            indicator = UIActivityIndicatorView(style: .white)
+        }
         indicator.color = WordPressAuthenticator.shared.style.primaryTitleColor
         indicator.hidesWhenStopped = true
         return indicator
@@ -69,7 +74,10 @@ import WordPressUI
     open override func awakeFromNib() {
         super.awakeFromNib()
         configureAppearance()
-        activityIndicator.style = .gray
+        guard #available(iOS 13, *) else {
+            activityIndicator.style = .gray
+            return
+        }
     }
 
     /// Setup: shorter reference for style

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -39,9 +39,6 @@ import WordPressUI
             frm.origin.y = (frame.height - frm.height) / 2.0
             activityIndicator.frame = frm.integral
         }
-
-        configureBackgrounds()
-        configureTitleColors()
     }
 
     // MARK: - Instance Methods

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -20,6 +20,14 @@ import WordPressUI
         return indicator
     }()
 
+    open override var isEnabled: Bool {
+        didSet {
+            if #available(iOS 13, *) {
+                activityIndicator.color = isEnabled ? style.primaryTitleColor : style.secondaryTitleColor
+            }
+        }
+    }
+
     override open func layoutSubviews() {
         super.layoutSubviews()
 

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -39,6 +39,9 @@ import WordPressUI
             frm.origin.y = (frame.height - frm.height) / 2.0
             activityIndicator.frame = frm.integral
         }
+
+        configureBackgrounds()
+        configureTitleColors()
     }
 
     // MARK: - Instance Methods
@@ -137,10 +140,6 @@ import WordPressUI
         setTitleColor(titleColorNormal, for: .normal)
         setTitleColor(titleColorNormal, for: .highlighted)
         setTitleColor(style.disabledTitleColor, for: .disabled)
-
-        if #available(iOS 13, *) {
-            activityIndicator.color = titleColorNormal
-        }
     }
 
     /// Setup: TitleLabel

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -8,6 +8,14 @@ import WordPressUI
         return activityIndicator.isAnimating
     }
 
+    open override var isEnabled: Bool {
+        didSet {
+            if #available(iOS 13, *) {
+                activityIndicator.color = isEnabled ? style.primaryTitleColor : style.secondaryTitleColor
+            }
+        }
+    }
+
     @objc let activityIndicator: UIActivityIndicatorView = {
         let indicator: UIActivityIndicatorView
         if #available(iOS 13, *) {


### PR DESCRIPTION
Fixes #140 

This PR reload the activity indicator color when the button `isEnabled` property is true/false

## To Test
- Run WP iOS [#12610](https://github.com/wordpress-mobile/WordPress-iOS/pull/12610)