### PR TITLE
Fix Google 2FA login

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.3-beta.1"
+  s.version       = "1.10.3-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -347,15 +347,16 @@
 		B5609095208A4EAF00399AE4 /* Signin */ = {
 			isa = PBXGroup;
 			children = (
+				98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */,
 				B5609126208A563600399AE4 /* EmailMagicLink.storyboard */,
 				B560912E208A563700399AE4 /* Login.storyboard */,
 				B5609125208A563600399AE4 /* Login2FAViewController.swift */,
 				B5609128208A563600399AE4 /* LoginEmailViewController.swift */,
 				B5609129208A563600399AE4 /* LoginLinkRequestViewController.swift */,
 				B5609131208A563700399AE4 /* LoginNavigationController.swift */,
+				982C8E7823021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift */,
 				B560912C208A563700399AE4 /* LoginProloguePageViewController.swift */,
 				B560912B208A563600399AE4 /* LoginProloguePromoViewController.swift */,
-				982C8E7823021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift */,
 				B5609133208A563700399AE4 /* LoginPrologueSignupMethodViewController.swift */,
 				B5609130208A563700399AE4 /* LoginPrologueViewController.swift */,
 				B560912A208A563600399AE4 /* LoginSelfHostedViewController.swift */,
@@ -366,7 +367,6 @@
 				B5609134208A563700399AE4 /* LoginViewController.swift */,
 				B5609124208A563600399AE4 /* LoginWPComViewController.swift */,
 				B560912D208A563700399AE4 /* SigninEditingState.swift */,
-				98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */,
 			);
 			path = Signin;
 			sourceTree = "<group>";

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -123,11 +123,12 @@
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="N3P-wt-Rn3"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="Njv-lY-Lyi"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="UV4-XI-c0q"/>
+                        <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="2Of-BA-xqb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieq-Ar-5OF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-122" y="270"/>
+            <point key="canvasLocation" x="-81" y="255"/>
         </scene>
         <!--Login Navigation Controller-->
         <scene sceneID="1BJ-CW-C88">
@@ -176,8 +177,37 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ozJ-hT-OEw">
                                 <rect key="frame" x="0.0" y="44" width="383" height="632"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="582"/>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                        <rect key="frame" x="327" y="568" width="36" height="44"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="PgU-lW-anB"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <state key="normal" title="Next">
+                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="handleSubmitButtonTapped:" destination="fwZ-QE-5et" eventType="touchUpInside" id="bLs-uJ-s0q"/>
+                                        </connections>
+                                    </button>
+                                    <textField opaque="NO" alpha="0.10000000000000001" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="usY-bV-fpM" customClass="WPWalkthroughTextField">
+                                        <rect key="frame" x="1" y="630" width="1" height="1"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="JlK-kU-NkS"/>
+                                            <constraint firstAttribute="width" constant="1" id="gg9-4D-yft"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" textContentType="password"/>
+                                        <connections>
+                                            <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="aJ6-Ep-HbW"/>
+                                        </connections>
+                                    </textField>
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
+                                        <rect key="frame" x="8" y="-65" width="383" height="582"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-yW-tzf">
                                                 <rect key="frame" x="0.0" y="211" width="383" height="167"/>
@@ -280,36 +310,6 @@
                                             <constraint firstItem="JdU-yW-tzf" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" id="yAg-ul-Rff"/>
                                         </constraints>
                                     </view>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="327" y="568" width="36" height="44"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="PgU-lW-anB"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <state key="normal" title="Next">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="handleSubmitButtonTapped:" destination="fwZ-QE-5et" eventType="touchUpInside" id="bLs-uJ-s0q"/>
-                                        </connections>
-                                    </button>
-                                    <textField opaque="NO" alpha="0.10000000000000001" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="usY-bV-fpM" customClass="WPWalkthroughTextField">
-                                        <rect key="frame" x="1" y="630" width="1" height="1"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="JlK-kU-NkS"/>
-                                            <constraint firstAttribute="width" constant="1" id="gg9-4D-yft"/>
-                                        </constraints>
-                                        <nil key="textColor"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" textContentType="password"/>
-                                        <connections>
-                                            <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="aJ6-Ep-HbW"/>
-                                        </connections>
-                                    </textField>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="KAn-ug-oE6" firstAttribute="leading" secondItem="ozJ-hT-OEw" secondAttribute="leading" id="K1C-YL-EQU"/>
@@ -373,7 +373,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wWl-qb-1Yp" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1730" y="255"/>
+            <point key="canvasLocation" x="1674" y="188"/>
         </scene>
         <!--emailEntry-->
         <scene sceneID="CQL-qu-sjW">
@@ -402,29 +402,29 @@
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="559"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wnq-Hk-jIw" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="20" y="201.5" width="343" height="36"/>
+                                                <rect key="frame" x="20" y="197.5" width="343" height="40"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="40"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf" userLabel="Icon">
-                                                                <rect key="frame" x="0.0" y="7" width="18" height="22"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="36" height="40"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="F6S-wN-1Jp"/>
                                                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="Z7H-Ud-llZ"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uN1-Al-ygf">
-                                                                <rect key="frame" x="28" y="0.0" width="315" height="36"/>
+                                                                <rect key="frame" x="46" y="2" width="297" height="36"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehh-92-XG8" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="315" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="297" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6" userLabel="Subtitle">
-                                                                        <rect key="frame" x="0.0" y="18" width="315" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="18" width="297" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -454,7 +454,6 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
-                                                        <nil key="textColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES" smartInsertDeleteType="no" textContentType="one-time-code"/>
                                                         <userDefinedRuntimeAttributes>
@@ -471,7 +470,6 @@
                                                         <rect key="frame" x="0.0" y="44" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
-                                                        <nil key="textColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES" textContentType="one-time-code"/>
                                                         <userDefinedRuntimeAttributes>
@@ -612,22 +610,22 @@
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="559"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
-                                                <rect key="frame" x="20" y="169.5" width="343" height="48"/>
+                                                <rect key="frame" x="20" y="176.5" width="343" height="48"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3be-99-g62">
-                                                <rect key="frame" x="0.0" y="249.5" width="383" height="88"/>
+                                                <rect key="frame" x="0.0" y="256.5" width="383" height="74"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
-                                                        <rect key="frame" x="20" y="0.0" width="343" height="36"/>
+                                                        <rect key="frame" x="20" y="0.0" width="343" height="22"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
-                                                                <rect key="frame" x="0.0" y="0.0" width="36" height="36"/>
+                                                                <rect key="frame" x="0.0" y="2" width="18" height="18"/>
                                                             </imageView>
                                                             <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sx0-OR-XAf">
-                                                                <rect key="frame" x="46" y="7" width="297" height="22"/>
+                                                                <rect key="frame" x="28" y="0.0" width="315" height="22"/>
                                                                 <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <textInputTraits key="textInputTraits" textContentType="username"/>
@@ -638,7 +636,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                                                        <rect key="frame" x="0.0" y="44" width="383" height="44"/>
+                                                        <rect key="frame" x="0.0" y="30" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
                                                         <constraints>
@@ -662,7 +660,7 @@
                                                 </constraints>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                                <rect key="frame" x="20" y="357.5" width="343" height="18"/>
+                                                <rect key="frame" x="20" y="350.5" width="343" height="18"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="pswdErrorLabel"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
@@ -918,6 +916,7 @@
                             </mask>
                         </variation>
                     </view>
+                    <navigationItem key="navigationItem" id="nSB-GD-C7r"/>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="tJ5-Do-kBC" id="lfp-1Z-g7f"/>
                         <outlet property="errorLabel" destination="zhF-jf-Wcv" id="NDc-4E-Aqv"/>
@@ -1262,10 +1261,10 @@
                                 <rect key="frame" x="-4" y="64" width="383" height="539"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-HN-aFE" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="20" y="23" width="343" height="204.5"/>
+                                        <rect key="frame" x="20" y="27" width="343" height="200.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-b4-JSG">
-                                                <rect key="frame" x="8" y="98.5" width="327" height="98"/>
+                                                <rect key="frame" x="8" y="98.5" width="327" height="94"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in with your WordPress.com account to manage your WooCommerce stores" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au1-mY-r58">
                                                         <rect key="frame" x="0.0" y="0.0" width="327" height="38"/>
@@ -1274,26 +1273,26 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="IMk-aA-1GF" userLabel="Header Stack View">
-                                                        <rect key="frame" x="0.0" y="58" width="327" height="40"/>
+                                                        <rect key="frame" x="0.0" y="58" width="327" height="36"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Gak-2q-wul" userLabel="Icon">
-                                                                <rect key="frame" x="0.0" y="0.0" width="36" height="40"/>
+                                                                <rect key="frame" x="0.0" y="7" width="18" height="22"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="c8o-Eq-kBi"/>
                                                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="r0G-JB-SfD"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DWy-yy-er4">
-                                                                <rect key="frame" x="46" y="2" width="281" height="36"/>
+                                                                <rect key="frame" x="28" y="0.0" width="299" height="36"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCX-uI-ruO" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="281" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="299" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUi-aQ-0SQ" userLabel="Subtitle">
-                                                                        <rect key="frame" x="0.0" y="18" width="281" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="18" width="299" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -1325,7 +1324,6 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
-                                                <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES" smartInsertDeleteType="no" textContentType="one-time-code"/>
                                                 <userDefinedRuntimeAttributes>
@@ -1464,15 +1462,15 @@
         <image name="icon-username-field" width="18" height="18"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="5hL-j3-eMs"/>
-        <segue reference="bK1-J1-hfT"/>
-        <segue reference="kRR-qz-Hu2"/>
-        <segue reference="8p6-rS-9Ml"/>
-        <segue reference="TkG-0R-c3i"/>
-        <segue reference="sIC-Hv-FJw"/>
+        <segue reference="N3P-wt-Rn3"/>
+        <segue reference="Njv-lY-Lyi"/>
+        <segue reference="2Of-BA-xqb"/>
+        <segue reference="UV4-XI-c0q"/>
+        <segue reference="4SK-mG-U33"/>
+        <segue reference="nCA-u7-fKm"/>
         <segue reference="D3h-Su-Jwk"/>
         <segue reference="swV-lc-6gI"/>
-        <segue reference="EmH-Av-vhT"/>
-        <segue reference="pe1-D0-Mpg"/>
+        <segue reference="gD5-d0-X3t"/>
+        <segue reference="aSC-hU-lzE"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -399,7 +399,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             vc.googleTapped = { [weak self] in
                 self?.performSegue(withIdentifier: NUXViewController.SegueIdentifier.showGoogle.rawValue, sender: self)
             }
-            // TODO: remove this - erroneously added when fixing #12398.
             vc.appleTapped = { [weak self] in
                 self?.appleTapped()
             }

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -29,7 +29,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     var didFindSafariSharedCredentials = false
     var didRequestSafariSharedCredentials = false
     open var offerSignupOption = false
-    fileprivate var awaitingGoogle = false
     private let showNewLoginFlow = WordPressAuthenticator.shared.configuration.showNewLoginFlow
 
     private struct Constants {
@@ -145,7 +144,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         let button = WPStyleGuide.googleLoginButton()
         stackView.addArrangedSubview(button)
-        button.addTarget(self, action: #selector(googleLoginTapped), for: .touchUpInside)
+        button.addTarget(self, action: #selector(handleGoogleLoginTapped), for: .touchUpInside)
 
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
@@ -153,26 +152,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             ])
 
         googleLoginButton = button
-    }
-
-    @objc func googleLoginTapped() {
-        awaitingGoogle = true
-        configureViewLoading(true)
-
-        GIDSignIn.sharedInstance().disconnect()
-
-        // Flag this as a social sign in.
-        loginFields.meta.socialService = SocialServiceName.google
-
-        // Configure all the things and sign in.
-        GIDSignIn.sharedInstance().delegate = self
-        GIDSignIn.sharedInstance().uiDelegate = self
-        GIDSignIn.sharedInstance().clientID = WordPressAuthenticator.shared.configuration.googleLoginClientId
-        GIDSignIn.sharedInstance().serverClientID = WordPressAuthenticator.shared.configuration.googleLoginServerClientId
-
-        GIDSignIn.sharedInstance().signIn()
-
-        WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "google"])
     }
 
     /// Add the log in with site address button to the view
