### PR TITLE
UL&S: Remove `.showSignupMethod`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.12.0-beta.2"
+  s.version       = "1.12.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.12.0-beta.4"
+  s.version       = "1.12.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -25,7 +25,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     // MARK: associated type for NUXSegueHandler
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
-        case showSignupMethod
         case showSigninV2
         case showGoogle
         case showURLUsernamePassword

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -363,7 +363,6 @@
                         <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="kRR-qz-Hu2"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="bK1-J1-hfT"/>
                         <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
-                        <segue destination="IwV-3R-6dB" kind="presentation" identifier="showSignupMethod" id="EmH-Av-vhT"/>
                         <segue destination="T5n-nb-cOW" kind="show" identifier="showSigninV2" id="sIC-Hv-FJw"/>
                         <segue destination="MEg-KS-Afs" kind="show" identifier="showGoogle" id="HMT-Z5-QHr"/>
                         <segue destination="SZS-o3-1P7" kind="show" identifier="showURLUsernamePassword" id="4SK-mG-U33"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -116,7 +116,6 @@
                     </view>
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>
                     <connections>
-                        <segue destination="IwV-3R-6dB" kind="presentation" identifier="showSignupMethod" id="gD5-d0-X3t"/>
                         <segue destination="T5n-nb-cOW" kind="show" identifier="showSigninV2" id="nCA-u7-fKm"/>
                         <segue destination="MEg-KS-Afs" kind="show" identifier="showGoogle" id="aSC-hU-lzE"/>
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="N3P-wt-Rn3"/>
@@ -1466,7 +1465,6 @@
         <segue reference="4SK-mG-U33"/>
         <segue reference="nCA-u7-fKm"/>
         <segue reference="swV-lc-6gI"/>
-        <segue reference="gD5-d0-X3t"/>
         <segue reference="aSC-hU-lzE"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -29,7 +29,7 @@
         <!--Login Prologue Signup Method View Controller-->
         <scene sceneID="8K7-Gj-yNn">
             <objects>
-                <viewController id="IwV-3R-6dB" customClass="LoginPrologueSignupMethodViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginPrologueSignupMethodViewController" id="IwV-3R-6dB" customClass="LoginPrologueSignupMethodViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="LS5-8f-iNn"/>
                         <viewControllerLayoutGuide type="bottom" id="NZ0-gC-OHl"/>
@@ -1463,7 +1463,7 @@
         <segue reference="0ao-yi-yZI"/>
         <segue reference="4SK-mG-U33"/>
         <segue reference="nCA-u7-fKm"/>
