### PR TITLE
CircleCI: Use updated Orb to publish to trunk & post to Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.31
+  ios: wordpress-mobile/ios@0.0.35
 
 workflows:
   test_and_validate:
@@ -23,6 +23,7 @@ workflows:
           name: Publish to Trunk
           xcode-version: "11.0"
           podspec-path: WordPressAuthenticator.podspec
+          post-to-slack: true
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
This is just an Orb bump to used the improved CocoaPods publishing from https://github.com/wordpress-mobile/circleci-orbs/pull/38. It was already tested on that PR.