### PR TITLE
CircleCI: Bump Orbs to use any 1.0.x version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.36
+  # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
+  ios: wordpress-mobile/ios@1.0
 
 workflows:
   test_and_validate:
@@ -14,14 +14,18 @@ workflows:
           scheme: WordPressAuthenticator
           device: iPhone 11
           ios-version: "13.0"
+          bundle-install: true
+          pod-install: true
       - ios/validate-podspec:
           name: Validate Podspec
           xcode-version: "11.0"
           podspec-path: WordPressAuthenticator.podspec
+          bundle-install: true
       - ios/publish-podspec:
           name: Publish to Trunk
           xcode-version: "11.0"
           podspec-path: WordPressAuthenticator.podspec
+          bundle-install: true
           post-to-slack: true
           filters:
             tags:


### PR DESCRIPTION
Our [CircleCI Orbs repo](https://github.com/wordpress-mobile/circleci-orbs) has been stabilising and I released version 1.0.0 this week. In this PR, I am bumping the versions we use to `1.0` so that it will pick up any future 1.0.x version. This means we don't need to bump the version for any little change to our Orbs.

To test:

- CircleCI is green