-        <segue reference="swV-lc-6gI"/>
+        <segue reference="iD4-VS-n3M"/>
         <segue reference="aSC-hU-lzE"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -188,7 +188,18 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         let button = WPStyleGuide.wpcomSignupButton()
         stackView.addArrangedSubview(button)
         button.on(.touchUpInside) { [weak self] (button) in
-            self?.performSegue(withIdentifier: .showSignupMethod, sender: self)
+            guard let vc = LoginPrologueSignupMethodViewController.instantiate(from: .login) else {
+                DDLogError("Failed to navigate to LoginPrologueSignupMethodViewController")
+                return
+            }
+
+            guard let self = self else { return }
+
+            vc.loginFields = self.loginFields
+            vc.dismissBlock = self.dismissBlock
+            vc.transitioningDelegate = self
+            vc.modalPresentationStyle = .custom
+            self.navigationController?.pushViewController(vc, animated: true)
         }
 
         stackView.addConstraints([

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -142,7 +142,7 @@ class LoginPrologueViewController: LoginViewController {
         vc.dismissBlock = dismissBlock
         vc.transitioningDelegate = self
         vc.modalPresentationStyle = .custom
-        navigationController?.pushViewController(vc, animated: true)
+        navigationController?.present(vc, animated: true, completion: nil)
     }
 
     private func appleTapped() {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -123,10 +123,18 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func signupTapped() {
-        // This stat is part of a funnel that provides critical information.  Before
-        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
+        // This stat is part of a funnel that provides critical information.
+        // Before making ANY modification to this stat please refer to: p4qSXL-35X-p2
         WordPressAuthenticator.track(.signupButtonTapped)
-        performSegue(withIdentifier: .showSignupMethod, sender: self)
+
+        guard let vc = LoginPrologueSignupMethodViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate to LoginPrologueSignupMethodViewController")
+            return
+        }
+
+        vc.loginFields = self.loginFields
+        vc.dismissBlock = dismissBlock
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     private func appleTapped() {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -134,6 +134,8 @@ class LoginPrologueViewController: LoginViewController {
 
         vc.loginFields = self.loginFields
         vc.dismissBlock = dismissBlock
+        vc.transitioningDelegate = self
+        vc.modalPresentationStyle = .custom
         navigationController?.pushViewController(vc, animated: true)
     }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -48,14 +48,6 @@ class LoginPrologueViewController: LoginViewController {
         else if let vc = segue.destination as? LoginPrologueSignupMethodViewController {
             vc.transitioningDelegate = self
 
-            vc.googleTapped = { [weak self] in
-                guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
-                    DDLogError("Failed to navigate to SignupGoogleViewController")
-                    return
-                }
-
-                self?.navigationController?.pushViewController(toVC, animated: true)
-            }
             vc.appleTapped = { [weak self] in
                 self?.appleTapped()
             }
@@ -142,6 +134,15 @@ class LoginPrologueViewController: LoginViewController {
 
         vc.emailTapped = { [weak self] in
             self?.performSegue(withIdentifier: .showSigninV2, sender: self)
+        }
+
+        vc.googleTapped = { [weak self] in
+            guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
+                DDLogError("Failed to navigate to SignupGoogleViewController")
+                return
+            }
+
+            self?.navigationController?.pushViewController(toVC, animated: true)
         }
 
         navigationController?.present(vc, animated: true, completion: nil)

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -48,9 +48,6 @@ class LoginPrologueViewController: LoginViewController {
         else if let vc = segue.destination as? LoginPrologueSignupMethodViewController {
             vc.transitioningDelegate = self
 
-            vc.emailTapped = { [weak self] in
-                self?.performSegue(withIdentifier: .showSigninV2, sender: self)
-            }
             vc.googleTapped = { [weak self] in
                 guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
                     DDLogError("Failed to navigate to SignupGoogleViewController")
@@ -142,6 +139,11 @@ class LoginPrologueViewController: LoginViewController {
         vc.dismissBlock = dismissBlock
         vc.transitioningDelegate = self
         vc.modalPresentationStyle = .custom
+
+        vc.emailTapped = { [weak self] in
+            self?.performSegue(withIdentifier: .showSigninV2, sender: self)
+        }
+
         navigationController?.present(vc, animated: true, completion: nil)
     }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -45,15 +45,6 @@ class LoginPrologueViewController: LoginViewController {
         if let vc = segue.destination as? NUXButtonViewController {
             buttonViewController = vc
         }
-        else if let vc = segue.destination as? LoginPrologueSignupMethodViewController {
-            vc.transitioningDelegate = self
-
-            vc.appleTapped = { [weak self] in
-                self?.appleTapped()
-            }
-            vc.modalPresentationStyle = .custom
-        }
-
         else if let vc = segue.destination as? LoginPrologueLoginMethodViewController {
             vc.transitioningDelegate = self
             
@@ -143,6 +134,10 @@ class LoginPrologueViewController: LoginViewController {
             }
 
             self?.navigationController?.pushViewController(toVC, animated: true)
+        }
+
+        vc.appleTapped = { [weak self] in
+            self?.appleTapped()
         }
 
         navigationController?.present(vc, animated: true, completion: nil)


### PR DESCRIPTION
Fixes #224 
Ref. #182 

This PR removes all references to the segue `.showSignupMethod` and programmatically navigates the user to the `LoginPrologueSignupMethodViewController`. There are 2 areas where the segues have been removed:

1. WPiOS sign up
2. WPiOS sign in

### To Test - WPiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WPiOS PR to run the changes: https://github.com/wordpress-mobile/WordPress-iOS/pull/13733