@@ -321,14 +300,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-
-    /// Displays the self-hosted sign in form.
-    ///
-    func loginToSelfHostedSite() {
-        performSegue(withIdentifier: .showSelfHostedLogin, sender: self)
-    }
-
-
     /// Proceeds along the "magic link" sign-in flow, showing a form that let's
     /// the user request a magic link.
     ///
@@ -404,32 +375,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     override open func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
-
-        if awaitingGoogle {
-            awaitingGoogle = false
-            GIDSignIn.sharedInstance().disconnect()
-
-            let errorTitle: String
-            let errorDescription: String
-            if (error as NSError).code == WordPressComOAuthError.unknownUser.rawValue {
-                errorTitle = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
-                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
-                WordPressAuthenticator.track(.loginSocialErrorUnknownUser)
-            } else {
-                errorTitle = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
-                errorDescription = error.localizedDescription
-            }
-
-            let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription)
-            let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
-            socialErrorVC.delegate = self
-            socialErrorVC.loginFields = loginFields
-            socialErrorVC.modalPresentationStyle = .fullScreen
-            present(socialErrorNav, animated: true) {}
-        } else {
-            errorToPresent = error
-            performSegue(withIdentifier: .showWPComLogin, sender: self)
-        }
+        displayRemoteErrorForGoogle(error)
     }
 
 
