### PR TITLE
Update WordPressKit pod to v4.6.0 beta.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  # pod 'WordPressKit', '~> 4.5.9-beta'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/224-update-wpxmlrpc-pod'
+  pod 'WordPressKit', '~> 4.6.0-beta.1'
+  #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/224-update-wpxmlrpc-pod'
   pod 'WordPressShared', '~> 1.8.13'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.15'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  pod 'WordPressKit', '~> 4.5.9-beta'
-  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/apple_2fa_auth'
+  # pod 'WordPressKit', '~> 4.5.9-beta'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/224-update-wpxmlrpc-pod'
   pod 'WordPressShared', '~> 1.8.13'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -50,12 +50,12 @@ PODS:
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.8.13-beta)
-    - wpxmlrpc (= 0.8.4)
+    - wpxmlrpc (= 0.8.5-beta.1)
   - WordPressShared (1.8.13):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.4-beta.1)
-  - wpxmlrpc (0.8.4)
+  - wpxmlrpc (0.8.5-beta.1)
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.8.5)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/224-update-wpxmlrpc-pod`)
+  - WordPressKit (~> 4.6.0-beta.1)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: issue/224-update-wpxmlrpc-pod
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 68fae371296313406e294a60e6e2f8cda7c7522e
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -126,11 +117,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: cec4dfcb3fb5aa04c08fd84b16452ab919474a20
+  WordPressKit: 769dca02698a7097b1dc2bf0d7c2aeb9c3cf38f8
   WordPressShared: fde9523bd00696fc1dfa45ed5299e16de111ebcc
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
-  wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
+  wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: c688709d675b8517105d2e15f808b9c90aa350f3
+PODFILE CHECKSUM: 731846f35dc585c867ce1af029d78c4bfb3bbf5f
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.5.9-beta.2):
+  - WordPressKit (4.6.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.5.9-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/224-update-wpxmlrpc-pod`)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: issue/224-update-wpxmlrpc-pod
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 68fae371296313406e294a60e6e2f8cda7c7522e
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -117,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: 54b1c041c59b871e91a331f24a2fb5d347e070b0
+  WordPressKit: cec4dfcb3fb5aa04c08fd84b16452ab919474a20
   WordPressShared: fde9523bd00696fc1dfa45ed5299e16de111ebcc
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: c8429d9d1b129c0d3f037b246b2a63567bf0f654
+PODFILE CHECKSUM: c688709d675b8517105d2e15f808b9c90aa350f3
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.4-beta.1'
-  s.dependency 'WordPressKit', '~> 4.6.0-beta.1'
+  s.dependency 'WordPressKit', '~> 4.5.9-beta'
   s.dependency 'WordPressShared', '~> 1.8.13-beta'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.4-beta.1'
-  s.dependency 'WordPressKit', '~> 4.5.9-beta'
+  s.dependency 'WordPressKit', '~> 4.6.0-beta.1'
   s.dependency 'WordPressShared', '~> 1.8.13-beta'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.10.9"
+  s.version       = "1.11.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.15'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.4-beta.1'
-  s.dependency 'WordPressKit', '~> 4.5.9-beta'
+  s.dependency 'WordPressKit', '~> 4.6.0-beta.1'
   s.dependency 'WordPressShared', '~> 1.8.13-beta'
 end


### PR DESCRIPTION
This PR updates the podfile to point to the feature branch for WordPress kit. 

Authenticator needs updated at the same time as WPiOS, as they both depend upon `wpkit` and expect the same version to be used in WPiOS.

**Known issues**
CircleCI podspec changes are broken on purpose. It's currently failing because the `wpxmlrpc` dependency version 4.6.0-beta.1 hasn't been published to CocoaPods yet. It's set to that declaration so that running `rake dependencies` in Authenticator and WPiOS will pass.

**Do not merge this PR until:**
1. The `wpxmlrpc` pod changes have been merged to develop ✔️ 
2. The `wpxmlrpc` podspec has been published to CocoaPods ✔️ 
3. This podfile points to the correct version of wpkit (4.6.0-beta.1) ✔️ 
4. This podspec shows the `WordPressKit` dependency version 4.6.0-beta.1 ✔️ 