### PR TITLE
Updating magic link instruction text.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.9"
+  s.version       = "1.11.0-beta.10"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
@@ -75,7 +75,7 @@ class NUXLinkMailViewController: LoginViewController {
 
         usePasswordButton?.isHidden = emailMagicLinkSource == .signup
 
-        label?.text = NSLocalizedString("Check your email on this device, and tap the link in the email you receive from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder.", comment: "Instructional text on how to open the email containing a magic link.")
+        label?.text = NSLocalizedString("Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder.", comment: "Instructional text on how to open the email containing a magic link.")
 
         label?.textColor = WordPressAuthenticator.shared.style.instructionColor
     }

--- a/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
@@ -75,14 +75,8 @@ class NUXLinkMailViewController: LoginViewController {
 
         usePasswordButton?.isHidden = emailMagicLinkSource == .signup
 
-        label?.text = {
-            switch emailMagicLinkSource {
-            case .login:
-                return NSLocalizedString("Your magic link is on its way! Check your email on this device, and tap the link in the email you receive from WordPress.com", comment: "Instructional text on how to open the email containing a magic link.")
-            case .signup:
-                return NSLocalizedString("We sent you a magic signup link! Check your email on this device, and tap the link in the email to finish signing up.", comment: "Instructional text on how to open the email containing a magic link.")
-            }
-        }()
+        label?.text = NSLocalizedString("Check your email on this device, and tap the link in the email you receive from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder.", comment: "Instructional text on how to open the email containing a magic link.")
+
         label?.textColor = WordPressAuthenticator.shared.style.instructionColor
     }
 


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/13664

This updates the Signup and Login Magic Link confirmation screen advising the user to check their spam/junk folder.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13665