@@ -453,6 +399,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             vc.googleTapped = { [weak self] in
                 self?.performSegue(withIdentifier: NUXViewController.SegueIdentifier.showGoogle.rawValue, sender: self)
             }
+            // TODO: remove this - erroneously added when fixing #12398.
             vc.appleTapped = { [weak self] in
                 self?.appleTapped()
             }
@@ -484,6 +431,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
+    @objc func handleGoogleLoginTapped() {
+        googleLoginTapped(withDelegate: self)
+    }
 
     @IBAction func handleSelfHostedButtonTapped(_ sender: UIButton) {
         loginToSelfHostedSite()
@@ -550,91 +500,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     }
 }
 
-// LoginFacadeDelegate methods for Google Google Sign In
-extension LoginEmailViewController {
-    func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
-        let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: false, siteURL: loginFields.siteAddress)
-        let credentials = AuthenticatorCredentials(wpcom: wpcom)
-        syncWPComAndPresentEpilogue(credentials: credentials)
-
-        // Disconnect now that we're done with Google.
-        GIDSignIn.sharedInstance().disconnect()
-        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
-        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
-    }
-
-
-    func existingUserNeedsConnection(_ email: String) {
-        // Disconnect now that we're done with Google.
-        GIDSignIn.sharedInstance().disconnect()
-
-        loginFields.username = email
-        loginFields.emailAddress = email
-
-        performSegue(withIdentifier: .showWPComLogin, sender: self)
-        WordPressAuthenticator.track(.loginSocialAccountsNeedConnecting, properties: ["source": "google"])
-        configureViewLoading(false)
-    }
-
-
-    func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
-        loginFields.nonceInfo = nonceInfo
-        loginFields.nonceUserID = userID
-
-        performSegue(withIdentifier: .show2FA, sender: self)
-        WordPressAuthenticator.track(.loginSocial2faNeeded)
-        configureViewLoading(false)
-    }
-}
-
-extension LoginEmailViewController: GIDSignInDelegate {
-    open func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
-        guard let user = user,
-            let token = user.authentication.idToken,
-            let email = user.profile.email else {
-                // The Google SignIn for may have been canceled.
-                WordPressAuthenticator.track(.loginSocialButtonFailure, error: error)
-                configureViewLoading(false)
-                return
-        }
-
-        // Store the email address and token.
-        loginFields.emailAddress = email
-        loginFields.username = email
-        loginFields.meta.socialServiceIDToken = token
-
-        loginFacade.loginToWordPressDotCom(withGoogleIDToken: token)
-    }
-}
-
-extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
-    private func cleanupAfterSocialErrors() {
-        dismiss(animated: true) {}
-    }
-
-    func retryWithEmail() {
-        loginFields.username = ""
-        cleanupAfterSocialErrors()
-    }
-    func retryWithAddress() {
-        cleanupAfterSocialErrors()
-        loginToSelfHostedSite()
-    }
-    func retryAsSignup() {
-        cleanupAfterSocialErrors()
-
-
-        let storyboard = UIStoryboard(name: "Signup", bundle: WordPressAuthenticator.bundle)
-        if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
-            controller.loginFields = loginFields
-            navigationController?.pushViewController(controller, animated: true)
-        }
-    }
-}
-
-/// This is needed to set self as uiDelegate, even though none of the methods are called
-extension LoginEmailViewController: GIDSignInUIDelegate {
-}
+// MARK: - AppleAuthenticatorDelegate
 
 extension LoginEmailViewController: AppleAuthenticatorDelegate {
 
@@ -647,4 +513,29 @@ extension LoginEmailViewController: AppleAuthenticatorDelegate {
         displayErrorAlert(message, sourceTag: .wpComSignupApple)
     }
     
+}
+
+// MARK: - Google Sign In
+
+// LoginFacadeDelegate methods for Google Google Sign In
+extension LoginEmailViewController {
+    func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
+        googleFinishedLogin(withGoogleIDToken: googleIDToken, authToken: authToken)
+    }
+
+    func existingUserNeedsConnection(_ email: String) {
+        configureViewLoading(false)
+        googleExistingUserNeedsConnection(email)
+    }
+
+    func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+        configureViewLoading(false)
+        googleNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
+    }
+}
+
+extension LoginEmailViewController: GIDSignInDelegate {
+    open func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
+        signInGoogleAccount(signIn, didSignInFor: user, withError: error)
+    }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -2,6 +2,8 @@ import UIKit
 import Lottie
 import WordPressShared
 import WordPressUI
