### PR TITLE
[VoiceOver] Self-hosted Login Flow enhancements

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.5-beta.3"
+  s.version       = "1.10.5-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -25,6 +25,6 @@ public extension WordPressAuthenticatorDisplayStrings {
     static var defaultStrings: WordPressAuthenticatorDisplayStrings {
         return WordPressAuthenticatorDisplayStrings(emailLoginInstructions: NSLocalizedString("Log in to your WordPress.com account with your email address.", comment: "Instruction text on the login's email address screen."),
                                                     jetpackLoginInstructions: NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.", comment: "Instruction text on the login's email address screen."),
-                                                    siteLoginInstructions: NSLocalizedString("Enter the address of your WordPress site you'd like to connect.", comment: "Instruction text on the login's site addresss screen."))
+                                                    siteLoginInstructions: NSLocalizedString("Enter the address of the WordPress site you'd like to connect.", comment: "Instruction text on the login's site addresss screen."))
     }
 }

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -47,6 +47,9 @@ extension WPStyleGuide {
         onePasswordButton.setImage(.onePasswordImage, for: .normal)
         onePasswordButton.sizeToFit()
 
+        onePasswordButton.accessibilityLabel =
+            NSLocalizedString("Fill with password manager", comment: "The password manager button in login pages. The button opens a dialog showing which password manager to use (e.g. 1Password, LastPass). ")
+
         textField.rightView = onePasswordButton
         textField.rightViewMode = .always
 

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -120,6 +120,8 @@ NSInteger const LeftImageSpacing = 8;
     [self.secureTextEntryToggle addTarget:self action:@selector(secureTextEntryToggleAction:) forControlEvents:UIControlEventTouchUpInside];
 
     [self updateSecureTextEntryToggleImage];
+    [self updateSecureTextEntryForAccessibility];
+
     self.rightView = self.secureTextEntryToggle;
     self.rightViewMode = UITextFieldViewModeAlways;
 }
@@ -253,6 +255,7 @@ NSInteger const LeftImageSpacing = 8;
 
     [super setSecureTextEntry:secureTextEntry];
     [self updateSecureTextEntryToggleImage];
+    [self updateSecureTextEntryForAccessibility];
 }
 
 - (void)secureTextEntryToggleAction:(id)sender
@@ -270,6 +273,19 @@ NSInteger const LeftImageSpacing = 8;
     UIImage *image = self.isSecureTextEntry ? self.secureTextEntryImageHidden : self.secureTextEntryImageVisible;
     [self.secureTextEntryToggle setImage:image forState:UIControlStateNormal];
     [self.secureTextEntryToggle sizeToFit];
+}
+
+- (void)updateSecureTextEntryForAccessibility
+{
+    self.secureTextEntryToggle.accessibilityLabel = NSLocalizedString(@"Show password", @"Accessibility label for the “Show password“ button in the login page's password field.");
+
+    NSString *accessibilityValue;
+    if (self.isSecureTextEntry) {
+        accessibilityValue = NSLocalizedString(@"Hidden", "Accessibility value if login page's password field is hiding the password (i.e. with asterisks).");
+    } else {
+        accessibilityValue = NSLocalizedString(@"Shown", "Accessibility value if login page's password field is displaying the password.");
+    }
+    self.secureTextEntryToggle.accessibilityValue = accessibilityValue;
 }
 
 @end

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -315,7 +315,9 @@ extension LoginSelfHostedViewController {
         configureViewLoading(false)
         let err = error as NSError
         if err.code == 403 {
-            displayError(message: NSLocalizedString("It looks like this username/password isn't associated with this site.", comment: "An error message shown during log in when the username or password is incorrect."))
+            let message = NSLocalizedString("It looks like this username/password isn't associated with this site.",
+                                            comment: "An error message shown during log in when the username or password is incorrect.")
+            displayError(message: message, moveVoiceOverFocus: true)
         } else {
             displayError(error as NSError, sourceTag: sourceTag)
         }

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -36,6 +36,7 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         localizeControls()
         setupOnePasswordButtonIfNeeded()
         displayLoginMessage("")
+        configureForAcessibility()
     }
 
 
@@ -87,6 +88,16 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         forgotPasswordButton.setTitle(forgotPasswordTitle, for: .normal)
         forgotPasswordButton.setTitle(forgotPasswordTitle, for: .highlighted)
         forgotPasswordButton.titleLabel?.numberOfLines = 0
