### PR TITLE
UL&S: Remove `.showSigninV2`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.12.0-beta.8"
+  s.version       = "1.13.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.12.0-beta.6"
+  s.version       = "1.12.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -25,7 +25,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     // MARK: associated type for NUXSegueHandler
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
-        case showSigninV2
         case showURLUsernamePassword
         case showWPUsernamePassword
         case showSelfHostedLogin

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -108,7 +108,6 @@
                     </view>
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>
                     <connections>
-                        <segue destination="T5n-nb-cOW" kind="show" identifier="showSigninV2" id="nCA-u7-fKm"/>
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="N3P-wt-Rn3"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="Njv-lY-Lyi"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="UV4-XI-c0q"/>
@@ -1451,7 +1450,6 @@
         <segue reference="2Of-BA-xqb"/>
         <segue reference="UV4-XI-c0q"/>
         <segue reference="4SK-mG-U33"/>
-        <segue reference="sIC-Hv-FJw"/>
         <segue reference="iD4-VS-n3M"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -353,21 +353,12 @@
                         <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="kRR-qz-Hu2"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="bK1-J1-hfT"/>
                         <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
-                        <segue destination="T5n-nb-cOW" kind="show" identifier="showSigninV2" id="sIC-Hv-FJw"/>
                         <segue destination="SZS-o3-1P7" kind="show" identifier="showURLUsernamePassword" id="4SK-mG-U33"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wWl-qb-1Yp" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1674" y="188"/>
-        </scene>
-        <!--SignupEmailViewController-->
-        <scene sceneID="CQL-qu-sjW">
-            <objects>
-                <viewControllerPlaceholder storyboardName="Signup" referencedIdentifier="SignupEmailViewController" id="T5n-nb-cOW" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="UdV-y0-6AN" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-530" y="760"/>
         </scene>
         <!--Login Self Hosted View Controller-->
         <scene sceneID="b2O-iW-wfB">

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -205,8 +205,14 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
             // Don't forget to handle the button taps!
             vc.emailTapped = { [weak self] in
-                self?.performSegue(withIdentifier: .showSigninV2, sender: self)
+                guard let toVC = SignupEmailViewController.instantiate(from: .signup) else {
+                    DDLogError("Failed to navigate from LoginEmailViewController to SignupEmailViewController")
+                    return
+                }
+
+                self?.navigationController?.pushViewController(toVC, animated: true)
             }
+
             vc.googleTapped = { [weak self] in
                 guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
                     DDLogError("Failed to navigate to SignupGoogleViewController")
@@ -215,6 +221,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
                 self?.navigationController?.pushViewController(toVC, animated: true)
             }
+
             vc.appleTapped = { [weak self] in
                 self?.appleTapped()
             }

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -519,7 +519,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
 // MARK: - Google Sign In
 
-// LoginFacadeDelegate methods for Google Google Sign In
+/// Make Google Sign In conform to the LoginFacade protocol.
+/// The delegate calls these methods from LoginFacade.m.
+///
 extension LoginEmailViewController {
     func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
         googleFinishedLogin(withGoogleIDToken: googleIDToken, authToken: authToken)
@@ -530,6 +532,9 @@ extension LoginEmailViewController {
         googleExistingUserNeedsConnection(email)
     }
 
+    /// After a successful Google Sign In, this method gets called when the user
+    /// has enabled 2-factor authentication for their WordPress.com account.
+    ///
     func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         configureViewLoading(false)
         socialNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -397,37 +397,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         return EmailFormatValidator.validate(string: loginFields.username)
     }
 
-
-    // MARK: - Segue
-
-    override open func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        super.prepare(for: segue, sender: sender)
-
-        if let vc = segue.destination as? LoginPrologueSignupMethodViewController {
-            vc.transitioningDelegate = self
-
-            vc.emailTapped = { [weak self] in
-                guard let toVC = SignupEmailViewController.instantiate(from: .signup) else {
-                    DDLogError("Failed to navigate from LoginEmailViewController to SignupEmailViewController")
-                    return
-                }
-
-                self?.navigationController?.pushViewController(toVC, animated: true)
-            }
-
-            vc.googleTapped = { [weak self] in
-                guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
-                    DDLogError("Failed to navigate to SignupGoogleViewController")
-                    return
-                }
-
-                self?.navigationController?.pushViewController(toVC, animated: true)
-            }
-
-            vc.modalPresentationStyle = .custom
-        }
-    }
-
     // MARK: - Actions
 
 

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -405,9 +405,16 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         if let vc = segue.destination as? LoginPrologueSignupMethodViewController {
             vc.transitioningDelegate = self
+
             vc.emailTapped = { [weak self] in
-                self?.performSegue(withIdentifier: .showSigninV2, sender: self)
+                guard let toVC = SignupEmailViewController.instantiate(from: .signup) else {
+                    DDLogError("Failed to navigate from LoginEmailViewController to SignupEmailViewController")
+                    return
+                }
+
+                self?.navigationController?.pushViewController(toVC, animated: true)
             }
+
             vc.googleTapped = { [weak self] in
                 guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
                     DDLogError("Failed to navigate to SignupGoogleViewController")
@@ -416,6 +423,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
                 self?.navigationController?.pushViewController(toVC, animated: true)
             }
+
             vc.modalPresentationStyle = .custom
         }
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -124,7 +124,12 @@ class LoginPrologueViewController: LoginViewController {
         vc.modalPresentationStyle = .custom
 
         vc.emailTapped = { [weak self] in
-            self?.performSegue(withIdentifier: .showSigninV2, sender: self)
+            guard let toVC = SignupEmailViewController.instantiate(from: .signup) else {
+                DDLogError("Failed to navigate to SignupEmailViewController")
+                return
+            }
+
+            self?.navigationController?.pushViewController(toVC, animated: true)
         }
 
         vc.googleTapped = { [weak self] in

--- a/WordPressAuthenticator/Signup/Signup.storyboard
+++ b/WordPressAuthenticator/Signup/Signup.storyboard
@@ -27,7 +27,7 @@
         <!--Signup Email View Controller-->
         <scene sceneID="b2m-u4-I3H">
             <objects>
-                <viewController storyboardIdentifier="SignupEmailViewController" id="Opx-rl-H3d" customClass="SignupEmailViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SignupEmailViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Opx-rl-H3d" customClass="SignupEmailViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="F3A-pe-bcZ">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
Fixes #229 

Ref. #182 

This PR removes all references to the segue `.showSigninV2` and programmatically navigates the user to the `SignupEmailViewController`. There is 1 area where the segue has been removed:

1. WPiOS signup

### To Test - WPiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WPiOS PR to run the changes: https://github.com/wordpress-mobile/WordPress-iOS/pull/13828