+import GoogleSignIn
+import WordPressKit
 
 class LoginPrologueViewController: LoginViewController {
 
@@ -56,7 +58,7 @@ class LoginPrologueViewController: LoginViewController {
             }
             vc.modalPresentationStyle = .custom
         }
-            
+
         else if let vc = segue.destination as? LoginPrologueLoginMethodViewController {
             vc.transitioningDelegate = self
             
@@ -64,10 +66,10 @@ class LoginPrologueViewController: LoginViewController {
                 self?.performSegue(withIdentifier: .showEmailLogin, sender: self)
             }
             vc.googleTapped = { [weak self] in
-                self?.performSegue(withIdentifier: .showGoogle, sender: self)
+                self?.googleLoginTapped(withDelegate: self)
             }
             vc.selfHostedTapped = { [weak self] in
-                self?.performSegue(withIdentifier: .showSelfHostedLogin, sender: self)
+                self?.loginToSelfHostedSite()
             }
             vc.appleTapped = { [weak self] in
                 self?.appleTapped()
@@ -124,6 +126,8 @@ class LoginPrologueViewController: LoginViewController {
 
 }
 
+// MARK: - AppleAuthenticatorDelegate
+
 extension LoginPrologueViewController: AppleAuthenticatorDelegate {
 
     func showWPComLogin(loginFields: LoginFields) {
@@ -134,5 +138,37 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
     func authFailedWithError(message: String) {
         displayErrorAlert(message, sourceTag: .loginApple)
     }
+
+}
+
+// MARK: - Google Sign In
+
+// LoginFacadeDelegate methods for Google Google Sign In
+extension LoginPrologueViewController {
     
+    override open func displayRemoteError(_ error: Error) {
+        configureViewLoading(false)
+        displayRemoteErrorForGoogle(error)
+    }
+    
+    func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
+        googleFinishedLogin(withGoogleIDToken: googleIDToken, authToken: authToken)
+    }
+
+    func existingUserNeedsConnection(_ email: String) {
+        configureViewLoading(false)
+        googleExistingUserNeedsConnection(email)
+    }
+
+    func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+        configureViewLoading(false)
+        googleNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
+    }
+
+}
+
+extension LoginPrologueViewController: GIDSignInDelegate {
+    open func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
+        signInGoogleAccount(signIn, didSignInFor: user, withError: error)
+    }
 }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -139,7 +139,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
         // Is everything filled out?
         if !loginFields.validateFieldsPopulatedForSignin() {
-            let errorMsg = NSLocalizedString("Please fill out all the fields", comment: "A short prompt asking the user to properly fill out all login fields.")
+            let errorMsg = LocalizedText.missingInfoError
             displayError(message: errorMsg)
 
             return
@@ -182,7 +182,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
         let err = error as NSError
         guard err.code != 403 else {
-            let message = NSLocalizedString("Whoops, something went wrong and we couldn't log you in. Please try again!", comment: "An error message shown when a wpcom user provides the wrong password.")
+            let message = LocalizedText.loginError
             displayError(message: message)
             return
         }
@@ -204,8 +204,16 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         SafariCredentialsService.updateSafariCredentialsIfNeeded(with: loginFields)
     }
     
