### PR TITLE
Updated 1PasswordExtension to a version that removes the support for UIWebView

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -19,7 +19,7 @@ def wordpress_authenticator_pods
   ## Third party libraries
   ## =====================
   ##
-  pod '1PasswordExtension', '1.8.5'
+  pod '1PasswordExtension', '1.8.6'
   pod 'Alamofire', '4.8'
   pod 'CocoaLumberjack', '3.5.2'
   pod 'GoogleSignIn', '4.4.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - 1PasswordExtension (1.8.5)
+  - 1PasswordExtension (1.8.6)
   - Alamofire (4.8.0)
   - CocoaLumberjack (3.5.2):
     - CocoaLumberjack/Core (= 3.5.2)
@@ -58,7 +58,7 @@ PODS:
   - wpxmlrpc (0.8.5-beta.1)
 
 DEPENDENCIES:
-  - 1PasswordExtension (= 1.8.5)
+  - 1PasswordExtension (= 1.8.6)
   - Alamofire (= 4.8)
   - CocoaLumberjack (= 3.5.2)
   - Expecta (= 1.0.6)
@@ -100,7 +100,7 @@ SPEC REPOS:
     - wpxmlrpc
 
 SPEC CHECKSUMS:
-  1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
+  1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -122,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 3d50fab3a75d681b60405f50bb5a9ce65f928c0f
+PODFILE CHECKSUM: 00b5323488731c72c574a2a8ff0563aaa76880db
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.12"
+  s.version       = "1.11.0-beta.13"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.static_framework = true # This is needed because GoogleSignIn vendors a static framework
   s.header_dir    = 'WordPressAuthenticator'
 
-  s.dependency '1PasswordExtension', '1.8.5'
+  s.dependency '1PasswordExtension', '1.8.6'
   s.dependency 'Alamofire', '4.8'
   s.dependency 'CocoaLumberjack', '~> 3.5'
   s.dependency 'lottie-ios', '3.1.6'

--- a/WordPressAuthenticator/Services/OnePasswordFacade.swift
+++ b/WordPressAuthenticator/Services/OnePasswordFacade.swift
@@ -133,8 +133,8 @@ enum OnePasswordError: Error {
     case unknown
 
     init(error: NSError) {
-        switch error.code {
-        case Int(AppExtensionErrorCodeCancelledByUser):
+        switch AppExtensionErrorCode.init(rawValue: UInt(error.code)) {
+        case .cancelledByUser:
             self = .cancelledByUser
         default:
             self = .unknown


### PR DESCRIPTION
This PR updates 1PasswordExtension from 1.8.5 to 1.8.6, and migrates a small piece of code.

Ref. https://github.com/woocommerce/woocommerce-ios/issues/1929 

## Changelog of 1PasswordExtension 1.8.6:
```
[IMPROVED] Moves all projects forward to Xcode 11 format
[IMPROVED] Updates build settings and localization targets
[IMPROVED] Converts swift projects to Swift 5
[IMPROVED] Moves the bar forward from iOS 7 to iOS 9
[IMPROVED] Removes all support for UIWebView <- ** this is what we are looking for **
[IMPROVED] Removes the deprecated call - (void)fillLoginIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nonnull OnePasswordSuccessCompletionBlock)completion;
[FIXED] Updates Readme.md urls, removes mention of a newsletter
[FIXED] Updated OnePasswordExtension.(h|m) to include our MIT license in the header
```

## To test
1. bundle exec pod install
2. run unit tests
3. build and run