### PR TITLE
Update Lottie

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ def wordpress_authenticator_pods
   pod 'Alamofire', '4.8'
   pod 'CocoaLumberjack', '3.5.2'
   pod 'GoogleSignIn', '4.4.0'
-  pod 'lottie-ios', '2.5.2'
+  pod 'lottie-ios', '3.1.6'
   pod 'NSURL+IDN', '0.4'
   pod 'SVProgressHUD', '2.2.5'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
   - Gridicons (0.20-beta.1)
   - GTMSessionFetcher/Core (1.3.1)
-  - lottie-ios (2.5.2)
+  - lottie-ios (3.1.6)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
   - OCMock (3.6)
@@ -64,7 +64,7 @@ DEPENDENCIES:
   - Expecta (= 1.0.6)
   - GoogleSignIn (= 4.4.0)
   - Gridicons (~> 0.20-beta.1)
-  - lottie-ios (= 2.5.2)
+  - lottie-ios (= 3.1.6)
   - "NSURL+IDN (= 0.4)"
   - OCMock (~> 3.4)
   - OHHTTPStubs (= 8.0.0)
@@ -109,7 +109,7 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
   Gridicons: a89c04840b560895223a2c5c1e1299b518e0fc6f
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
-  lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
+  lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
@@ -122,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 068e02be265114c0d3e8b5505b680cb23aceddcd
+PODFILE CHECKSUM: 03cc79718f43514bcbc8fcda080d47758031a031
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.6"
+  s.version       = "1.11.0-beta.9"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency '1PasswordExtension', '1.8.5'
   s.dependency 'Alamofire', '4.8'
   s.dependency 'CocoaLumberjack', '~> 3.5'
-  s.dependency 'lottie-ios', '2.5.2'
+  s.dependency 'lottie-ios', '3.1.6'
   s.dependency 'NSURL+IDN', '0.4'
   s.dependency 'SVProgressHUD', '2.2.5'
 

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -207,8 +207,8 @@
                                             <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="aJ6-Ep-HbW"/>
                                         </connections>
                                     </textField>
-                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
-                                        <rect key="frame" x="8" y="-65" width="383" height="582"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="582"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-yW-tzf">
                                                 <rect key="frame" x="0.0" y="211" width="383" height="167"/>
@@ -403,29 +403,29 @@
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="559"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wnq-Hk-jIw" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="20" y="197.5" width="343" height="40"/>
+                                                <rect key="frame" x="20" y="201.5" width="343" height="36"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="40"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf" userLabel="Icon">
-                                                                <rect key="frame" x="0.0" y="0.0" width="36" height="40"/>
+                                                                <rect key="frame" x="0.0" y="7" width="18" height="22"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="F6S-wN-1Jp"/>
                                                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="Z7H-Ud-llZ"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uN1-Al-ygf">
-                                                                <rect key="frame" x="46" y="2" width="297" height="36"/>
+                                                                <rect key="frame" x="28" y="0.0" width="315" height="36"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehh-92-XG8" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="297" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="315" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6" userLabel="Subtitle">
-                                                                        <rect key="frame" x="0.0" y="18" width="297" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="18" width="315" height="18"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>

--- a/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
@@ -8,7 +8,7 @@ class LoginProloguePromoViewController: UIViewController {
     fileprivate let stackView: UIStackView
     fileprivate let headingLabel: UILabel
     fileprivate let animationHolder: UIView
-    fileprivate var animationView: LOTAnimationView
+    fileprivate var animationView: AnimationView
 
     fileprivate struct Constants {
         static let stackSpacing: CGFloat = 36.0
@@ -41,7 +41,7 @@ class LoginProloguePromoViewController: UIViewController {
             case .notifications:
                 return NSLocalizedString("Your notifications travel with you — see comments and likes as they happen.", comment: "shown in promotional screens during first launch")
             case .jetpack:
-                return NSLocalizedString("Manage your Jetpack-powered site on the go — you‘ve got WordPress in your pocket.", comment: "shown in promotional screens during first launch")
+                return NSLocalizedString("Manage your Jetpack-powered site on the go — you've got WordPress in your pocket.", comment: "shown in promotional screens during first launch")
             }
         }
 
@@ -57,7 +57,7 @@ class LoginProloguePromoViewController: UIViewController {
         animationHolder = UIView()
 
         let bundle = WordPressAuthenticator.bundle
-        animationView = LOTAnimationView(name: type.animationKey, bundle: bundle)
+        animationView = AnimationView(name: type.animationKey, bundle: bundle)
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -96,7 +96,7 @@ class LoginProloguePromoViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        animationView.animationProgress = 0.0
+        animationView.currentProgress = 0.0
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Fixes #84 

This PR updates Lottie from `2.5.2` to `3.1.6`, and migrates the code from 2.x to 3.x

Ref. https://github.com/wordpress-mobile/WordPress-iOS/pull/13663

### To test
1. `bundle exec pod install`
2. run unit tests
3. build and run