-}
+    private enum LocalizedText {
+        static let loginError = NSLocalizedString("Whoops, something went wrong and we couldn't log you in. Please try again!", comment: "An error message shown when a wpcom user provides the wrong password.")
+        static let missingInfoError = NSLocalizedString("Please fill out all the fields", comment: "A short prompt asking the user to properly fill out all login fields.")
+        static let gettingAccountInfo = NSLocalizedString("Getting account information", comment: "Alerts the user that wpcom account information is being retrieved.")
+        static let googleConnected = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
+        static let googleConnectedError = NSLocalizedString("The Google account \"%@\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
+        static let googleUnableToConnect = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
+    }
 
+}
 
 // MARK: - Sync Helpers
 //
@@ -237,7 +245,7 @@ extension LoginViewController {
     private func syncWPCom(credentials: AuthenticatorCredentials, completion: (() -> ())? = nil) {
         SafariCredentialsService.updateSafariCredentialsIfNeeded(with: loginFields)
 
-        configureStatusLabel(NSLocalizedString("Getting account information", comment: "Alerts the user that wpcom account information is being retrieved."))
+        configureStatusLabel(LocalizedText.gettingAccountInfo)
 
         authenticationDelegate.sync(credentials: credentials) { [weak self] in
 
@@ -347,7 +355,7 @@ extension LoginViewController {
         loginFields.meta.socialService = SocialServiceName.google
 
         // Configure all the things and sign in.
-        GIDSignIn.sharedInstance().delegate = delegate//self
+        GIDSignIn.sharedInstance().delegate = delegate
         GIDSignIn.sharedInstance().uiDelegate = self
         GIDSignIn.sharedInstance().clientID = WordPressAuthenticator.shared.configuration.googleLoginClientId
         GIDSignIn.sharedInstance().serverClientID = WordPressAuthenticator.shared.configuration.googleLoginServerClientId
@@ -365,11 +373,11 @@ extension LoginViewController {
             let errorTitle: String
             let errorDescription: String
             if (error as NSError).code == WordPressComOAuthError.unknownUser.rawValue {
-                errorTitle = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
-                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
+                errorTitle = LocalizedText.googleConnected
+                errorDescription = String(format: LocalizedText.googleConnectedError, loginFields.username)
                 WordPressAuthenticator.track(.loginSocialErrorUnknownUser)
             } else {
-                errorTitle = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
+                errorTitle = LocalizedText.googleUnableToConnect
                 errorDescription = error.localizedDescription
             }
 

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -1,5 +1,6 @@
 import WordPressShared
 import WordPressKit
+import GoogleSignIn
 
 
 /// View Controller for login-specific screens
@@ -32,6 +33,8 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         return delegate
     }
 
+    private var awaitingGoogle = false
+    
     // MARK: Lifecycle Methods
 
     override open func viewDidLoad() {
@@ -122,6 +125,10 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         }
     }
 
+    /// Displays the self-hosted sign in form.
+    func loginToSelfHostedSite() {
+        performSegue(withIdentifier: .showSelfHostedLogin, sender: self)
+    }
 
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with login.
@@ -196,6 +203,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     func updateSafariCredentialsIfNeeded() {
         SafariCredentialsService.updateSafariCredentialsIfNeeded(with: loginFields)
     }
+    
 }
 
 
@@ -316,6 +324,145 @@ extension LoginViewController {
 
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             didChangePreferredContentSize()
+        }
+    }
+}
+
+
+// MARK: - Google Sign In Handling
+
+// This is needed to set self as uiDelegate, even though none of the methods are called
+extension LoginViewController: GIDSignInUIDelegate {
+}
+
+extension LoginViewController {
+
+    @objc func googleLoginTapped(withDelegate delegate: GIDSignInDelegate?) {
+        awaitingGoogle = true
+        configureViewLoading(true)
+
+        GIDSignIn.sharedInstance().disconnect()
+
+        // Flag this as a social sign in.
+        loginFields.meta.socialService = SocialServiceName.google
+
+        // Configure all the things and sign in.
+        GIDSignIn.sharedInstance().delegate = delegate//self
+        GIDSignIn.sharedInstance().uiDelegate = self
+        GIDSignIn.sharedInstance().clientID = WordPressAuthenticator.shared.configuration.googleLoginClientId
+        GIDSignIn.sharedInstance().serverClientID = WordPressAuthenticator.shared.configuration.googleLoginServerClientId
+        GIDSignIn.sharedInstance().signIn()
+
+        WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "google"])
+    }
+
+    func displayRemoteErrorForGoogle(_ error: Error) {
+
+        if awaitingGoogle {
+            awaitingGoogle = false
+            GIDSignIn.sharedInstance().disconnect()
+
+            let errorTitle: String
+            let errorDescription: String
+            if (error as NSError).code == WordPressComOAuthError.unknownUser.rawValue {
+                errorTitle = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
+                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
+                WordPressAuthenticator.track(.loginSocialErrorUnknownUser)
+            } else {
+                errorTitle = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
+                errorDescription = error.localizedDescription
+            }
+
+            let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription)
+            let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
+            socialErrorVC.delegate = self
+            socialErrorVC.loginFields = loginFields
+            socialErrorVC.modalPresentationStyle = .fullScreen
+            present(socialErrorNav, animated: true) {}
+        } else {
+            errorToPresent = error
+            performSegue(withIdentifier: .showWPComLogin, sender: self)
+        }
+    }
+    
+    func googleFinishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
+        let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: false, siteURL: loginFields.siteAddress)
+        let credentials = AuthenticatorCredentials(wpcom: wpcom)
+        syncWPComAndPresentEpilogue(credentials: credentials)
+
+        // Disconnect now that we're done with Google.
+        GIDSignIn.sharedInstance().disconnect()
+        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
+    }
+
+    func googleExistingUserNeedsConnection(_ email: String) {
+        // Disconnect now that we're done with Google.
+        GIDSignIn.sharedInstance().disconnect()
+
+        loginFields.username = email
+        loginFields.emailAddress = email
+
+        performSegue(withIdentifier: .showWPComLogin, sender: self)
+        WordPressAuthenticator.track(.loginSocialAccountsNeedConnecting, properties: ["source": "google"])
+        configureViewLoading(false)
+    }
+
+    func googleNeedsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+        loginFields.nonceInfo = nonceInfo
+        loginFields.nonceUserID = userID
+
+        performSegue(withIdentifier: .show2FA, sender: self)
+        WordPressAuthenticator.track(.loginSocial2faNeeded, properties: ["source": "google"])
+    }
+
+    func signInGoogleAccount(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
+        guard let user = user,
+            let token = user.authentication.idToken,
+            let email = user.profile.email else {
+                // The Google SignIn for may have been canceled.
+                WordPressAuthenticator.track(.loginSocialButtonFailure, error: error)
+                configureViewLoading(false)
+                return
+        }
+
+        updateLoginFields(googleUser: user, googleToken: token, googleEmail: email)
+        loginFacade.loginToWordPressDotCom(withGoogleIDToken: token)
+    }
+    
+    /// Updates the LoginFields structure, with the specified Google User + Token + Email.
+    ///
+    func updateLoginFields(googleUser: GIDGoogleUser, googleToken: String, googleEmail: String) {
+        loginFields.emailAddress = googleEmail
+        loginFields.username = googleEmail
+        loginFields.meta.socialServiceIDToken = googleToken
+        loginFields.meta.googleUser = googleUser
+    }
+    
+}
+
+extension LoginViewController: LoginSocialErrorViewControllerDelegate {
+    private func cleanupAfterSocialErrors() {
+        dismiss(animated: true) {}
+    }
+
+    func retryWithEmail() {
+        loginFields.username = ""
+        cleanupAfterSocialErrors()
+    }
+
+    func retryWithAddress() {
+        cleanupAfterSocialErrors()
+        loginToSelfHostedSite()
+    }
+
+    func retryAsSignup() {
+        cleanupAfterSocialErrors()
+
+        let storyboard = UIStoryboard(name: "Signup", bundle: WordPressAuthenticator.bundle)
+        if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
+            controller.loginFields = loginFields
+            navigationController?.pushViewController(controller, animated: true)
         }
     }
 }

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -83,15 +83,6 @@ extension SignupGoogleViewController: GIDSignInDelegate {
 //
 private extension SignupGoogleViewController {
 
-    /// Updates the LoginFields structure, with the specified Google User + Token + Email.
-    ///
-    func updateLoginFields(googleUser: GIDGoogleUser, googleToken: String, googleEmail: String) {
-        loginFields.emailAddress = googleEmail
-        loginFields.username = googleEmail
-        loginFields.meta.socialServiceIDToken = googleToken
-        loginFields.meta.googleUser = googleUser
-    }
-
     /// Creates a WordPress.com account with the associated GoogleUser + GoogleToken + GoogleEmail.
     ///
     func createWordPressComUser(googleUser: GIDGoogleUser, googleToken: String, googleEmail: String) {
@@ -168,11 +159,4 @@ private extension SignupGoogleViewController {
         titleLabel?.text = NSLocalizedString("Google sign up failed.", comment: "Message shown on screen after the Google sign up process failed.")
         displayError(error as NSError, sourceTag: .wpComSignup)
     }
-}
-
-// MARK: - GIDSignInUIDelegate
-
-/// This is needed to set self as UIDelegate, even though none of the methods are called
-extension SignupGoogleViewController: GIDSignInUIDelegate {
-
 }


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/13004
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13005
Woo test branch: `try/google_login`

This fixes the path where a user tries to login in with a Google account that has 2FA enabled on the WordPress account.

Previously, it was using the Google _sign up_ flow, which was incorrect (and doesn't handle 2FA accounts).

This moves the Google sign in logic into `LoginViewController` so it can be accessed via `LoginEmailViewController` (flow used by Woo) and `LoginPrologueViewController` (flow used by WPiOS).