+    }
+
+
+    /// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
+    ///
+    private func configureForAcessibility() {
+        usernameField.accessibilityLabel =
+            NSLocalizedString("Username", comment: "Accessibility label for the username text field in the self-hosted login page.")
+        passwordField.accessibilityLabel =
+            NSLocalizedString("Password", comment: "Accessibility label for the password text field in the self-hosted login page.")
     }
 
 

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -98,6 +98,14 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
             NSLocalizedString("Username", comment: "Accessibility label for the username text field in the self-hosted login page.")
         passwordField.accessibilityLabel =
             NSLocalizedString("Password", comment: "Accessibility label for the password text field in the self-hosted login page.")
+
+        if UIAccessibility.isVoiceOverRunning {
+            // Remove the placeholder if VoiceOver is running. VoiceOver speaks the label and the
+            // placeholder together. In this case, both labels and placeholders are the same so it's
+            // like VoiceOver is reading the same thing twice.
+            usernameField.placeholder = nil
+            passwordField.placeholder = nil
+        }
     }
 
 

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -106,6 +106,8 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
             usernameField.placeholder = nil
             passwordField.placeholder = nil
         }
+
+        forgotPasswordButton.accessibilityTraits = .link
     }
 
 

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -91,6 +91,8 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         siteAddressHelpButton.titleLabel?.numberOfLines = 0
     }
 
+    /// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
+    ///
     private func configureForAccessibility() {
         siteURLField.accessibilityLabel =
             NSLocalizedString("Site address", comment: "Accessibility label of the site address field shown when adding a self-hosted site.")

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -37,6 +37,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     override func viewDidLoad() {
         super.viewDidLoad()
         localizeControls()
+        configureForAccessibility()
     }
 
 
@@ -90,6 +91,10 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         siteAddressHelpButton.titleLabel?.numberOfLines = 0
     }
 
+    private func configureForAccessibility() {
+        siteURLField.accessibilityLabel =
+            NSLocalizedString("Site address", comment: "Accessibility label of the site address field shown when adding a self-hosted site.")
+    }
 
     /// Configures the content of the text fields based on what is saved in `loginFields`.
     ///

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -180,10 +180,17 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             WordPressAuthenticator.track(.loginFailed, error: error)
             self.configureViewLoading(false)
 
+            let displayAndFocusOnErrorLabel: (String) -> () = { message in
+                if let errorLabel = self.errorLabel {
+                    UIAccessibility.post(notification: .layoutChanged, argument: self.errorLabel)
+                }
+                self.displayError(message: message)
+            }
+
             let err = self.originalErrorOrError(error: error as NSError)
 
             if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                self.displayError(message: xmlrpcValidatorError.localizedDescription)
+                displayAndFocusOnErrorLabel(xmlrpcValidatorError.localizedDescription)
 
             } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
                 (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
@@ -191,7 +198,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                 let msg = NSLocalizedString(
                     "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
                     comment: "Error message shown a URL does not point to an existing site.")
-                self.displayError(message: msg)
+                displayAndFocusOnErrorLabel(msg)
 
             } else {
                 self.displayError(error as NSError, sourceTag: self.sourceTag)

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -182,17 +182,10 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             WordPressAuthenticator.track(.loginFailed, error: error)
             self.configureViewLoading(false)
 
-            let displayAndFocusOnErrorLabel: (String) -> () = { message in
-                if let errorLabel = self.errorLabel {
-                    UIAccessibility.post(notification: .layoutChanged, argument: self.errorLabel)
-                }
-                self.displayError(message: message)
-            }
-
             let err = self.originalErrorOrError(error: error as NSError)
 
             if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                displayAndFocusOnErrorLabel(xmlrpcValidatorError.localizedDescription)
+                self.displayError(message: xmlrpcValidatorError.localizedDescription, moveVoiceOverFocus: true)
 
             } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
                 (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
@@ -200,7 +193,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                 let msg = NSLocalizedString(
                     "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
                     comment: "Error message shown a URL does not point to an existing site.")
-                displayAndFocusOnErrorLabel(msg)
+                self.displayError(message: msg, moveVoiceOverFocus: true)
 
             } else {
                 self.displayError(error as NSError, sourceTag: self.sourceTag)

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -82,7 +82,13 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     }
 
     /// Sets the text of the error label.
