### PR TITLE
Color update: style the send code button in `viewWillAppear` in `Login2FAViewController`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.5-beta.1"
+  s.version       = "1.10.5-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -40,6 +40,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         super.viewWillAppear(animated)
 
         configureViewForEditingIfNeeded()
+        styleSendCodeButton()
     }
 
 


### PR DESCRIPTION
## Changes

I moved the color configuration for the `sendCodeButton` to a more appropriate function in `Login2FAViewController` in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/164/commits/2d6fd81ce79e2b6e21754e89004bf1c84d10de53, but forgot to call it in `viewWillAppear` 🤦🏻‍♀️

## Testing WPiOS

Example branch: [`issue/wcios-1555-color-updates`](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/wcios-1555-color-updates?expand=1)

- Launch the app
- Log in with WP.com with an account with 2FA enabled
- Enter the email address
- Enter the password --> should see the 2FA screen, and the "Text me a code instead" text button should have the right color

## Example screenshots in WPiOS

(there is a slight change in the blue color similar to https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/164)

before | after
-- | --
![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 12 09 56](https://user-images.githubusercontent.com/1945542/70295267-5a86ea00-1821-11ea-84fa-fd82d91375e0.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 12 03 58](https://user-images.githubusercontent.com/1945542/70295217-2ad7e200-1821-11ea-8ebb-2a5eebe8c395.png)
![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 12 09 40](https://user-images.githubusercontent.com/1945542/70295276-6377bb80-1821-11ea-8eca-52bbfe8dea13.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 12 04 21](https://user-images.githubusercontent.com/1945542/70295218-2b707880-1821-11ea-9896-82887a7cebe9.png)
