### PR TITLE
Auth init: login configs

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.7-beta.1"
+  s.version       = "1.10.7-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -61,6 +61,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSignInWithApple: Bool
 
+    /// Flag indicating if the unified login/signup flow should be displayed.
+    ///
+    let enableUnifiedAuth: Bool
+    
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -75,7 +79,8 @@ public struct WordPressAuthenticatorConfiguration {
                  userAgent: String,
                  showLoginOptions: Bool = false,
                  showLoginOptionsFromSiteAddress: Bool = false,
-                 enableSignInWithApple: Bool = false) {
+                 enableSignInWithApple: Bool = false,
+                 enableUnifiedAuth: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -90,5 +95,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.showLoginOptions = showLoginOptions
         self.showLoginOptionsFromSiteAddress = showLoginOptionsFromSiteAddress
         self.enableSignInWithApple = enableSignInWithApple
+        self.enableUnifiedAuth = enableUnifiedAuth
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -46,10 +46,10 @@ public struct WordPressAuthenticatorConfiguration {
     let userAgent: String
 
     /// Flag indicating which Log In flow to display.
-    /// In the new flow, when Log In is selected, a button view is displayed with options.
-    /// In the old flow, when Log In is selected, the email login view is displayed with alternative options.
+    /// If enabled, when Log In is selected, a button view is displayed with options.
+    /// If disabled, when Log In is selected, the email login view is displayed with alternative options.
     ///
-    let showNewLoginFlow: Bool
+    let showLoginOptions: Bool
 
     /// Flag indicating if the login options button view should be displayed in the site address flow.
     /// If enabled, the options button view will be displayed after the site address has been entered
@@ -73,7 +73,7 @@ public struct WordPressAuthenticatorConfiguration {
                  googleLoginServerClientId: String,
                  googleLoginScheme: String,
                  userAgent: String,
-                 showNewLoginFlow: Bool = false,
+                 showLoginOptions: Bool = false,
                  showLoginOptionsFromSiteAddress: Bool = false,
                  enableSignInWithApple: Bool = false) {
 
@@ -87,7 +87,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginServerClientId = googleLoginServerClientId
         self.googleLoginScheme = googleLoginScheme
         self.userAgent = userAgent
-        self.showNewLoginFlow = showNewLoginFlow
+        self.showLoginOptions = showLoginOptions
         self.showLoginOptionsFromSiteAddress = showLoginOptionsFromSiteAddress
         self.enableSignInWithApple = enableSignInWithApple
     }

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -155,7 +155,7 @@ extension WPStyleGuide {
         
         let button: UIButton
 
-        if WordPressAuthenticator.shared.configuration.showNewLoginFlow {
+        if WordPressAuthenticator.shared.configuration.showLoginOptions {
             let baseString =  NSLocalizedString("Or log in by _entering your site address_.", comment: "Label for button to log in using site address. Underscores _..._ denote underline.")
             
             let attrStrNormal = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonColor)

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -29,7 +29,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     var didFindSafariSharedCredentials = false
     var didRequestSafariSharedCredentials = false
     open var offerSignupOption = false
-    private let showNewLoginFlow = WordPressAuthenticator.shared.configuration.showNewLoginFlow
+    private let showLoginOptions = WordPressAuthenticator.shared.configuration.showLoginOptions
 
     private struct Constants {
         static let alternativeLogInAnimationDuration: TimeInterval = 0.33
@@ -46,8 +46,8 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         localizeControls()
         setupOnePasswordButtonIfNeeded()
         
-        alternativeLoginLabel?.isHidden = showNewLoginFlow
-        if !showNewLoginFlow {
+        alternativeLoginLabel?.isHidden = showLoginOptions
+        if !showLoginOptions {
             addGoogleButton()
         }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -105,7 +105,7 @@ class LoginPrologueViewController: LoginViewController {
     // MARK: - Actions
 
     private func loginTapped() {
-        if WordPressAuthenticator.shared.configuration.showNewLoginFlow {
+        if WordPressAuthenticator.shared.configuration.showLoginOptions {
             performSegue(withIdentifier: .showLoginMethod, sender: self)
         } else {
             performSegue(withIdentifier: .showEmailLogin, sender: self)


### PR DESCRIPTION
This change does the following:
- Renames `showNewLoginFlow` to `showLoginOptions`.
- Adds `enableUnifiedAuth` in preparation for Unified Auth project.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13394