### PR TITLE
Update NUX buttons when light/dark mode toggled.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.3"
+  s.version       = "1.11.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -41,6 +41,14 @@ import WordPressUI
         }
     }
 
+    open override func tintColorDidChange() {
+        // Update colors when toggling light/dark mode.
+        super.tintColorDidChange()
+        configureBackgrounds()
+        configureTitleColors()
+    }
+
+
     // MARK: - Instance Methods
 
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/12441

This updates the NUX buttons when light/dark mode is toggled.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13636