### PR TITLE
Remove whitespace from translation string

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.11.0"
+  s.version       = "1.11.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -153,7 +153,8 @@ extension WPStyleGuide {
                                             width: Constants.googleIconButtonSize, height: Constants.googleIconButtonSize)
 
             let buttonString = NSMutableAttributedString(attachment: googleAttachment)
-            let googleTitle = NSLocalizedString("  Continue with Google", comment: "Button title. Tapping begins log in using Google. There are leading spaces to separate it from the Google logo.")
+            //  Add leading non-breaking spaces to separate the button text from the Google logo.
+            let googleTitle = "\u{00a0}\u{00a0}" + NSLocalizedString("Continue with Google", comment: "Button title. Tapping begins log in using Google.")
             buttonString.append(NSAttributedString(string: googleTitle))
 
             return buttonString

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -178,7 +178,8 @@ extension WPStyleGuide {
                                         width: imageSize.width, height: imageSize.height)
 
         let buttonString = NSMutableAttributedString(attachment: appleAttachment)
-        let appleTitle = "\u{00a0}" + NSLocalizedString("Continue with Apple", comment: "Button title. Tapping begins log in using Apple. There is a leading space to separate it from the Apple logo.")
+        // Add leading non-breaking space to separate the button text from the Apple logo.
+        let appleTitle = "\u{00a0}" + NSLocalizedString("Continue with Apple", comment: "Button title. Tapping begins log in using Apple.")
         buttonString.append(NSAttributedString(string: appleTitle))
 
         return buttonString

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -178,7 +178,7 @@ extension WPStyleGuide {
                                         width: imageSize.width, height: imageSize.height)
 
         let buttonString = NSMutableAttributedString(attachment: appleAttachment)
-        let appleTitle = NSLocalizedString(" Continue with Apple", comment: "Button title. Tapping begins log in using Apple. There is a leading space to separate it from the Apple logo.")
+        let appleTitle = "\u{00a0}" + NSLocalizedString("Continue with Apple", comment: "Button title. Tapping begins log in using Apple. There is a leading space to separate it from the Apple logo.")
         buttonString.append(NSAttributedString(string: appleTitle))
 
         return buttonString

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -111,9 +111,16 @@ import WordPressKit
     /// Setup: Everything = [Insets, Backgrounds, titleColor(s), titleLabel]
     ///
     private func configureAppearance() {
+        configureInsets()
         configureBackgrounds()
         configureTitleColors()
         configureTitleLabel()
+    }
+
+    /// Setup: NUXButton's Default Settings
+    ///
+    private func configureInsets() {
+        contentEdgeInsets = UIImage.DefaultRenderMetrics.contentInsets
     }
 
     /// Setup: BackgroundImage


### PR DESCRIPTION
Fixes #220 
Fixes accidental revert of #216 

This PR alters the "Continue with Google" string. It substitutes unicode non-breaking spaces (instead of keyboard spaces) to keep whitespace fidelity. It also helps the spaces stand out in the code so they aren't accidentally deleted or refactored by Xcode during a "format code" command (Ctrl + i).

The spaces are removed from the localized string so that translators can accurately translate it without worrying about the formatting.

### To test
Check out WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13730