-    func displayError(message: String) {
+    ///
+    /// - Parameter message: The message to display in the `errorLabel`. If empty, the `errorLabel`
+    ///     will be hidden.
+    /// - Parameter moveVoiceOverFocus: If `true`, moves the VoiceOver focus to the `errorLabel`.
+    ///     You will want to set this to `true` if the error was caused after pressing a button
+    ///     (e.g. Next button).
+    func displayError(message: String, moveVoiceOverFocus: Bool = false) {
         guard message.count > 0 else {
             errorLabel?.isHidden = true
             return
@@ -90,6 +96,10 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         errorLabel?.isHidden = false
         errorLabel?.text = message
         errorToPresent = nil
+
+        if moveVoiceOverFocus, let errorLabel = errorLabel {
+            UIAccessibility.post(notification: .layoutChanged, argument: errorLabel)
+        }
     }
 
     private func mustShowLoginEpilogue() -> Bool {


### PR DESCRIPTION
This fixes the issues described in https://github.com/wordpress-mobile/WordPress-iOS/issues/13086. 

This is a dependency of https://github.com/wordpress-mobile/WordPress-iOS/pull/13099. This PR needs to be reviewed first. 

## Changes

The changes mainly involve the `LoginSiteAddressViewController` and `LoginSelfHostedViewController`. 

### Announce Errors

<img src="https://user-images.githubusercontent.com/198826/70827684-f75c0100-1da6-11ea-90c7-fae1cdb8cb49.gif" width="240">

For errors that happen after pressing _Next_, we sometimes use the [`errorLabel`](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/1361a86fec25f7b69d88f74a7bb676b739749713/WordPressAuthenticator/NUX/NUXViewController.swift#L56) to display the error. The problem with this is that it is a UI element that just appears unannounced. A VoiceOver user may not know that it's there and would expect that a network request is still happening in the background. 

This fixes that by making VoiceOver focus on the error label. Which, in effect, makes VoiceOver speak the error message. 

### Text Field Labels

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/70827913-7f420b00-1da7-11ea-9a9e-7b74ac891184.png" width="320">  |  <img src="https://user-images.githubusercontent.com/198826/70827959-97b22580-1da7-11ea-9342-497c9030128d.png" width="320">

For these view controllers, we rely on the text field's placeholders instead of labels to describe what the text field is. [Placeholders are a bit of a concern for accessibility](https://www.nngroup.com/articles/form-design-placeholders/). For this, I was mostly concerned about the VoiceOver user navigating back to the text field again and **not knowing** what it is. 

This changes the text fields so they will have a static label like “Username“ or “Password“. 

### Show Password Toggle Button

Shown | Hidden 
--------|-------
   ![image](https://user-images.githubusercontent.com/198826/70828635-fc21b480-1da8-11ea-8732-3f468b0f6d6a.png)  |       ![image](https://user-images.githubusercontent.com/198826/70828663-0ba0fd80-1da9-11ea-987b-a96056198cf1.png)

The Show Password button didn't have a label. This is a toggle button so it's a bit tricky. Some apps would change the `accessibilityLabel` when the image changes. WPAndroid uses a static label and makes TalkBack say “selected“ or “not selected“. 

For this, I opted to have a static `accessibilityLabel` but change the `accessibilityValue` to the **current state** of the toggle button. 

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/cafee3d971f3212631d8dd063980925db8ab9480/WordPressAuthenticator/NUX/WPWalkthroughTextField.m#L278-L289

This is the same strategy used in https://github.com/wordpress-mobile/WordPress-iOS/pull/13057 which seems to work well. I believe it's a bad idea to change the `accessibilityLabel` as that would indicate that there are **2 different buttons**. 

### Others

- Added accessibility label for the 1Password button
- Fixed https://github.com/wordpress-mobile/WordPress-iOS/issues/12188 in 
0c3a93f
- Change the forgot password button's trait to be a `.link` since it opens Safari

## Testing

Please use the WPiOS branch at https://github.com/wordpress-mobile/WordPress-iOS/pull/13099. 

1. Log out
2. Turn VoiceOver on
3. Navigate to Login → Enter Site Address
4. Confirm that the site address text field has a label
5. Enter an invalid URL and press Next. An error will be shown in red. Confirm that VoiceOver speaks the error. 
6. Enter a valid self-hosted URL and press Next to navigate to the next page. 
7. Confirm that:
    a. The username and password text fields have labels
    b. The 1Password button has a label
    c. _Lost your password_ is announced as a link
8. Enter some values in the username and password fields. 
9. Navigate between the username and password fields. Confirm that their labels are still spoken by VoiceOver. 
10. Navigate VoiceOver to the Show Password button
11. Toggle the button a couple of times. Confirm that VoiceOver would always speak the current status like “Show password, Shown“ or “Show password, Hidden“. 

## Reviewer Checklist

- [ ] Review this PR
- [ ] Approve https://github.com/wordpress-mobile/WordPress-iOS/pull/13099 if you approved this PR 🙂 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
- [ ] Create a release version after merging

--- 

@mindgraffiti Would you have some time to review this? 🙂 