### PR TITLE
Consistently track Google and Apple sign up/log in actions

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.1"
+  s.version       = "1.10.2-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -65,6 +65,7 @@ private extension AppleAuthenticator {
                 return
         }
         
+        WordPressAuthenticator.track(.createAccountInitiated, properties: ["source": "apple"])
         SVProgressHUD.show(withStatus: NSLocalizedString("Continuing with Apple", comment: "Shown while logging in with Apple and the app waits for the site creation process to complete."))
         
         let email = appleCredentials.email ?? ""
@@ -138,7 +139,7 @@ private extension AppleAuthenticator {
     
     func signupFailed(with error: Error) {
         DDLogError("Apple Authenticator: Signup failed. error: \(error.localizedDescription)")
-        WordPressAuthenticator.track(.signupSocialFailure, properties: ["source": "apple"])
+        WordPressAuthenticator.track(.signupSocialFailure, error: error)
         delegate?.authFailedWithError(message: error.localizedDescription)
     }
     

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -139,7 +139,12 @@ private extension AppleAuthenticator {
     
     func signupFailed(with error: Error) {
         DDLogError("Apple Authenticator: Signup failed. error: \(error.localizedDescription)")
-        WordPressAuthenticator.track(.signupSocialFailure, error: error)
+
+        let properties = [ "source": "apple",
+                           "error": error.localizedDescription
+        ]
+
+        WordPressAuthenticator.track(.signupSocialFailure, properties: properties)
         delegate?.authFailedWithError(message: error.localizedDescription)
     }
     

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -559,7 +559,7 @@ extension LoginEmailViewController {
 
         // Disconnect now that we're done with Google.
         GIDSignIn.sharedInstance().disconnect()
-        WordPressAuthenticator.track(.loginSocialSuccess)
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
     }
 
 
@@ -571,7 +571,7 @@ extension LoginEmailViewController {
         loginFields.emailAddress = email
 
         performSegue(withIdentifier: .showWPComLogin, sender: self)
-        WordPressAuthenticator.track(.loginSocialAccountsNeedConnecting)
+        WordPressAuthenticator.track(.loginSocialAccountsNeedConnecting, properties: ["source": "google"])
         configureViewLoading(false)
     }
 

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -21,7 +21,7 @@ class SignupGoogleViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         titleLabel?.text = NSLocalizedString("Waiting for Google to complete…", comment: "Message shown on screen while waiting for Google to finish its signup process.")
-        WordPressAuthenticator.track(.createAccountInitiated)
+        WordPressAuthenticator.track(.createAccountInitiated, properties: ["source": "google"])
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -133,7 +133,7 @@ private extension SignupGoogleViewController {
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         WordPressAuthenticator.track(.createdAccount, properties: ["source": "google"])
-        WordPressAuthenticator.track(.signupSocialSuccess)
+        WordPressAuthenticator.track(.signupSocialSuccess, properties: ["source": "google"])
 
         showSignupEpilogue(for: credentials)
     }
@@ -141,8 +141,8 @@ private extension SignupGoogleViewController {
     /// Social Login Successful: Analytics + Pushing the Login Epilogue.
     ///
     func wasLoggedInInstead(with credentials: AuthenticatorCredentials) {
-        WordPressAuthenticator.track(.signupSocialToLogin)
-        WordPressAuthenticator.track(.loginSocialSuccess)
+        WordPressAuthenticator.track(.signupSocialToLogin, properties: ["source": "google"])
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
 
         showLoginEpilogue(for: credentials)
     }
@@ -150,7 +150,7 @@ private extension SignupGoogleViewController {
     /// Social Signup Failure: Analytics + UI Updates
     ///
     func socialSignupDidFail(with error: Error) {
-        WPAnalytics.track(.signupSocialFailure)
+        WordPressAuthenticator.track(.signupSocialFailure, error: error)
 
         if (error as? SignupError) == .unknown {
             navigationController?.popViewController(animated: true)

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -150,7 +150,12 @@ private extension SignupGoogleViewController {
     /// Social Signup Failure: Analytics + UI Updates
     ///
     func socialSignupDidFail(with error: Error) {
-        WordPressAuthenticator.track(.signupSocialFailure, error: error)
+
+        let properties = [ "source": "google",
+                           "error": error.localizedDescription
+        ]
+
+        WordPressAuthenticator.track(.signupSocialFailure, properties: properties)
 
         if (error as? SignupError) == .unknown {
             navigationController?.popViewController(animated: true)


### PR DESCRIPTION
This updates tracking signup and login for social accounts:
- To be consistent between Google and Apple (i.e. they track the same actions). 
- Adding ["source": "google"] to Google tracks to differentiate between the two.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12803