### PR TITLE
[SIWA] Add flow for 2FA accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0
+  ios: wordpress-mobile/ios@1.0 
 
 workflows:
   test_and_validate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0.7
+  ios: wordpress-mobile/ios@1.0
 
 workflows:
   test_and_validate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0
+  ios: wordpress-mobile/ios@1.0.7
 
 workflows:
   test_and_validate:

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  pod 'WordPressKit', '~> 4.5.1'
+#  pod 'WordPressKit', '~> 4.5.4-beta.1'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/apple_2fa_auth'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  pod 'WordPressKit', '~> 4.5.4-beta.1'
+  pod 'WordPressKit', '~> 4.5.4'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/apple_2fa_auth'
   pod 'WordPressShared', '~> 1.8'
 

--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.4-beta.1'
-#  pod 'WordPressKit', '~> 4.5.4-beta.1'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/apple_2fa_auth'
+  pod 'WordPressKit', '~> 4.5.4-beta.1'
+  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/apple_2fa_auth'
   pod 'WordPressShared', '~> 1.8'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -43,12 +43,12 @@ PODS:
     - OHHTTPStubs/Default
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
-  - UIDeviceIdentifier (1.1.4)
+  - UIDeviceIdentifier (1.4.0)
   - WordPressKit (4.5.4-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
-    - UIDeviceIdentifier (~> 1.1.4)
+    - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressShared (1.8.7):
@@ -105,7 +105,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressKit:
-    :commit: 87b02503b34a91f5714bb1fb2317d95ce2c3c496
+    :commit: 2c332bae66457f2ac9a48d18982729cb0383a7bf
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -125,8 +125,8 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 9cbce6364bec557cc3439aa6bb7514670d780881
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: deaebd8e75514c2ca9f6f3d53a5e0f5508c0409b
+  UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
+  WordPressKit: 75bbd7f43ec6851a2617f847898c5f0f546b86f8
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/apple_2fa_auth`)
+  - WordPressKit (~> 4.5.4-beta.1)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: issue/apple_2fa_auth
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 2c332bae66457f2ac9a48d18982729cb0383a7bf
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -131,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 1cf7ba2d02f99dc82cc3043a5a9975fa2763c4e1
+PODFILE CHECKSUM: 08a1526dc06f08452b6066b18253c7a4478c317d
 
 COCOAPODS: 1.8.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.5.4-beta.1):
+  - WordPressKit (4.5.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.5.4-beta.1)
+  - WordPressKit (~> 4.5.4)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -117,11 +117,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: 75bbd7f43ec6851a2617f847898c5f0f546b86f8
+  WordPressKit: 1d365775fac17903a76ad5723bc146ab1739ec82
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 08a1526dc06f08452b6066b18253c7a4478c317d
+PODFILE CHECKSUM: 6f930e58860031b74be490800e49e91a4f3cd75f
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (4.5.1):
+  - WordPressKit (4.5.4-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.5.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/apple_2fa_auth`)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: issue/apple_2fa_auth
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 87b02503b34a91f5714bb1fb2317d95ce2c3c496
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -117,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: c35230114bbd380d63250b6d9a43337c29266c9b
+  WordPressKit: deaebd8e75514c2ca9f6f3d53a5e0f5508c0409b
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 831117be8f1a447aaa2277d2b421a8e64fe6f02c
+PODFILE CHECKSUM: 1cf7ba2d02f99dc82cc3043a5a9975fa2763c4e1
 
 COCOAPODS: 1.8.3

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ WordPressAuthenticator is available through [CocoaPods](http://cocoapods.org). T
 it, simply add the following line to your Podfile:
 
 ```bash
-pod "WordPressAuthenticator" 
+pod "WordPressAuthenticator"
 ```

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ WordPressAuthenticator is available through [CocoaPods](http://cocoapods.org). T
 it, simply add the following line to your Podfile:
 
 ```bash
-pod "WordPressAuthenticator"
+pod "WordPressAuthenticator" 
 ```

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.3-beta.3"
+  s.version       = "1.10.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -39,6 +39,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.4-beta.1'
-  s.dependency 'WordPressKit', '~> 4.5.4-beta.1'
+  s.dependency 'WordPressKit', '~> 4.5.4'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.3"
+  s.version       = "1.10.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.3-beta.2"
+  s.version       = "1.10.3-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,6 +39,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.4-beta.1'
-  s.dependency 'WordPressKit', '~> 4.5.1'
+  s.dependency 'WordPressKit', '~> 4.5.4-beta.1'
   s.dependency 'WordPressShared', '~> 1.8'
 end

--- a/WordPressAuthenticator/Services/LoginFacade.h
+++ b/WordPressAuthenticator/Services/LoginFacade.h
@@ -58,11 +58,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)requestSocial2FACodeWithLoginFields:(LoginFields *)loginFields;
 
 /**
- * Social login via google.
+ * Social login.
  *
- * @param googleIDToken A Google id_token.
+ * @param token Social id token.
  */
-- (void)loginToWordPressDotComWithGoogleIDToken:(NSString *)googleIDToken;
+- (void)loginToWordPressDotComWithSocialIDToken:(NSString *)token
+                                        service:(NSString *)service;
 
 /**
  * Social login via a social account with 2FA using a nonce.

--- a/WordPressAuthenticator/Services/LoginFacade.m
+++ b/WordPressAuthenticator/Services/LoginFacade.m
@@ -73,7 +73,7 @@
     [self.wordpressComOAuthClientFacade authenticateWithSocialIDToken:token
                                                               service:service
                                                               success:^(NSString *authToken) {
-        if ([self.delegate respondsToSelector:@selector(finishedLoginWithGoogleIDToken:authToken:)]) {
+        if ([service isEqualToString:@"google"] && [self.delegate respondsToSelector:@selector(finishedLoginWithGoogleIDToken:authToken:)]) {
             // Apple is handled in AppleAuthenticator
             [self.delegate finishedLoginWithGoogleIDToken:token authToken:authToken];
         }

--- a/WordPressAuthenticator/Services/LoginFacade.m
+++ b/WordPressAuthenticator/Services/LoginFacade.m
@@ -63,21 +63,26 @@
                                                                  }];
 }
 
-- (void)loginToWordPressDotComWithGoogleIDToken:(NSString *)googleIDToken
+- (void)loginToWordPressDotComWithSocialIDToken:(NSString *)token
+                                        service:(NSString *)service
 {
     if ([self.delegate respondsToSelector:@selector(displayLoginMessage:)]) {
         [self.delegate displayLoginMessage:NSLocalizedString(@"Connecting to WordPress.com", nil)];
     }
 
-    [self.wordpressComOAuthClientFacade authenticateWithGoogleIDToken:googleIDToken success:^(NSString *authToken) {
+    [self.wordpressComOAuthClientFacade authenticateWithSocialIDToken:token
+                                                              service:service
+                                                              success:^(NSString *authToken) {
         if ([self.delegate respondsToSelector:@selector(finishedLoginWithGoogleIDToken:authToken:)]) {
-            [self.delegate finishedLoginWithGoogleIDToken:googleIDToken authToken:authToken];
+            // Apple is handled in AppleAuthenticator
+            [self.delegate finishedLoginWithGoogleIDToken:token authToken:authToken];
         }
     } needsMultiFactor:^(NSInteger userID, SocialLogin2FANonceInfo *nonceInfo){
         if ([self.delegate respondsToSelector:@selector(needsMultifactorCodeForUserID:andNonceInfo:)]) {
             [self.delegate needsMultifactorCodeForUserID:userID andNonceInfo:nonceInfo];
         }
     } existingUserNeedsConnection: ^(NSString *email) {
+        // Apple is handled in AppleAuthenticator
         if ([self.delegate respondsToSelector:@selector(existingUserNeedsConnection:)]) {
             [self.delegate existingUserNeedsConnection: email];
         }

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.h
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.h
@@ -22,7 +22,8 @@
                                success:(void (^)(NSString *newNonce))success
                                failure:(void (^)(NSError *error, NSString *newNonce))failure;
 
-- (void)authenticateWithGoogleIDToken:(NSString *)token
+- (void)authenticateWithSocialIDToken:(NSString *)token
+                              service:(NSString *)service
                               success:(void (^)(NSString *authToken))success
                      needsMultiFactor:(void (^)(NSInteger userID, SocialLogin2FANonceInfo *nonceInfo))needsMultifactor
           existingUserNeedsConnection:(void (^)(NSString *email))existingUserNeedsConnection

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
@@ -68,13 +68,19 @@
     [self.client requestSocial2FACodeWithUserID:userID nonce:nonce success:success failure:failure];
 }
 
-- (void)authenticateWithGoogleIDToken:(NSString *)token
+- (void)authenticateWithSocialIDToken:(NSString *)token
+                              service:(NSString *)service
                               success:(void (^)(NSString *authToken))success
                      needsMultiFactor:(void (^)(NSInteger userID, SocialLogin2FANonceInfo *nonceInfo))needsMultifactor
           existingUserNeedsConnection:(void (^)(NSString *email))existingUserNeedsConnection
                               failure:(void (^)(NSError *error))failure
 {
-    [self.client authenticateWithIDToken:token success:success needsMultifactor:needsMultifactor existingUserNeedsConnection:existingUserNeedsConnection failure:failure];
+    [self.client authenticateWithIDToken:token
+                                 service:service
+                                 success:success
+                        needsMultifactor:needsMultifactor
+             existingUserNeedsConnection:existingUserNeedsConnection
+                                 failure:failure];
 }
 
 - (void)authenticateSocialLoginUser:(NSInteger)userID

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -180,7 +180,13 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         GIDSignIn.sharedInstance().disconnect()
 
         WordPressAuthenticator.track(.signedIn)
-        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": loginFields.meta.socialService?.rawValue ?? ""])
+
+        var properties = [AnyHashable:Any]()
+        if let service = loginFields.meta.socialService?.rawValue {
+            properties["source"] = service
+        }
+
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: properties)
     }
 
     /// Only allow digits in the 2FA text field

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -180,7 +180,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         GIDSignIn.sharedInstance().disconnect()
 
         WordPressAuthenticator.track(.signedIn)
-        WordPressAuthenticator.track(.loginSocialSuccess)
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": loginFields.meta.socialService?.rawValue ?? ""])
     }
 
     /// Only allow digits in the 2FA text field

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -394,13 +394,10 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         if let vc = segue.destination as? LoginPrologueSignupMethodViewController {
             vc.transitioningDelegate = self
             vc.emailTapped = { [weak self] in
-                self?.performSegue(withIdentifier: NUXViewController.SegueIdentifier.showSigninV2.rawValue, sender: self)
+                self?.performSegue(withIdentifier: .showSigninV2, sender: self)
             }
             vc.googleTapped = { [weak self] in
-                self?.performSegue(withIdentifier: NUXViewController.SegueIdentifier.showGoogle.rawValue, sender: self)
-            }
-            vc.appleTapped = { [weak self] in
-                self?.appleTapped()
+                self?.performSegue(withIdentifier: .showGoogle, sender: self)
             }
             vc.modalPresentationStyle = .custom
         }
@@ -493,25 +490,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-    private func appleTapped() {
-        AppleAuthenticator.sharedInstance.delegate = self
-        AppleAuthenticator.sharedInstance.showFrom(viewController: self)
-    }
-}
-
-// MARK: - AppleAuthenticatorDelegate
-
-extension LoginEmailViewController: AppleAuthenticatorDelegate {
-
-    func showWPComLogin(loginFields: LoginFields) {
-        self.loginFields = loginFields
-         performSegue(withIdentifier: .showWPComLogin, sender: self)
-    }
-   
-    func authFailedWithError(message: String) {
-        displayErrorAlert(message, sourceTag: .wpComSignupApple)
-    }
-    
 }
 
 // MARK: - Google Sign In

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -529,7 +529,7 @@ extension LoginEmailViewController {
 
     func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         configureViewLoading(false)
-        googleNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
+        socialNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
     }
 }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -135,15 +135,19 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
          performSegue(withIdentifier: .showWPComLogin, sender: self)
     }
 
+    func showApple2FA(loginFields: LoginFields) {
+        self.loginFields = loginFields
+        signInAppleAccount()
+    }
+    
     func authFailedWithError(message: String) {
         displayErrorAlert(message, sourceTag: .loginApple)
     }
 
 }
 
-// MARK: - Google Sign In
+// MARK: - Social LoginFacadeDelegate Methods
 
-// LoginFacadeDelegate methods for Google Google Sign In
 extension LoginPrologueViewController {
     
     override open func displayRemoteError(_ error: Error) {
@@ -162,10 +166,12 @@ extension LoginPrologueViewController {
 
     func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         configureViewLoading(false)
-        googleNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
+        socialNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
     }
 
 }
+
+// MARK: - GIDSignInDelegate
 
 extension LoginPrologueViewController: GIDSignInDelegate {
     open func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -372,6 +372,11 @@ extension LoginSiteAddressViewController: AppleAuthenticatorDelegate {
         self.loginFields = loginFields
         performSegue(withIdentifier: .showWPComLogin, sender: self)
     }
+
+    func showApple2FA(loginFields: LoginFields) {
+        self.loginFields = loginFields
+        signInAppleAccount()
+    }
     
     func authFailedWithError(message: String) {
         displayErrorAlert(message, sourceTag: .loginApple)

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -416,12 +416,22 @@ extension LoginViewController {
         configureViewLoading(false)
     }
 
-    func googleNeedsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+    func socialNeedsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         loginFields.nonceInfo = nonceInfo
         loginFields.nonceUserID = userID
 
         performSegue(withIdentifier: .show2FA, sender: self)
-        WordPressAuthenticator.track(.loginSocial2faNeeded, properties: ["source": "google"])
+        WordPressAuthenticator.track(.loginSocial2faNeeded, properties: ["source": loginFields.meta.socialService?.rawValue ?? ""])
+    }
+
+    func signInAppleAccount() {
+        guard let token = loginFields.meta.socialServiceIDToken else {
+            WordPressAuthenticator.track(.loginSocialButtonFailure, properties: ["source": SocialServiceName.apple.rawValue])
+            configureViewLoading(false)
+            return
+        }
+
+        loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.apple.rawValue)
     }
 
     func signInGoogleAccount(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -421,7 +421,13 @@ extension LoginViewController {
         loginFields.nonceUserID = userID
 
         performSegue(withIdentifier: .show2FA, sender: self)
-        WordPressAuthenticator.track(.loginSocial2faNeeded, properties: ["source": loginFields.meta.socialService?.rawValue ?? ""])
+
+        var properties = [AnyHashable:Any]()
+        if let service = loginFields.meta.socialService?.rawValue {
+            properties["source"] = service
+        }
+
+        WordPressAuthenticator.track(.loginSocial2faNeeded, properties: properties)
     }
 
     func signInAppleAccount() {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -429,13 +429,17 @@ extension LoginViewController {
             let token = user.authentication.idToken,
             let email = user.profile.email else {
                 // The Google SignIn for may have been canceled.
-                WordPressAuthenticator.track(.loginSocialButtonFailure, error: error)
+
+                let properties = ["error": error?.localizedDescription,
+                                  "source": SocialServiceName.google.rawValue]
+
+                WordPressAuthenticator.track(.loginSocialButtonFailure, properties: properties as [AnyHashable : Any])
                 configureViewLoading(false)
                 return
         }
 
         updateLoginFields(googleUser: user, googleToken: token, googleEmail: email)
-        loginFacade.loginToWordPressDotCom(withGoogleIDToken: token)
+        loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
     }
     
     /// Updates the LoginFields structure, with the specified Google User + Token + Email.


### PR DESCRIPTION
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/201
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13013

This adds support for logging in with an Apple account linked to a WordPress account that has 2FA enabled.

Can be tested with WPiOS PR noted above.