### PR TITLE
Fix error handling for email verification.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,9 +11,9 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  pod 'WordPressKit', '~> 4.5.6-beta.1'
+  pod 'WordPressKit', '~> 4.5.7.1'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/apple_2fa_auth'
-  pod 'WordPressShared', '~> 1.8.13-beta'
+  pod 'WordPressShared', '~> 1.8.0'
 
   ## Third party libraries
   ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,12 +44,12 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.5.6-beta.1):
+  - WordPressKit (4.5.7.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1)
-    - WordPressShared (~> 1.8.0)
+    - WordPressShared (~> 1.8.13-beta)
     - wpxmlrpc (= 0.8.4)
   - WordPressShared (1.8.15-beta.2):
     - CocoaLumberjack (~> 3.4)
@@ -71,8 +71,8 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.5.6-beta.1)
-  - WordPressShared (~> 1.8.13-beta)
+  - WordPressKit (~> 4.5.7.1)
+  - WordPressShared (~> 1.8.0)
   - WordPressUI (~> 1.4-beta.1)
 
 SPEC REPOS:
@@ -117,11 +117,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: eb6742df639843f5e7b2da9450da39d222b22ab8
+  WordPressKit: 72628bc40c4e74a508636f166fbd9183f47fc395
   WordPressShared: 28f28c072d5d97fbd892fa23d58f4205c2e09e90
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: cd6192c82a037e8dd61008367d1ca0b3398f17e7
+PODFILE CHECKSUM: a961e203e4cc376f2d9f4f18e65ec4dc9bcc6e9a
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.4-beta.1'
-  s.dependency 'WordPressKit', '~> 4.5.6-beta.1'
-  s.dependency 'WordPressShared', '~> 1.8.13-beta'
+  s.dependency 'WordPressKit', '~> 4.5.7.1'
+  s.dependency 'WordPressShared', '~> 1.8.0'
 end

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -152,12 +152,24 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
             }
             completion(available)
         }, failure: { error in
-            if let error = error {
-                DDLogError("Error checking email availability: \(error.localizedDescription)")
+            guard let error = error else {
+                self.displayError(message: ErrorMessage.availabilityCheckFail.description())
+                completion(false)
+                return
             }
-            // If check failed, display generic error message.
-            self.displayError(message: ErrorMessage.availabilityCheckFail.description())
-            completion(false)
+            
+            DDLogError("Error checking email availability: \(error.localizedDescription)")
+            
+            switch error {
+            case AccountServiceRemoteError.emailAddressInvalid:
+                fallthrough
+            case AccountServiceRemoteError.emailAddressTaken:
+                self.displayError(message: error.localizedDescription)
+                completion(false)
+            default:
+                self.displayError(message: ErrorMessage.availabilityCheckFail.description())
+                completion(false)
+            }
         })
     }
 


### PR DESCRIPTION
### Description

Moves forward https://github.com/wordpress-mobile/WordPress-iOS/issues/13583

This PR improves the error handling in WPAuth so that we don't ignore some error responses.

## Related branches and PRs:

WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/13585
WPKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/220

Once this is merged I'll open the WPiOS PR.

### Testing Details

#### Test 1:

Try signing up with a valid email account.  It should send you the magic link.

#### Test 2:

Try signing up with an invalid email provider.  For example "tester@mailinator.com".
You should see an error prompting you to use a different email provider.

#### Test 3:

Try singing up with a used email address (you can try with the email of your existing account).
You should see an error letting you know the email address is not available.

- [ ] Please check here if your pull request includes additional test coverage.
