### PR TITLE
Update version of WordPressKit to 4.6.0-beta.6

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.20-beta.1'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  pod 'WordPressKit', '~> 4.6.0-beta.2'
-  #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/224-update-wpxmlrpc-pod'
+  #pod 'WordPressKit', '~> 4.6.0-beta.6'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/79-migrate-swift-5'
   pod 'WordPressShared', '~> 1.8.13'
 
   ## Third party libraries
@@ -23,7 +23,7 @@ def wordpress_authenticator_pods
   pod 'CocoaLumberjack', '3.5.2'
   pod 'GoogleSignIn', '4.4.0'
   pod 'lottie-ios', '2.5.2'
-  pod 'NSURL+IDN', '0.3'
+  pod 'NSURL+IDN', '0.4'
   pod 'SVProgressHUD', '2.2.5'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.20-beta.1'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  #pod 'WordPressKit', '~> 4.6.0-beta.6'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/79-migrate-swift-5'
+  pod 'WordPressKit', '~> 4.6.0-beta.6'
+  #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/79-migrate-swift-5'
   pod 'WordPressShared', '~> 1.8.13'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/79-migrate-swift-5`)
+  - WordPressKit (~> 4.6.0-beta.6)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: issue/79-migrate-swift-5
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 1a219b3095835dc204fded6eeb13c7e3a09850d7
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -131,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 4e08e8480e3428d23186cd6b917e3842616619dd
+PODFILE CHECKSUM: 068e02be265114c0d3e8b5505b680cb23aceddcd
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,8 +23,8 @@ PODS:
   - Gridicons (0.20-beta.1)
   - GTMSessionFetcher/Core (1.3.1)
   - lottie-ios (2.5.2)
-  - NSObject-SafeExpectations (0.0.3)
-  - "NSURL+IDN (0.3)"
+  - NSObject-SafeExpectations (0.0.4)
+  - "NSURL+IDN (0.4)"
   - OCMock (3.6)
   - OHHTTPStubs (8.0.0):
     - OHHTTPStubs/Default (= 8.0.0)
@@ -44,12 +44,12 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.6.0-beta.2):
+  - WordPressKit (4.6.0-beta.6):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
-    - NSObject-SafeExpectations (= 0.0.3)
+    - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
-    - WordPressShared (~> 1.8.13-beta)
+    - WordPressShared (~> 1.8.15-beta)
     - wpxmlrpc (= 0.8.5-beta.1)
   - WordPressShared (1.8.15):
     - CocoaLumberjack (~> 3.4)
@@ -65,13 +65,13 @@ DEPENDENCIES:
   - GoogleSignIn (= 4.4.0)
   - Gridicons (~> 0.20-beta.1)
   - lottie-ios (= 2.5.2)
-  - "NSURL+IDN (= 0.3)"
+  - "NSURL+IDN (= 0.4)"
   - OCMock (~> 3.4)
   - OHHTTPStubs (= 8.0.0)
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.6.0-beta.2)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/79-migrate-swift-5`)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: issue/79-migrate-swift-5
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 1a219b3095835dc204fded6eeb13c7e3a09850d7
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -110,18 +119,18 @@ SPEC CHECKSUMS:
   Gridicons: a89c04840b560895223a2c5c1e1299b518e0fc6f
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
-  NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
-  "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
+  NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
+  "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
   OHHTTPStubs: 9cbce6364bec557cc3439aa6bb7514670d780881
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: 36f3dd07e27cee3153ea0d77b9802bc4fec48c19
+  WordPressKit: c6f6f2b4a47bd042bfb35f4f7b0225fd857d5007
   WordPressShared: 02e0947034648cbd7251ffcc10f64d512f93a53b
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 52b3df23b7561e96f203b0752935d9e9477b1f10
+PODFILE CHECKSUM: 4e08e8480e3428d23186cd6b917e3842616619dd
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.20-beta.1'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.4-beta.1'
-  s.dependency 'WordPressKit', '~> 4.6.0-beta.2'
+  s.dependency 'WordPressKit', '~> 4.6.0-beta.6'
   s.dependency 'WordPressShared', '~> 1.8.13-beta'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.4"
+  s.version       = "1.11.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
This PR updates Authenticator to use the most recent version of WordPressKit. 
Ref. https://github.com/wordpress-mobile/WordPressKit-iOS/pull/232

**Do not merge until:**
- WordPressKit Swift 5 migration PR is merged first (above ref.) ✔️
- WordPressKit release has been published on CocoaPods ✔️
- this podfile has been updated to point to 4.6.0-beta.6 instead of a branch ✔️