### PR TITLE
Add signed_in Tracks event whenever we log in socially

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.2"
+  s.version       = "1.10.3-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -178,6 +178,8 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
 
         // Disconnect now that we're done with Google.
         GIDSignIn.sharedInstance().disconnect()
+
+        WordPressAuthenticator.track(.signedIn)
         WordPressAuthenticator.track(.loginSocialSuccess)
     }
 

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -559,6 +559,7 @@ extension LoginEmailViewController {
 
         // Disconnect now that we're done with Google.
         GIDSignIn.sharedInstance().disconnect()
+        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
         WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
     }
 

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -288,7 +288,7 @@ extension LoginViewController {
                         serviceToken: serviceToken,
                         connectParameters: appleConnectParameters,
                         success: {
-                            let source: String = appleConnectParameters != nil ? "apple" : "google"
+                            let source = appleConnectParameters != nil ? "apple" : "google"
                             WordPressAuthenticator.track(.signedIn, properties: ["source": source])
                             WordPressAuthenticator.track(.loginSocialConnectSuccess)
                             WordPressAuthenticator.track(.loginSocialSuccess)

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -288,6 +288,8 @@ extension LoginViewController {
                         serviceToken: serviceToken,
                         connectParameters: appleConnectParameters,
                         success: {
+                            let source: String = appleConnectParameters != nil ? "apple" : "google"
+                            WordPressAuthenticator.track(.signedIn, properties: ["source": source])
                             WordPressAuthenticator.track(.loginSocialConnectSuccess)
                             WordPressAuthenticator.track(.loginSocialSuccess)
         }, failure: { error in

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -141,6 +141,7 @@ private extension SignupGoogleViewController {
     /// Social Login Successful: Analytics + Pushing the Login Epilogue.
     ///
     func wasLoggedInInstead(with credentials: AuthenticatorCredentials) {
+        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
         WordPressAuthenticator.track(.signupSocialToLogin, properties: ["source": "google"])
         WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
 

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -133,6 +133,7 @@ private extension SignupGoogleViewController {
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         WordPressAuthenticator.track(.createdAccount, properties: ["source": "google"])
+        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
         WordPressAuthenticator.track(.signupSocialSuccess, properties: ["source": "google"])
 
         showSignupEpilogue(for: credentials)


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/12827. This PR adds `signedIn` tracks events everywhere we're already posting a `loginSocialSuccess` event. You can test this PR with the associated WPiOS PR here: https://github.com/wordpress-mobile/WordPress-iOS/pull/12981

I updated 4 locations where I could find usages of `loginSocialSuccess` with no associated `signedIn`. I'm not 100% sure if these are correct, so please let me know what you think! Here's my thoughts on each one:

* **Login2FAController**: I'm a little unsure about this one, as the line above mentions Google login but I'm honestly not quite sure how to trigger this method. It doesn't appear to get called by doing a normal sign in with 2FA.
* **LoginEmailViewController**: I updated this one, but as far as I can tell this method is actually not used any more, as we no longer display the Google option on this screen. Since the addition of Sign in with Apple, we moved it as an option at the start of the process.
* **LoginViewController**: I also couldn't seem to get this one called. I'm not sure if it's used when connecting an Apple account for the first time? It doesn't seem to be called for my already-connected Google or Apple accounts.
* **SignupGoogleViewController**: This one is definitely called when I log in with my Google account :)

**To test**

* Review the code and see if you think these placements look okay
* As far as possible, exercise each event here. As I mentioned, I don't think the email one is used any more, and I could only get the SignupGoogleViewController method called (by signing in with my existing Google account).
* Any thoughts you have on this would be very welcome!