### PR TITLE
Update to Gridicons 1.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ def wordpress_authenticator_pods
   ## Automattic libraries
   ## ====================
   ##
-  pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'release/1.0' 
+  pod 'Gridicons', '~> 1.0-beta.1' 
   pod 'WordPressUI', '~> 1.4-beta.1'
   pod 'WordPressKit', '~> 4.6.0-beta.8'
   #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ def wordpress_authenticator_pods
   ## Automattic libraries
   ## ====================
   ##
-  pod 'Gridicons', '~> 0.20-beta.1'
+  pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'release/1.0' 
   pod 'WordPressUI', '~> 1.4-beta.1'
   pod 'WordPressKit', '~> 4.6.0-beta.8'
   #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
-  - Gridicons (0.20-beta.1)
+  - Gridicons (1.0-beta.1)
   - GTMSessionFetcher/Core (1.3.1)
   - lottie-ios (3.1.6)
   - NSObject-SafeExpectations (0.0.4)
@@ -63,7 +63,7 @@ DEPENDENCIES:
   - CocoaLumberjack (= 3.5.2)
   - Expecta (= 1.0.6)
   - GoogleSignIn (= 4.4.0)
-  - Gridicons (~> 0.20-beta.1)
+  - Gridicons (from `https://github.com/Automattic/Gridicons-iOS.git`, branch `release/1.0`)
   - lottie-ios (= 3.1.6)
   - "NSURL+IDN (= 0.4)"
   - OCMock (~> 3.4)
@@ -84,7 +84,6 @@ SPEC REPOS:
     - FormatterKit
     - GoogleSignIn
     - GoogleToolboxForMac
-    - Gridicons
     - GTMSessionFetcher
     - lottie-ios
     - NSObject-SafeExpectations
@@ -99,6 +98,16 @@ SPEC REPOS:
     - WordPressUI
     - wpxmlrpc
 
+EXTERNAL SOURCES:
+  Gridicons:
+    :branch: release/1.0
+    :git: https://github.com/Automattic/Gridicons-iOS.git
+
+CHECKOUT OPTIONS:
+  Gridicons:
+    :commit: 760a6901b8edf203453e653d06449d7cda359f27
+    :git: https://github.com/Automattic/Gridicons-iOS.git
+
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -107,7 +116,7 @@ SPEC CHECKSUMS:
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
-  Gridicons: a89c04840b560895223a2c5c1e1299b518e0fc6f
+  Gridicons: 48ccbe284c39db15cc796af0c523e749683ae061
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
@@ -122,6 +131,6 @@ SPEC CHECKSUMS:
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 3d50fab3a75d681b60405f50bb5a9ce65f928c0f
+PODFILE CHECKSUM: c4b7f3ce4eacf096c4484c4aef985f3ce0538a66
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -63,7 +63,7 @@ DEPENDENCIES:
   - CocoaLumberjack (= 3.5.2)
   - Expecta (= 1.0.6)
   - GoogleSignIn (= 4.4.0)
-  - Gridicons (from `https://github.com/Automattic/Gridicons-iOS.git`, branch `release/1.0`)
+  - Gridicons (~> 1.0-beta.1)
   - lottie-ios (= 3.1.6)
   - "NSURL+IDN (= 0.4)"
   - OCMock (~> 3.4)
@@ -84,6 +84,7 @@ SPEC REPOS:
     - FormatterKit
     - GoogleSignIn
     - GoogleToolboxForMac
+    - Gridicons
     - GTMSessionFetcher
     - lottie-ios
     - NSObject-SafeExpectations
