### PR TITLE
Remove .showEmailLogin segue

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -116,6 +116,9 @@
 		CE30A2A722579F4100DF3CDA /* LoginUsernamePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */; };
 		CE30A2A92257C60500DF3CDA /* WordPressOrgCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */; };
 		CE30A2AD2257CECC00DF3CDA /* AuthenticatorCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */; };
+		CE5D486523F3117D003FB367 /* UIStoryboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5D486423F3117D003FB367 /* UIStoryboard+Helpers.swift */; };
+		CE5D486723F3349A003FB367 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5D486623F3349A003FB367 /* NSObject+Helpers.swift */; };
+		CE5D486923F33779003FB367 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5D486823F33779003FB367 /* UIViewController+Helpers.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
 		FF629D9622393500004C4106 /* WordPressAuthenticator.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */; };
 /* End PBXBuildFile section */
@@ -270,6 +273,9 @@
 		CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginUsernamePasswordViewController.swift; sourceTree = "<group>"; };
 		CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentials.swift; sourceTree = "<group>"; };
 		CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatorCredentials.swift; sourceTree = "<group>"; };
+		CE5D486423F3117D003FB367 /* UIStoryboard+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Helpers.swift"; sourceTree = "<group>"; };
+		CE5D486623F3349A003FB367 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
+		CE5D486823F33779003FB367 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
 		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -511,6 +517,9 @@
 				B56090EE208A527000399AE4 /* String+Underline.swift */,
 				B56090EC208A527000399AE4 /* WPStyleGuide+Login.swift */,
 				B5CDBED320B4714500BC1EF2 /* UIImage+Assets.swift */,
+				CE5D486423F3117D003FB367 /* UIStoryboard+Helpers.swift */,
+				CE5D486623F3349A003FB367 /* NSObject+Helpers.swift */,
+				CE5D486823F33779003FB367 /* UIViewController+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -903,6 +912,7 @@
 				B5609140208A563800399AE4 /* LoginSocialErrorCell.swift in Sources */,
 				B56090F7208A533200399AE4 /* WordPressAuthenticator+Errors.swift in Sources */,
 				B56090D2208A4F5400399AE4 /* NUXButton.swift in Sources */,
+				CE5D486723F3349A003FB367 /* NSObject+Helpers.swift in Sources */,
 				CE1B18C920EEC2C200BECC3F /* SocialService.swift in Sources */,
 				B56090D3208A4F5400399AE4 /* NUXLinkAuthViewController.swift in Sources */,
 				B5609120208A555E00399AE4 /* SignupNavigationController.swift in Sources */,
@@ -917,7 +927,9 @@
 				B5609116208A555600399AE4 /* LoginTextField.swift in Sources */,
 				B56090E2208A4F9D00399AE4 /* WPNUXSecondaryButton.m in Sources */,
 				B56090E6208A4F9D00399AE4 /* WPNUXPrimaryButton.m in Sources */,
+				CE5D486923F33779003FB367 /* UIViewController+Helpers.swift in Sources */,
 				B5609135208A563800399AE4 /* LoginWPComViewController.swift in Sources */,
