### PR TITLE
Fixed a SignUp regression.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ def wordpress_authenticator_pods
   pod 'WordPressUI', '~> 1.4-beta.1'
   #pod 'WordPressKit', '~> 4.6.0-beta.7'
   #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '553c6a80173914d104bea74f531f29cf9ce18c9f'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '161e25634814566c260fb48530179d70279b2d66'
   pod 'WordPressShared', '~> 1.8.13'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -11,9 +11,9 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.20-beta.1'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  #pod 'WordPressKit', '~> 4.6.0-beta.7'
+  pod 'WordPressKit', '~> 4.6.0-beta.8'
   #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '161e25634814566c260fb48530179d70279b2d66'
+  #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
   pod 'WordPressShared', '~> 1.8.13'
 
   ## Third party libraries

--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,9 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 0.20-beta.1'
   pod 'WordPressUI', '~> 1.4-beta.1'
-  pod 'WordPressKit', '~> 4.6.0-beta.6'
-  #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/79-migrate-swift-5'
+  #pod 'WordPressKit', '~> 4.6.0-beta.7'
+  #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '553c6a80173914d104bea74f531f29cf9ce18c9f'
   pod 'WordPressShared', '~> 1.8.13'
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.6.0-beta.6):
+  - WordPressKit (4.6.0-beta.7):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.6.0-beta.6)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `553c6a80173914d104bea74f531f29cf9ce18c9f`)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :commit: 553c6a80173914d104bea74f531f29cf9ce18c9f
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 553c6a80173914d104bea74f531f29cf9ce18c9f
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -117,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: c6f6f2b4a47bd042bfb35f4f7b0225fd857d5007
+  WordPressKit: af813ac74d5248bbc2b89e274dc023b6e960e000
   WordPressShared: ddcb40e608bc0f0162cce5e8df006584febcec50
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 03cc79718f43514bcbc8fcda080d47758031a031
+PODFILE CHECKSUM: 4f119c7e5bbcc9690a1d60afc7ed9f1817591c14
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `161e25634814566c260fb48530179d70279b2d66`)
+  - WordPressKit (~> 4.6.0-beta.8)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :commit: 161e25634814566c260fb48530179d70279b2d66
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 161e25634814566c260fb48530179d70279b2d66
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -131,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: c85b5b495885c8195ff6356daa69c5f1791d904c
+PODFILE CHECKSUM: 3d50fab3a75d681b60405f50bb5a9ce65f928c0f
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.6.0-beta.7):
+  - WordPressKit (4.6.0-beta.8):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `553c6a80173914d104bea74f531f29cf9ce18c9f`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `161e25634814566c260fb48530179d70279b2d66`)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.4-beta.1)
 
@@ -100,12 +100,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressKit:
-    :commit: 553c6a80173914d104bea74f531f29cf9ce18c9f
+    :commit: 161e25634814566c260fb48530179d70279b2d66
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressKit:
-    :commit: 553c6a80173914d104bea74f531f29cf9ce18c9f
+    :commit: 161e25634814566c260fb48530179d70279b2d66
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -126,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: af813ac74d5248bbc2b89e274dc023b6e960e000
+  WordPressKit: eb884caeba0fab58ea1e99ceee2403559c4e99a4
   WordPressShared: ddcb40e608bc0f0162cce5e8df006584febcec50
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 4f119c7e5bbcc9690a1d60afc7ed9f1817591c14
+PODFILE CHECKSUM: c85b5b495885c8195ff6356daa69c5f1791d904c
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.10"
+  s.version       = "1.11.0-beta.11"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 0.20-beta'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.5-beta'
-  s.dependency 'WordPressKit', '~> 4.6.0-beta.6'
+  s.dependency 'WordPressKit', '~> 4.6.0-beta.8'
   s.dependency 'WordPressShared', '~> 1.8.16-beta'
 end

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -164,8 +164,6 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
             case AccountServiceRemoteError.emailAddressInvalid:
                 self.displayError(message: error.localizedDescription)
                 completion(false)
-            case AccountServiceRemoteError.emailAddressTaken:
-                completion(false)
             default:
                 self.displayError(message: ErrorMessage.availabilityCheckFail.description())
                 completion(false)

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -162,9 +162,9 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
             
             switch error {
             case AccountServiceRemoteError.emailAddressInvalid:
-                fallthrough
-            case AccountServiceRemoteError.emailAddressTaken:
                 self.displayError(message: error.localizedDescription)
+                completion(false)
+            case AccountServiceRemoteError.emailAddressTaken:
                 completion(false)
             default:
                 self.displayError(message: ErrorMessage.availabilityCheckFail.description())


### PR DESCRIPTION
## Description

Fixes a signup regression.  Existing accounts should be redirected to login, instead of displaying an error.

## Associated branches and PRs:

WPiOS: `try/fix-signup-issue`
WPKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/235

## Testing Details

These tests are the same we did on the WPKit PR.  Since the code hasn't changed since that PR was tested, there may not be a need to re-check all 3 cases here.

### Test 1:

1. Check out the WPiOS branch.
2. Install the pods.
3. Run the app from scratch.
4. Try to sign up with an existing account.

Verify that you're redirected to login and that you an complete the login process.

### Test 2:

Same test steps as in Test 1, but try to sign up with a mailinator account instead (any random account will do, like `testing@mailinator.com`).

Verify that there's an error message explaining this email provider is not supported by us.

### Test 3:

Same test steps as in Test 1 and 2, but try to sign up using a valid / supported email account instead.

Verify that signup works.