### PR TITLE
Update WordpressKit dependency to 1.7.0-beta.1

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.12.0-beta.1"
+  s.version       = "1.12.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.5.2'
-  s.dependency 'WordPressKit', '~> 4.6.0'
+  s.dependency 'WordPressKit', '~> 4.7.0'
   s.dependency 'WordPressShared', '~> 1.8.16'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.5.2'
-  s.dependency 'WordPressKit', '~> 4.7.0'
+  s.dependency 'WordPressKit', '~> 4.7.0-beta.1'
   s.dependency 'WordPressShared', '~> 1.8.16'
 end


### PR DESCRIPTION
I'm just bumping the dependency of WordPressKit to 1.7.0-beta.1 to get at the same requirement as the main app on this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13020