### PR TITLE
UL&S: Remove `.show2FA`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.12.0-beta.5"
+  s.version       = "1.12.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -33,7 +33,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
         case showWPComLogin
         case startMagicLinkFlow
         case showMagicLink
-        case show2FA
         case showDomains
         case showCreateSite
         case showSignupEmail

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1383,7 +1383,6 @@
                         <outlet property="siteHeaderView" destination="vkO-HN-aFE" id="Eyg-MS-QDE"/>
                         <outlet property="submitButton" destination="YGE-OB-HmV" id="39T-xt-cuq"/>
                         <outlet property="usernameField" destination="ZUH-Y9-OaY" id="VLq-Va-EaD"/>
-                        <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="2Bq-Nv-ZkV"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mOF-Ry-81y" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -113,7 +113,6 @@
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="N3P-wt-Rn3"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="Njv-lY-Lyi"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="UV4-XI-c0q"/>
-                        <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="2Of-BA-xqb"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieq-Ar-5OF" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1450,7 +1449,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="N3P-wt-Rn3"/>
         <segue reference="Njv-lY-Lyi"/>
-        <segue reference="2Of-BA-xqb"/>
+        <segue reference="2Bq-Nv-ZkV"/>
         <segue reference="UV4-XI-c0q"/>
         <segue reference="4SK-mG-U33"/>
         <segue reference="nCA-u7-fKm"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -571,7 +571,6 @@
                         <outlet property="siteHeaderView" destination="Wnq-Hk-jIw" id="x0l-lh-uuX"/>
                         <outlet property="submitButton" destination="SBB-7Z-qWs" id="jfi-ms-7V1"/>
                         <outlet property="usernameField" destination="ESh-DI-dtB" id="T1z-yJ-peq"/>
-                        <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="fWM-mD-lXg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="X4T-gd-ISx" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -748,7 +748,6 @@
                         <outlet property="instructionLabel" destination="bBi-2N-RAh" id="NDi-pM-b0p"/>
                         <outlet property="passwordField" destination="BtS-3D-CIU" id="FjI-Ba-FDh"/>
                         <outlet property="submitButton" destination="E3x-LN-sUk" id="9eE-vi-xgc"/>
-                        <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="qLI-qX-rkG"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Z8b-3z-D46" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1447,7 +1446,6 @@
     <inferredMetricsTieBreakers>
         <segue reference="N3P-wt-Rn3"/>
         <segue reference="Njv-lY-Lyi"/>
-        <segue reference="2Bq-Nv-ZkV"/>
         <segue reference="UV4-XI-c0q"/>
         <segue reference="4SK-mG-U33"/>
         <segue reference="nCA-u7-fKm"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -351,7 +351,6 @@
                         <outlet property="submitButton" destination="OZC-xf-OAn" id="k1c-SJ-qiK"/>
                         <segue destination="Kvo-Y2-yhG" kind="show" identifier="startMagicLinkFlow" id="db9-5R-Qq7"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="ySQ-EM-6JI"/>
-                        <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="kRR-qz-Hu2"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="bK1-J1-hfT"/>
                         <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
                         <segue destination="IwV-3R-6dB" kind="presentation" identifier="showSignupMethod" id="EmH-Av-vhT"/>

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -205,7 +205,17 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         configureViewLoading(false)
 
         WordPressAuthenticator.track(.twoFactorCodeRequested)
-        self.performSegue(withIdentifier: .show2FA, sender: self)
+
+        guard let vc = Login2FAViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     // Update safari stored credentials. Call after a successful sign in.
@@ -430,14 +440,23 @@ extension LoginViewController {
         loginFields.nonceInfo = nonceInfo
         loginFields.nonceUserID = userID
 
-        performSegue(withIdentifier: .show2FA, sender: self)
-
         var properties = [AnyHashable:Any]()
         if let service = loginFields.meta.socialService?.rawValue {
             properties["source"] = service
         }
 
         WordPressAuthenticator.track(.loginSocial2faNeeded, properties: properties)
+
+        guard let vc = Login2FAViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     func signInAppleAccount() {


### PR DESCRIPTION
Fixes #227 
Ref. #182 

This PR removes all references to the segue `.show2FA` and programmatically navigates the user to the `Login2FAViewController`. There are 2 areas where the segues have been removed:

1. WPiOS login
2. WCiOS login

### To Test - WPiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WPiOS PR to run the changes: https://github.com/wordpress-mobile/WordPress-iOS/pull/13786

### To Test - WCiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WCiOS PR to run the changes: https://github.com/woocommerce/woocommerce-ios/pull/2071