### PR TITLE
Update Google button appearance

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.11"
+  s.version       = "1.11.0-beta.12"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -21,7 +21,9 @@ extension WPStyleGuide {
         static let buttonMinHeight: CGFloat = 50.0
 
         static let textButtonMinHeight: CGFloat = 40.0
-        static let googleIconOffset: CGFloat = -1.0
+        static let googleIconHyperlinkOffset: CGFloat = -1.0
+        static let googleIconButtonOffset: CGFloat = -2.0
+        static let googleIconButtonSize: CGFloat = 15.0
         static let domainsIconPaddingToRemove: CGFloat = 2.0
         static let domainsIconSize = CGSize(width: 18, height: 18)
         static let verticalLabelSpacing: CGFloat = 10.0
@@ -111,7 +113,7 @@ extension WPStyleGuide {
 
     // MARK: - Login Button Methods
 
-    /// Creates a button for Google Sign-in
+    /// Creates a button for Google Sign-in with hyperlink style.
     ///
     /// - Returns: A properly styled UIButton
     ///
@@ -126,6 +128,43 @@ extension WPStyleGuide {
         return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font)
     }
 
+    /// Creates an attributed string that includes the Google logo.
+    ///
+    /// - Parameters:
+    ///     - forHyperlink: Indicates if the string will be displayed in a hyperlink.
+    ///                     Otherwise, it will be styled to be displayed on a NUXButton.
+    /// - Returns: A properly styled NSAttributedString
+    ///
+    class func formattedGoogleString(forHyperlink: Bool = false) -> NSAttributedString {
+        
+        let googleAttachment = NSTextAttachment()
+        let googleIcon = UIImage.googleIcon
+        googleAttachment.image = googleIcon
+        
+        if forHyperlink {
+            // Create an attributed string that contains the Google icon.
+            let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
+            googleAttachment.bounds = CGRect(x: 0,
+                                             y: font.descender + Constants.googleIconHyperlinkOffset,
+                                             width: googleIcon.size.width,
+                                             height: googleIcon.size.height)
+
+            return NSAttributedString(attachment: googleAttachment)
+        } else {
+            // Create an attributed string that contains the Google icon + button text.
+            googleAttachment.bounds = CGRect(x: 0,
+                                             y: Constants.googleIconButtonOffset,
+                                             width: Constants.googleIconButtonSize,
+                                             height: Constants.googleIconButtonSize)
+
+            let buttonString = NSMutableAttributedString(attachment: googleAttachment)
+            let googleTitle = NSLocalizedString(" Continue with Google", comment: "Button title. Tapping begins log in using Google. There is a leading space to separate it from the Google logo.")
+            buttonString.append(NSAttributedString(string: googleTitle))
+
+            return buttonString
+        }
+    }
+    
     /// Creates a button for Apple Sign-in
     ///
     /// - Returns: A properly styled UIControl
@@ -235,7 +274,6 @@ extension WPStyleGuide {
 
     private class func googleButtonString(_ baseString: String, linkColor: UIColor) -> NSAttributedString {
         let labelParts = baseString.components(separatedBy: "{G}")
-        let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 
         let firstPart = labelParts[0]
         // 👇 don't want to crash when a translation lacks "{G}"
@@ -244,12 +282,7 @@ extension WPStyleGuide {
         let labelString = NSMutableAttributedString(string: firstPart, attributes: [.foregroundColor: WPStyleGuide.greyDarken30()])
 
         if lastPart != "" {
-            let googleIcon = UIImage.googleIcon
-            let googleAttachment = NSTextAttachment()
-            googleAttachment.image = googleIcon
-            googleAttachment.bounds = CGRect(x: 0.0, y: font.descender + Constants.googleIconOffset, width: googleIcon.size.width, height: googleIcon.size.height)
-            let iconString = NSAttributedString(attachment: googleAttachment)
-            labelString.append(iconString)
+            labelString.append(formattedGoogleString(forHyperlink: true))
         }
 
         labelString.append(NSAttributedString(string: lastPart, attributes: [.foregroundColor: linkColor]))

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressKit
 
 @objc public protocol NUXButtonViewControllerDelegate {
     func primaryButtonPressed()
@@ -9,13 +10,15 @@ import UIKit
 private struct NUXButtonConfig {
     typealias CallBackType = () -> Void
 
-    let title: String
+    let title: String?
+    let attributedTitle: NSAttributedString?
     let isPrimary: Bool
     let accessibilityIdentifier: String?
     let callback: CallBackType?
 
-    init(title: String, isPrimary: Bool, accessibilityIdentifier: String? = nil, callback: CallBackType?) {
+    init(title: String? = nil, attributedTitle: NSAttributedString? = nil, isPrimary: Bool, accessibilityIdentifier: String? = nil, callback: CallBackType?) {
         self.title = title
+        self.attributedTitle = attributedTitle
         self.isPrimary = isPrimary
         self.accessibilityIdentifier = accessibilityIdentifier
         self.callback = callback
@@ -61,7 +64,13 @@ open class NUXButtonViewController: UIViewController {
 
     private func configure(button: NUXButton?, withConfig buttonConfig: NUXButtonConfig?) {
         if let buttonConfig = buttonConfig, let button = button {
-            button.setTitle(buttonConfig.title, for: .normal)
+            
+            if let attributedTitle = buttonConfig.attributedTitle {
+                button.setAttributedTitle(attributedTitle, for: .normal)
+            } else {
+                button.setTitle(buttonConfig.title, for: .normal)
+            }
+            
             button.accessibilityIdentifier = buttonConfig.accessibilityIdentifier ?? accessibilityIdentifier(for: buttonConfig.title)
             button.isPrimary = buttonConfig.isPrimary
             button.isHidden = false
@@ -98,6 +107,26 @@ open class NUXButtonViewController: UIViewController {
 
     func setupBottomButton(title: String, isPrimary: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {
         bottomButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
+    }
+    
+    func setupButtomButtonFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) {
+
+        var attributedTitle = NSAttributedString()
+        var accessibilityIdentifier = String()
+        
+        switch socialService {
+        case .google:
+            attributedTitle = WPStyleGuide.formattedGoogleString()
+            accessibilityIdentifier = "Continue with Google Button"
+        default:
+            // TODO: add Apple support when add custom SIWA button.
+            DDLogInfo("Apple not yet supported.")
+        }
+
+        bottomButtonConfig = NUXButtonConfig(attributedTitle: attributedTitle,
+                                             isPrimary: false,
+                                             accessibilityIdentifier: accessibilityIdentifier,
+                                             callback: callback)
     }
 
     func setupTertiaryButton(title: String, isPrimary: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -45,16 +45,8 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
             self?.dismiss(animated: true)
             self?.emailTapped?()
         }
-
-        let googleTitle = NSLocalizedString("Continue with Google", comment: "Button title. Tapping begins log in using Google.")
-        buttonViewController.setupBottomButton(title: googleTitle, isPrimary: false, accessibilityIdentifier: "Log in with Google Button") { [weak self] in
-            defer {
-                WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "google"])
-            }
-
-            self?.dismiss(animated: true)
-            self?.googleTapped?()
-        }
+        
+        buttonViewController.setupButtomButtonFor(socialService: .google, onTap: handleGoogleButtonTapped)
 
         if !LoginFields().restrictToWPCom && selfHostedTapped != nil {
             let selfHostedLoginButton = WPStyleGuide.selfHostedLoginButton(alignment: .center)
@@ -89,6 +81,13 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
         appleTapped?()
     }
 
+    @objc func handleGoogleButtonTapped() {
+        WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "google"])
+
+        dismiss(animated: true)
+        googleTapped?()
+    }
+    
     // MARK: - Accessibility
 
     private func configureForAccessibility() {

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -42,7 +42,6 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         }
 
         let loginTitle = NSLocalizedString("Sign up with Email", comment: "Button title. Tapping begins our normal sign up process.")
-        let createTitle = NSLocalizedString("Sign up with Google", comment: "Button title. Tapping begins sign up using Google.")
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Sign up with Email Button") { [weak self] in
             defer {
                 WordPressAuthenticator.track(.signupEmailButtonTapped)
@@ -51,14 +50,8 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
             self?.emailTapped?()
         }
 
-        buttonViewController.setupBottomButton(title: createTitle, isPrimary: false, accessibilityIdentifier: "Sign up with Google Button") { [weak self] in
-            defer {
-                WordPressAuthenticator.track(.signupSocialButtonTapped, properties: ["source": "google"])
-            }
+        buttonViewController.setupButtomButtonFor(socialService: .google, onTap: handleGoogleButtonTapped)
 
-            self?.dismiss(animated: true)
-            self?.googleTapped?()
-        }
         let termsButton = WPStyleGuide.termsButton()
         termsButton.on(.touchUpInside) { [weak self] button in
             defer {
@@ -96,6 +89,13 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         appleTapped?()
     }
 
+    @objc func handleGoogleButtonTapped() {
+        WordPressAuthenticator.track(.signupSocialButtonTapped, properties: ["source": "google"])
+
+        dismiss(animated: true)
+        googleTapped?()
+    }
+    
     private func trackCancellationAndThenDismiss() {
         WordPressAuthenticator.track(.signupCancelled)
         dismiss(animated: true)


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/13620

This updates the appearance of the Google button shown in the login and signup flows.

<img width="438" alt="Screen Shot 2020-03-17 at 2 33 20 PM" src="https://user-images.githubusercontent.com/1816888/76898936-44df8280-685c-11ea-98a1-aa8031579bf7.png">


Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13675