### PR TITLE
SIWA 2FA login: Remove incorrect Track.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.4"
+  s.version       = "1.10.5-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -166,7 +166,6 @@ private extension AppleAuthenticator {
     }
     
     func show2FA() {
-        WordPressAuthenticator.track(.signupSocialToLogin, properties: ["source": "apple"])
         delegate?.showApple2FA(loginFields: loginFields)
     }
     


### PR DESCRIPTION
This removes an incorrect `signupSocialToLogin` Track in the SIWA 2FA login flow.

Can be tested with WPiOS PR: