### PR TITLE
Try/fix lint error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0
+  ios: wordpress-mobile/ios@dev:fix/pod_lint_failure
 
 workflows:
   test_and_validate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@dev:fix/pod_lint_failure
+  ios: wordpress-mobile/ios@1.0
 
 workflows:
   test_and_validate:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org' do
-  gem 'cocoapods', '~> 1.8.0'
+  gem 'cocoapods', '~> 1.8.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.0.3)
-    cocoapods (1.8.3)
+    cocoapods (1.8.4)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.8.3)
+      cocoapods-core (= 1.8.4)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -31,14 +31,14 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.11.1, < 2.0)
-    cocoapods-core (1.8.3)
+    cocoapods-core (1.8.4)
       activesupport (>= 4.0.2, < 6)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.4)
-    cocoapods-downloader (1.2.2)
+    cocoapods-downloader (1.3.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -57,7 +57,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
-    minitest (5.12.2)
+    minitest (5.13.0)
     molinillo (0.6.6)
     nanaimo (0.2.6)
     nap (1.1.0)
@@ -66,7 +66,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.12.0)
+    xcodeproj (1.13.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -77,7 +77,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.8.0)!
+  cocoapods (~> 1.8.4)!
 
 BUNDLED WITH
    2.0.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.5.4-beta.1):
+  - WordPressKit (4.5.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.5.4-beta.1)
+  - WordPressKit (~> 4.5.4)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -117,11 +117,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: 75bbd7f43ec6851a2617f847898c5f0f546b86f8
+  WordPressKit: 1d365775fac17903a76ad5723bc146ab1739ec82
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 08a1526dc06f08452b6066b18253c7a4478c317d
+PODFILE CHECKSUM: 6f930e58860031b74be490800e49e91a4f3cd75f
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.8.4


### PR DESCRIPTION
This PR tries to fix Ci for https://github.com/wordpress-mobile/WordPress-iOS/pull/13013, by updating the `.lock` files and importing a fix for `circleci-orbs`