### PR TITLE
Update WP signup button style.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.6"
+  s.version       = "1.11.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.5"
+  s.version       = "1.11.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -184,10 +184,10 @@ extension WPStyleGuide {
     /// - Note: This button is only used during Jetpack setup, not the usual flows
     ///
     class func wpcomSignupButton() -> UIButton {
+        let style = WordPressAuthenticator.shared.style
         let baseString = NSLocalizedString("Don't have an account? _Sign up_", comment: "Label for button to log in using your site address. The underscores _..._ denote underline")
-        let attrStrNormal = baseString.underlined(color: WPStyleGuide.greyDarken20(), underlineColor: WPStyleGuide.wordPressBlue())
-        let attrStrHighlight = baseString.underlined(color: WPStyleGuide.greyDarken20(), underlineColor: WPStyleGuide.lightBlue())
-
+        let attrStrNormal = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonColor)
+        let attrStrHighlight = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonHighlightColor)
         let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 
         return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font)


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/13441

This updates the style of the `Don't have an account?` button to match the log in by site address button.

<img width="279" alt="Screen Shot 2020-03-13 at 2 51 01 PM" src="https://user-images.githubusercontent.com/1816888/76658589-1307ac80-653a-11ea-82f1-50d642e2c13b.png">

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13652