@@ -97,16 +98,6 @@ SPEC REPOS:
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  Gridicons:
-    :branch: release/1.0
-    :git: https://github.com/Automattic/Gridicons-iOS.git
-
-CHECKOUT OPTIONS:
-  Gridicons:
-    :commit: 760a6901b8edf203453e653d06449d7cda359f27
-    :git: https://github.com/Automattic/Gridicons-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -131,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 8730d3ae506c86a5a89637a9af5477f14f5aede3
+PODFILE CHECKSUM: 2e5021849975679c2bb33ac20f23b10422ca8b52
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   s.dependency 'NSURL+IDN', '0.4'
   s.dependency 'SVProgressHUD', '2.2.5'
 
-  s.dependency 'Gridicons', '~> 0.20-beta'
+  s.dependency 'Gridicons', '~> 1.0-beta.1'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.5-beta'
   s.dependency 'WordPressKit', '~> 4.6.0-beta.8'

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.11"
+  s.version       = "1.11.0-beta.12"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0-beta.13"
+  s.version       = "1.11.0-beta.14"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -265,7 +265,7 @@ extension WPStyleGuide {
 
         let labelString = NSMutableAttributedString(string: "")
 
-        if let originalDomainsIcon = Gridicon.iconOfType(.domains).imageWithTintColor(WordPressAuthenticator.shared.style.placeholderColor) {
+        if let originalDomainsIcon = UIImage.gridicon(.domains).imageWithTintColor(WordPressAuthenticator.shared.style.placeholderColor) {
             var domainsIcon = originalDomainsIcon.cropping(to: CGRect(x: Constants.domainsIconPaddingToRemove,
                                                                       y: Constants.domainsIconPaddingToRemove,
                                                                       width: originalDomainsIcon.size.width - Constants.domainsIconPaddingToRemove * 2,

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -110,8 +110,8 @@ NSInteger const LeftImageSpacing = 8;
     if (self.showSecureTextEntryToggle == NO) {
         return;
     }
-    self.secureTextEntryImageVisible = [Gridicon iconOfType:GridiconTypeVisible];
-    self.secureTextEntryImageHidden = [Gridicon iconOfType:GridiconTypeNotVisible];
+    self.secureTextEntryImageVisible = [UIImage gridiconOfType:GridiconTypeVisible];
+    self.secureTextEntryImageHidden = [UIImage gridiconOfType:GridiconTypeNotVisible];
 
     self.secureTextEntryToggle = [UIButton buttonWithType:UIButtonTypeCustom];
     self.secureTextEntryToggle.clipsToBounds = true;

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -159,19 +159,19 @@ extension LoginSocialErrorViewController {
         switch index {
         case Buttons.tryEmail.rawValue:
             buttonText = NSLocalizedString("Try with another email", comment: "When social login fails, this button offers to let the user try again with a differen email address")
-            buttonIcon = Gridicon.iconOfType(.undo)
+            buttonIcon = .gridicon(.undo)
         case Buttons.tryAddress.rawValue:
             if loginFields.restrictToWPCom {
                 fallthrough
             } else {
                 buttonText = NSLocalizedString("Try with the site address", comment: "When social login fails, this button offers to let them try tp login using a URL")
-                buttonIcon = Gridicon.iconOfType(.domains)
+                buttonIcon = .gridicon(.domains)
             }
         case Buttons.signup.rawValue:
             fallthrough
         default:
             buttonText = NSLocalizedString("Sign up", comment: "When social login fails, this button offers to let them signup for a new WordPress.com account")
-            buttonIcon = Gridicon.iconOfType(.mySites)
+            buttonIcon = .gridicon(.mySites)
         }
         cell.textLabel?.text = buttonText
         cell.textLabel?.textColor = WPStyleGuide.darkGrey()


### PR DESCRIPTION
This PR updates the authenticator library to use the new Gridicons 1.0 framework. I've updated the podspec and Podfile (which I'll further update once the pod is released), as well as switched over to the new style method calls.

**To Test**

Build and run the associated WordPress-iOS PR, and ensure that the auth flow loads and that some of the icons loaded here appear correctly: https://github.com/wordpress-mobile/WordPress-iOS/pull/13682