+				CE5D486523F3117D003FB367 /* UIStoryboard+Helpers.swift in Sources */,
 				B5609119208A555600399AE4 /* SiteInfoHeaderView.swift in Sources */,
 				B560913E208A563800399AE4 /* SigninEditingState.swift in Sources */,
 				B56090CF208A4F5400399AE4 /* NUXCollectionViewController.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -164,8 +164,7 @@ import AuthenticationServices
             trackOpenedLogin()
         }
 
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
-        guard let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? LoginEmailViewController else {
+        guard let controller = LoginEmailViewController.instantiate(from: .login) else {
             return
         }
 
@@ -231,8 +230,7 @@ import AuthenticationServices
     /// This allows the host app to configure the controller's features.
     ///
     public class func signinForWPCom() -> LoginEmailViewController {
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
-        guard let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? LoginEmailViewController else {
+        guard let controller = LoginEmailViewController.instantiate(from: .login) else {
             fatalError()
         }
 

--- a/WordPressAuthenticator/Extensions/NSObject+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/NSObject+Helpers.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+
+// MARK - NSObject Helper Methods
+//
+extension NSObject {
+
+    /// Returns the receiver's classname as a string, not including the namespace.
+    ///
+    class var classNameWithoutNamespaces: String {
+        return String(describing: self)
+    }
+}

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+
+// MARK - Storyboard enum
+enum Storyboard: String {
+    case login
+
+    var instance: UIStoryboard {
+        return UIStoryboard(name: self.rawValue.capitalized, bundle: WordPressAuthenticator.bundle)
+    }
+
+    /// Returns a view controller from a Storyboard
+    /// assuming the identifier is the same as the class name.
+    ///
+    func instantiateViewController<T: NSObject>(ofClass classType: T.Type) -> T? {
+        let identifier = classType.classNameWithoutNamespaces
+        return instance.instantiateViewController(withIdentifier: identifier) as? T
+    }
+}

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -4,6 +4,7 @@ import Foundation
 // MARK - Storyboard enum
 enum Storyboard: String {
     case login
+    case signup
 
     var instance: UIStoryboard {
         return UIStoryboard(name: self.rawValue.capitalized, bundle: WordPressAuthenticator.bundle)

--- a/WordPressAuthenticator/Extensions/UIViewController+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIViewController+Helpers.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+
+extension UIViewController {
+
+    static func instantiate(from storyboard: Storyboard) -> Self? {
+        return storyboard.instantiateViewController(ofClass: self)
+    }
+}

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -25,7 +25,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     // MARK: associated type for NUXSegueHandler
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
-        case showEmailLogin
         case showSignupMethod
         case showSigninV2
         case showGoogle

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -157,10 +157,10 @@
         <!--Signup Email Entry-->
         <scene sceneID="gjg-iE-qSx">
             <objects>
-                <viewControllerPlaceholder storyboardName="Signup" referencedIdentifier="emailEntry" id="klu-4U-PyL" userLabel="Signup Email Entry" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="Signup" referencedIdentifier="SignupEmailViewController" id="klu-4U-PyL" userLabel="Signup Email Entry" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OWM-SL-SwW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2387" y="-231"/>
+            <point key="canvasLocation" x="2539" y="-262"/>
         </scene>
         <!--Login Email View Controller-->
         <scene sceneID="w6Y-pB-a3f">
@@ -375,10 +375,10 @@
             </objects>
             <point key="canvasLocation" x="1914" y="129"/>
         </scene>
-        <!--emailEntry-->
+        <!--SignupEmailViewController-->
         <scene sceneID="CQL-qu-sjW">
             <objects>
-                <viewControllerPlaceholder storyboardName="Signup" referencedIdentifier="emailEntry" id="T5n-nb-cOW" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="Signup" referencedIdentifier="SignupEmailViewController" id="T5n-nb-cOW" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UdV-y0-6AN" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-530" y="760"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -207,8 +207,8 @@
                                             <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="aJ6-Ep-HbW"/>
                                         </connections>
                                     </textField>
-                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
-                                        <rect key="frame" x="8" y="-65" width="383" height="582"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="606"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-yW-tzf">
                                                 <rect key="frame" x="0.0" y="223" width="383" height="167"/>
@@ -374,7 +374,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wWl-qb-1Yp" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1674" y="188"/>
+            <point key="canvasLocation" x="1914" y="129"/>
         </scene>
         <!--emailEntry-->
         <scene sceneID="CQL-qu-sjW">
@@ -601,23 +601,23 @@
                         <viewControllerLayoutGuide type="bottom" id="kOH-fr-1L0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="tEh-Nj-xof">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7OQ-0t-1zq">
-                                <rect key="frame" x="-4" y="44" width="383" height="623"/>
+                                <rect key="frame" x="-4" y="0.0" width="383" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-TJ-W9T">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="559"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="583"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
-                                                <rect key="frame" x="20" y="176.5" width="343" height="48"/>
+                                                <rect key="frame" x="20" y="188.5" width="343" height="48"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3be-99-g62">
-                                                <rect key="frame" x="0.0" y="256.5" width="383" height="74"/>
+                                                <rect key="frame" x="0.0" y="268.5" width="383" height="74"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
                                                         <rect key="frame" x="20" y="0.0" width="343" height="22"/>
@@ -661,7 +661,7 @@
                                                 </constraints>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                                <rect key="frame" x="20" y="350.5" width="343" height="18"/>
+                                                <rect key="frame" x="20" y="362.5" width="343" height="18"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="pswdErrorLabel"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
@@ -684,7 +684,7 @@
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
-                                        <rect key="frame" x="20" y="559" width="343" height="44"/>
+                                        <rect key="frame" x="20" y="583" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="141" height="30"/>
@@ -779,23 +779,23 @@
                         <viewControllerLayoutGuide type="bottom" id="fG1-qw-2YS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="cm5-76-st7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hTY-xb-H5h">
-                                <rect key="frame" x="-4" y="44" width="383" height="623"/>
+                                <rect key="frame" x="-4" y="0.0" width="383" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DHF-bN-so0">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="551"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="575"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
-                                                <rect key="frame" x="20" y="215.5" width="343" height="18"/>
+                                                <rect key="frame" x="20" y="227.5" width="343" height="18"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" textAlignment="natural" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="0.0" y="253.5" width="383" height="44"/>
+                                                <rect key="frame" x="0.0" y="265.5" width="383" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
                                                 <constraints>
@@ -825,7 +825,7 @@
                                                 </connections>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhF-jf-Wcv">
-                                                <rect key="frame" x="20" y="317.5" width="343" height="0.0"/>
+                                                <rect key="frame" x="20" y="329.5" width="343" height="0.0"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -845,7 +845,7 @@
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="x1G-Lf-mra">
-                                        <rect key="frame" x="20" y="551" width="343" height="44"/>
+                                        <rect key="frame" x="20" y="575" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="309-z3-fPx" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="0.0" width="131" height="44"/>
@@ -1038,23 +1038,23 @@
                         <viewControllerLayoutGuide type="bottom" id="rYV-q2-blN"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="CvY-vN-fn9">
-                        <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
+                        <rect key="frame" x="0.0" y="0.0" width="383" height="656"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a59-c7-WBk">
-                                <rect key="frame" x="-4" y="44" width="391" height="632"/>
+                                <rect key="frame" x="-4" y="0.0" width="391" height="656"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PIc-wF-cQF">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="556"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="580"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
-                                                <rect key="frame" x="20" y="198" width="351" height="38"/>
+                                                <rect key="frame" x="20" y="210" width="351" height="38"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="https://example.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="0.0" y="256" width="391" height="44"/>
+                                                <rect key="frame" x="0.0" y="268" width="391" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
                                                 <constraints>
@@ -1074,7 +1074,7 @@
                                                 </connections>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Up-9bc">
-                                                <rect key="frame" x="20" y="320" width="351" height="0.0"/>
+                                                <rect key="frame" x="20" y="332" width="351" height="0.0"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -1094,7 +1094,7 @@
                                         </constraints>
                                     </view>
                                     <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
-                                        <rect key="frame" x="20" y="556" width="351" height="44"/>
+                                        <rect key="frame" x="20" y="580" width="351" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="250" height="30"/>
@@ -1202,14 +1202,14 @@
                         <viewControllerLayoutGuide type="bottom" id="NPl-SI-4X2"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="UzI-Qm-mc3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O9q-gs-qUh">
-                                <rect key="frame" x="-4" y="44" width="383" height="623"/>
+                                <rect key="frame" x="-4" y="0.0" width="383" height="647"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hzZ-dr-nAB">
-                                        <rect key="frame" x="20" y="559" width="343" height="44"/>
+                                        <rect key="frame" x="20" y="583" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XI0-rr-yUh" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="141" height="30"/>
@@ -1259,13 +1259,13 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uk6-st-DBG">
-                                <rect key="frame" x="-4" y="64" width="383" height="539"/>
+                                <rect key="frame" x="-4" y="64" width="383" height="519"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-HN-aFE" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="20" y="27" width="343" height="200.5"/>
+                                        <rect key="frame" x="20" y="20" width="343" height="197.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-b4-JSG">
-                                                <rect key="frame" x="8" y="98.5" width="327" height="94"/>
+                                                <rect key="frame" x="8" y="98.5" width="327" height="91"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in with your WordPress.com account to manage your WooCommerce stores" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au1-mY-r58">
                                                         <rect key="frame" x="0.0" y="0.0" width="327" height="38"/>
@@ -1274,33 +1274,42 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="IMk-aA-1GF" userLabel="Header Stack View">
-                                                        <rect key="frame" x="0.0" y="58" width="327" height="36"/>
+                                                        <rect key="frame" x="0.0" y="58" width="327" height="33"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Gak-2q-wul" userLabel="Icon">
-                                                                <rect key="frame" x="0.0" y="7" width="18" height="22"/>
+                                                                <rect key="frame" x="0.0" y="5.5" width="18" height="22"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="c8o-Eq-kBi"/>
                                                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="r0G-JB-SfD"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DWy-yy-er4">
-                                                                <rect key="frame" x="28" y="0.0" width="299" height="36"/>
+                                                                <rect key="frame" x="28" y="0.0" width="299" height="33"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCX-uI-ruO" userLabel="Title">
                                                                         <rect key="frame" x="0.0" y="0.0" width="299" height="18"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="18" id="cbi-n2-THW"/>
+                                                                        </constraints>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUi-aQ-0SQ" userLabel="Subtitle">
-                                                                        <rect key="frame" x="0.0" y="18" width="299" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="18" width="299" height="15"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                 </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="33" id="6LX-48-kqd"/>
+                                                                </constraints>
                                                             </stackView>
                                                         </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="QP6-Ko-RaV"/>
+                                                        </constraints>
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
@@ -1319,7 +1328,7 @@
                                         </connections>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="52R-ls-Jbr">
-                                        <rect key="frame" x="0.0" y="247.5" width="383" height="88"/>
+                                        <rect key="frame" x="0.0" y="237.5" width="383" height="88"/>
                                         <subviews>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZUH-Y9-OaY" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
@@ -1359,7 +1368,7 @@
                                         </constraints>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vpd-vq-FQH">
-                                        <rect key="frame" x="20" y="355.5" width="343" height="0.0"/>
+                                        <rect key="frame" x="20" y="345.5" width="343" height="0.0"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -172,14 +172,14 @@
                         <viewControllerLayoutGuide type="bottom" id="tip-gy-Hwr"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="e5n-Bf-JaL">
-                        <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
+                        <rect key="frame" x="0.0" y="0.0" width="383" height="656"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ozJ-hT-OEw">
-                                <rect key="frame" x="0.0" y="44" width="383" height="632"/>
+                                <rect key="frame" x="0.0" y="0.0" width="383" height="656"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="327" y="568" width="36" height="44"/>
+                                        <rect key="frame" x="327" y="592" width="36" height="44"/>
                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="PgU-lW-anB"/>
@@ -196,7 +196,7 @@
                                         </connections>
                                     </button>
                                     <textField opaque="NO" alpha="0.10000000000000001" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="usY-bV-fpM" customClass="WPWalkthroughTextField">
-                                        <rect key="frame" x="1" y="630" width="1" height="1"/>
+                                        <rect key="frame" x="1" y="654" width="1" height="1"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="JlK-kU-NkS"/>
                                             <constraint firstAttribute="width" constant="1" id="gg9-4D-yft"/>
@@ -211,7 +211,7 @@
                                         <rect key="frame" x="8" y="-65" width="383" height="582"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-yW-tzf">
-                                                <rect key="frame" x="0.0" y="211" width="383" height="167"/>
+                                                <rect key="frame" x="0.0" y="223" width="383" height="167"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in to your WordPress.com account with your email address." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
                                                         <rect key="frame" x="20" y="0.0" width="343" height="38"/>
@@ -393,39 +393,39 @@
                         <viewControllerLayoutGuide type="bottom" id="Ktl-It-Kmo"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="HTO-Y8-god">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dSZ-FR-Cdo">
-                                <rect key="frame" x="-4" y="44" width="383" height="623"/>
+                                <rect key="frame" x="-4" y="0.0" width="383" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y8j-4r-VXw">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="559"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="583"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wnq-Hk-jIw" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="20" y="197.5" width="343" height="40"/>
+                                                <rect key="frame" x="20" y="213.5" width="343" height="36"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="40"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf" userLabel="Icon">
-                                                                <rect key="frame" x="0.0" y="0.0" width="36" height="40"/>
+                                                                <rect key="frame" x="0.0" y="7" width="18" height="22"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="F6S-wN-1Jp"/>
                                                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="Z7H-Ud-llZ"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uN1-Al-ygf">
-                                                                <rect key="frame" x="46" y="2" width="297" height="36"/>
+                                                                <rect key="frame" x="28" y="0.0" width="315" height="36"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehh-92-XG8" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="297" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="315" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6" userLabel="Subtitle">
-                                                                        <rect key="frame" x="0.0" y="18" width="297" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="18" width="315" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -449,7 +449,7 @@
                                                 </connections>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
-                                                <rect key="frame" x="0.0" y="257.5" width="383" height="88"/>
+                                                <rect key="frame" x="0.0" y="269.5" width="383" height="88"/>
                                                 <subviews>
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                         <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
@@ -489,7 +489,7 @@
                                                 </constraints>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dmn-nh-HTH">
-                                                <rect key="frame" x="20" y="365.5" width="343" height="0.0"/>
+                                                <rect key="frame" x="20" y="377.5" width="343" height="0.0"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -509,7 +509,7 @@
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zbk-h0-lpE">
-                                        <rect key="frame" x="20" y="559" width="343" height="44"/>
+                                        <rect key="frame" x="20" y="583" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="7" width="141" height="30"/>
@@ -940,11 +940,11 @@
                         <viewControllerLayoutGuide type="bottom" id="h4a-j8-84P"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="HnR-5a-suO">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Mq6-n0-6iO">
-                                <rect key="frame" x="36" y="184.5" width="303" height="258.5"/>
+                                <rect key="frame" x="36" y="174.5" width="303" height="258.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ukv-qo-ql4" customClass="CircularImageView" customModule="WordPressAuthenticator">
                                         <rect key="frame" x="101.5" y="0.0" width="100" height="100"/>
@@ -992,7 +992,7 @@
                                 </variation>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6x-b7-hU9" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
-                                <rect key="frame" x="0.0" y="617" width="375" height="30"/>
+                                <rect key="frame" x="0.0" y="597" width="375" height="30"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <state key="normal" title="Enter your password instead"/>
                                 <connections>
@@ -1472,8 +1472,8 @@
         <segue reference="UV4-XI-c0q"/>
         <segue reference="4SK-mG-U33"/>
         <segue reference="nCA-u7-fKm"/>
-        <segue reference="D3h-Su-Jwk"/>
-        <segue reference="swV-lc-6gI"/>
+        <segue reference="1xT-tL-sp6"/>
+        <segue reference="iD4-VS-n3M"/>
         <segue reference="gD5-d0-X3t"/>
         <segue reference="aSC-hU-lzE"/>
     </inferredMetricsTieBreakers>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -67,7 +67,7 @@
                     </view>
                     <connections>
                         <outlet property="dismissButton" destination="gpM-nW-lFQ" id="8iA-TH-TF4"/>
-                        <segue destination="fwZ-QE-5et" kind="show" identifier="showEmailLogin" id="1xT-tL-sp6"/>
+                        <segue destination="fwZ-QE-5et" kind="show" identifier="LoginEmailViewController" id="1xT-tL-sp6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fbD-KM-2nK" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -120,7 +120,6 @@
                         <segue destination="IwV-3R-6dB" kind="presentation" identifier="showSignupMethod" id="gD5-d0-X3t"/>
                         <segue destination="T5n-nb-cOW" kind="show" identifier="showSigninV2" id="nCA-u7-fKm"/>
                         <segue destination="MEg-KS-Afs" kind="show" identifier="showGoogle" id="aSC-hU-lzE"/>
-                        <segue destination="fwZ-QE-5et" kind="show" identifier="showEmailLogin" id="D3h-Su-Jwk"/>
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="N3P-wt-Rn3"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="Njv-lY-Lyi"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="UV4-XI-c0q"/>
@@ -166,7 +165,7 @@
         <!--Login Email View Controller-->
         <scene sceneID="w6Y-pB-a3f">
             <objects>
-                <viewController storyboardIdentifier="emailEntry" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="fwZ-QE-5et" customClass="LoginEmailViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginEmailViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="fwZ-QE-5et" customClass="LoginEmailViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="bn3-aC-RIM"/>
                         <viewControllerLayoutGuide type="bottom" id="tip-gy-Hwr"/>
@@ -1476,14 +1475,13 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="N3P-wt-Rn3"/>
-        <segue reference="Njv-lY-Lyi"/>
-        <segue reference="2Of-BA-xqb"/>
-        <segue reference="UV4-XI-c0q"/>
+        <segue reference="bK1-J1-hfT"/>
+        <segue reference="2Bq-Nv-ZkV"/>
+        <segue reference="ySQ-EM-6JI"/>
         <segue reference="4SK-mG-U33"/>
-        <segue reference="nCA-u7-fKm"/>
-        <segue reference="1xT-tL-sp6"/>
+        <segue reference="sIC-Hv-FJw"/>
         <segue reference="iD4-VS-n3M"/>
-        <segue reference="gD5-d0-X3t"/>
-        <segue reference="aSC-hU-lzE"/>
+        <segue reference="EmH-Av-vhT"/>
+        <segue reference="HMT-Z5-QHr"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -113,7 +113,12 @@ class LoginPrologueViewController: LoginViewController {
         if WordPressAuthenticator.shared.configuration.showLoginOptions {
             performSegue(withIdentifier: .showLoginMethod, sender: self)
         } else {
-            performSegue(withIdentifier: .showEmailLogin, sender: self)
+            guard let vc = LoginEmailViewController.instantiate(from: .login) else {
+                DDLogError("Failed to navigate to LoginEmailViewController from LoginPrologueViewController")
+                return
+            }
+
+            navigationController?.pushViewController(vc, animated: true)
         }
     }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -61,9 +61,14 @@ class LoginPrologueViewController: LoginViewController {
 
         else if let vc = segue.destination as? LoginPrologueLoginMethodViewController {
             vc.transitioningDelegate = self
-            
+
             vc.emailTapped = { [weak self] in
-                self?.performSegue(withIdentifier: .showEmailLogin, sender: self)
+                guard let vc = LoginEmailViewController.instantiate(from: .login) else {
+                    DDLogError("Failed to navigate to LoginEmailViewController")
+                    return
+                }
+
+                self?.navigationController?.pushViewController(vc, animated: true)
             }
             vc.googleTapped = { [weak self] in
                 self?.googleLoginTapped(withDelegate: self)

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -497,8 +497,7 @@ extension LoginViewController: LoginSocialErrorViewControllerDelegate {
     func retryAsSignup() {
         cleanupAfterSocialErrors()
 
-        let storyboard = UIStoryboard(name: "Signup", bundle: WordPressAuthenticator.bundle)
-        if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
+        if let controller = SignupEmailViewController.instantiate(from: .signup) {
             controller.loginFields = loginFields
             navigationController?.pushViewController(controller, animated: true)
         }

--- a/WordPressAuthenticator/Signup/Signup.storyboard
+++ b/WordPressAuthenticator/Signup/Signup.storyboard
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="N83-gK-pDm">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="N83-gK-pDm">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +13,7 @@
             <objects>
                 <navigationController id="N83-gK-pDm" customClass="SignupNavigationController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="hUd-8k-dJs">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -36,10 +33,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HbI-Pt-4Fr">
-                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="19Z-ie-Qfz">
-                                        <rect key="frame" x="0.0" y="221.5" width="375" height="102"/>
+                                        <rect key="frame" x="0.0" y="231.5" width="375" height="102"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CPF-7g-0y5">
                                                 <rect key="frame" x="20" y="0.0" width="335" height="38"/>
@@ -47,7 +44,7 @@
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HTy-KJ-his" customClass="LoginTextField" customModule="WordPressAuthenticator" >
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HTy-KJ-his" customClass="LoginTextField" customModule="WordPressAuthenticator">
                                                 <rect key="frame" x="0.0" y="58" width="375" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
@@ -85,8 +82,8 @@
                                             <constraint firstAttribute="trailing" secondItem="EYw-oM-W1K" secondAttribute="trailing" constant="20" id="q6O-HJ-f7f"/>
                                         </constraints>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Su-Zc-Omp" customClass="NUXButton" customModule="WordPressAuthenticator" >
-                                        <rect key="frame" x="319" y="539" width="36" height="44"/>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Su-Zc-Omp" customClass="NUXButton" customModule="WordPressAuthenticator">
+                                        <rect key="frame" x="319" y="559" width="36" height="44"/>
                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="6Qa-nw-X83"/>
@@ -148,13 +145,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="social-signup-waiting" translatesAutoresizingMaskIntoConstraints="NO" id="YhU-Hd-s0v">
-                                <rect key="frame" x="80" y="284" width="214.5" height="119"/>
+                                <rect key="frame" x="80" y="273.5" width="215" height="120"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="YhU-Hd-s0v" secondAttribute="height" multiplier="273:152" id="C7u-Fh-NUi"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is the title text." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fiA-2f-xfj">
-                                <rect key="frame" x="20" y="433" width="335" height="20.5"/>
+                                <rect key="frame" x="20" y="423.5" width="335" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="bqy-9g-gij"/>
                                 </constraints>
@@ -191,10 +188,10 @@
             </objects>
             <point key="canvasLocation" x="-358" y="190"/>
         </scene>
-        <!--emailEntry-->
+        <!--LoginEmailViewController-->
         <scene sceneID="JU2-CA-QR6">
             <objects>
-                <viewControllerPlaceholder storyboardName="Login" referencedIdentifier="emailEntry" id="J8B-jx-UJD" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="Login" referencedIdentifier="LoginEmailViewController" id="J8B-jx-UJD" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Y5k-uW-muf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-346" y="-127"/>

--- a/WordPressAuthenticator/Signup/Signup.storyboard
+++ b/WordPressAuthenticator/Signup/Signup.storyboard
@@ -27,7 +27,7 @@
         <!--Signup Email View Controller-->
         <scene sceneID="b2m-u4-I3H">
             <objects>
-                <viewController storyboardIdentifier="emailEntry" id="Opx-rl-H3d" customClass="SignupEmailViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SignupEmailViewController" id="Opx-rl-H3d" customClass="SignupEmailViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="F3A-pe-bcZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -142,13 +142,18 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
         let remote = AccountServiceRemoteREST(
             wordPressComRestApi: WordPressComRestApi(baseUrlString: WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL))
 
-        remote.isEmailAvailable(loginFields.emailAddress, success: { available in
+        remote.isEmailAvailable(loginFields.emailAddress, success: { [weak self] available in
             if !available {
                 defer {
                     WordPressAuthenticator.track(.signupEmailToLogin)
                 }
                 // If the user has already signed up redirect to the Login flow
-                self.performSegue(withIdentifier: .showEmailLogin, sender: self)
+                guard let vc = LoginEmailViewController.instantiate(from: .login) else {
+                    DDLogError("Failed to navigate to LoginEmailViewController from SignupEmailViewController")
+                    return
+                }
+
+                self?.navigationController?.pushViewController(vc, animated: true)
             }
             completion(available)
         }, failure: { error in


### PR DESCRIPTION
Master issue #182 - this is a spike to test removing segues.

This PR removes all references to the segue `.showEmailLogin` and programmatically navigates the user to the `LoginEmailViewController` screen. There are 3 areas where the segue has been removed: WPiOS sign up, WPiOS sign in, and WCiOS sign in.

### To Test - WPiOS
1. Check out this branch
2. Check out this branch for WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/tree/try/break-up-storyboard and point it to your local pod by changing the podfile location to your local copy of WordPressAuthenticator-iOS
3. Build the Authenticator project
4. `rake dependencies` on WPiOS
5. Build the WPiOS project. You are now set up with local pod development! 
6. Navigate to and back from each of these flows: 

1) Login > Continue with WordPress.com - should land on the LoginEmailViewController page
2) Sign up for WordPress.com > Sign up with Email >  Enter an email address that has an existing WP.com account and tap Next - should land on the LoginEmailViewController page

### To Test - WCiOS
1. Check out this branch
2. In the WCiOS project, open the podfile, comment out Authenticator and replace with local pod development. It will look similar to this: `pod 'WordPressAuthenticator', :path => '/Users/thuycopeland/WordPressAuthenticator-iOS/'` 
3. Build the Authenticator project
4. `rake dependencies` on WCiOS
5. Build the WCiOS project. You are now set up with local pod development! 
6. Navigate to and back from this flow: Log in with Jetpack > should show the expected LoginEmailViewController

### To Test - Newspack
When checking out the `develop` branch on Newspack, I see the Site Address flow. I don't think this PR applies to Newspack. Pinging @aerych just in case.