### PR TITLE
[VoiceOver] Login and Signup enhancements

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.5-beta.2"
+  s.version       = "1.10.5-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -66,6 +66,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="dismissButton" destination="gpM-nW-lFQ" id="8iA-TH-TF4"/>
                         <segue destination="fwZ-QE-5et" kind="show" identifier="showEmailLogin" id="1xT-tL-sp6"/>
                     </connections>
                 </viewController>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1450,6 +1450,9 @@
                             <constraint firstAttribute="trailing" secondItem="Ueg-Bw-KU6" secondAttribute="trailing" id="nXh-Tu-veg"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="dismissButton" destination="Ueg-Bw-KU6" id="icp-fM-bz4"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Rrd-X3-roK" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -27,6 +27,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureButtonVC()
+        configureForAccessibility()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -86,5 +87,9 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
         
         dismiss(animated: true)
         appleTapped?()
+    }
+
+    private func configureForAccessibility() {
+        dismissButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.")
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -93,6 +93,15 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
 
     private func configureForAccessibility() {
         dismissButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.")
+
+        // Ensure that the first button (in buttonViewController) is automatically selected by
+        // VoiceOver instead of the dismiss button.
+        if buttonViewController?.isViewLoaded == true, let buttonsView = buttonViewController?.view {
+            view.accessibilityElements = [
+                buttonsView,
+                dismissButton
+            ]
+        }
     }
 
     override func accessibilityPerformEscape() -> Bool {

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -89,7 +89,14 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
         appleTapped?()
     }
 
+    // MARK: - Accessibility
+
     private func configureForAccessibility() {
         dismissButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.")
+    }
+
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true)
+        return true
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -13,7 +13,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     open var selfHostedTapped: (() -> Void)?
     open var appleTapped: (() -> Void)?
 
-    /// The big transparent dismiss button behind the dialog
+    /// The big transparent (dismiss) button behind the buttons
     @IBOutlet weak var dismissButton: UIButton!
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -13,6 +13,9 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     open var selfHostedTapped: (() -> Void)?
     open var appleTapped: (() -> Void)?
 
+    /// The big transparent dismiss button behind the dialog
+    @IBOutlet weak var dismissButton: UIButton!
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
 
@@ -84,5 +87,4 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
         dismiss(animated: true)
         appleTapped?()
     }
-
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -14,7 +14,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     open var appleTapped: (() -> Void)?
 
     /// The big transparent (dismiss) button behind the buttons
-    @IBOutlet weak var dismissButton: UIButton!
+    @IBOutlet private weak var dismissButton: UIButton!
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -105,6 +105,15 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
 
     private func configureForAccessibility() {
         dismissButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.")
+
+        // Ensure that the first button (in buttonViewController) is automatically selected by
+        // VoiceOver instead of the dismiss button.
+        if buttonViewController?.isViewLoaded == true, let buttonsView = buttonViewController?.view {
+            view.accessibilityElements = [
+                buttonsView,
+                dismissButton
+            ]
+        }
     }
 
     override func accessibilityPerformEscape() -> Bool {

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -86,8 +86,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
     }
 
     @IBAction func dismissTapped() {
-        WordPressAuthenticator.track(.signupCancelled)
-        dismiss(animated: true)
+        trackCancellationAndThenDismiss()
     }
 
     @objc func handleAppleButtonTapped() {
@@ -97,9 +96,19 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         appleTapped?()
     }
 
+    private func trackCancellationAndThenDismiss() {
+        WordPressAuthenticator.track(.signupCancelled)
+        dismiss(animated: true)
+    }
+
     // MARK: - Accessibility
 
     private func configureForAccessibility() {
         dismissButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.")
+    }
+
+    override func accessibilityPerformEscape() -> Bool {
+        trackCancellationAndThenDismiss()
+        return true
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -28,6 +28,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureButtonVC()
+        configureForAccessibility()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -94,5 +95,11 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         
         dismiss(animated: true)
         appleTapped?()
+    }
+
+    // MARK: - Accessibility
+
+    private func configureForAccessibility() {
+        dismissButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.")
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -15,7 +15,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
     open var appleTapped: (() -> Void)?
 
     /// The big transparent (dismiss) button behind the buttons
-    @IBOutlet weak var dismissButton: UIButton!
+    @IBOutlet private weak var dismissButton: UIButton!
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -14,6 +14,9 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
     open var googleTapped: (() -> Void)?
     open var appleTapped: (() -> Void)?
 
+    /// The big transparent (dismiss) button behind the buttons
+    @IBOutlet weak var dismissButton: UIButton!
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/13062. This is a dependency of https://github.com/wordpress-mobile/WordPress-iOS/pull/13067. 

## Changes

### First Selected Element

Before | After 
--------|-------
![RPReplay_Final1575989720 2019-12-10 07_56_34](https://user-images.githubusercontent.com/198826/70540497-9f14cd00-1b22-11ea-8631-519f41c46015.gif)    |       ![RPReplay_Final1575989420 2019-12-10 07_54_14](https://user-images.githubusercontent.com/198826/70540338-4e04d900-1b22-11ea-9816-63af63de14d4.gif)



When opening the Login or Signup dialog, the first button is now selected by VoiceOver instead of the _Dismiss_ button.



### Dismissal using Escape Gesture

I added support for dismissing the dialog using VoiceOver's escape gesture — making a Z with 2 fingers. 

## Testing

### Login

1. Use the branch in https://github.com/wordpress-mobile/WordPress-iOS/pull/13067. 
2. Log out. 
3. Turn VoiceOver on.
3. Tap on the Login button.
5. Confirm that: 
     a. The first selected (and announced) element is the first button and not the Dismiss button
     b. You can dismiss dialog by using the VoiceOver escape gesture (Z)

### Sign up

1. Use the same WPiOS branch
2. Log out. 
3. Turn VoiceOver on.
3. Tap on the Sign Up button.
5. Confirm that: 
     a. The first selected (and announced) element is the first button and not the Dismiss button
     b. You can dismiss dialog by using the VoiceOver escape gesture (Z)

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
- [ ] Create a release version
- [ ] Update WPiOS to use pod version

--- 

Hi @jaclync! Can I bother you with this one? 🙂 