### PR TITLE
Jetpack Signup Flow pushes 3 buttons instead of present

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.12.0"
+  s.version       = "1.12.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -199,7 +199,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             vc.dismissBlock = self.dismissBlock
             vc.transitioningDelegate = self
             vc.modalPresentationStyle = .custom
-            self.navigationController?.pushViewController(vc, animated: true)
+            self.navigationController?.present(vc, animated: true, completion: nil)
         }
 
         stackView.addConstraints([

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -187,6 +187,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         let button = WPStyleGuide.wpcomSignupButton()
         stackView.addArrangedSubview(button)
+
+        // Tapping the Sign up text link in "Don't have an account? _Sign up_"
+        // will present the 3 button view for signing up.
         button.on(.touchUpInside) { [weak self] (button) in
             guard let vc = LoginPrologueSignupMethodViewController.instantiate(from: .login) else {
                 DDLogError("Failed to navigate to LoginPrologueSignupMethodViewController")
@@ -199,6 +202,20 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             vc.dismissBlock = self.dismissBlock
             vc.transitioningDelegate = self
             vc.modalPresentationStyle = .custom
+
+            // Don't forget to handle the button taps!
+            vc.emailTapped = { [weak self] in
+                self?.performSegue(withIdentifier: .showSigninV2, sender: self)
+            }
+            vc.googleTapped = { [weak self] in
+                guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
+                    DDLogError("Failed to navigate to SignupGoogleViewController")
+                    return
+                }
+
+                self?.navigationController?.pushViewController(toVC, animated: true)
+            }
+
             self.navigationController?.present(vc, animated: true, completion: nil)
         }
 

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -45,7 +45,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         localizeControls()
         setupOnePasswordButtonIfNeeded()
-        
+
         alternativeLoginLabel?.isHidden = showLoginOptions
         if !showLoginOptions {
             addGoogleButton()
@@ -214,6 +214,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
                 }
 
                 self?.navigationController?.pushViewController(toVC, animated: true)
+            }
+            vc.appleTapped = { [weak self] in
+                self?.appleTapped()
             }
 
             self.navigationController?.present(vc, animated: true, completion: nil)
@@ -391,7 +394,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         loginWithUsernamePassword(immediately: true)
     }
-    
+
     /// Configures loginFields to log into wordpress.com and
     /// navigates to the selfhosted username/password form. Displays the specified
     /// error message when the new view controller appears.
@@ -467,6 +470,11 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     @IBAction func handleSelfHostedButtonTapped(_ sender: UIButton) {
         loginToSelfHostedSite()
+    }
+
+    private func appleTapped() {
+        AppleAuthenticator.sharedInstance.delegate = self
+        AppleAuthenticator.sharedInstance.showFrom(viewController: self)
     }
 
 
@@ -548,5 +556,24 @@ extension LoginEmailViewController {
 extension LoginEmailViewController: GIDSignInDelegate {
     open func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
         signInGoogleAccount(signIn, didSignInFor: user, withError: error)
+    }
+}
+
+// MARK: - AppleAuthenticatorDelegate
+
+extension LoginEmailViewController: AppleAuthenticatorDelegate {
+
+    func showWPComLogin(loginFields: LoginFields) {
+        self.loginFields = loginFields
+         performSegue(withIdentifier: .showWPComLogin, sender: self)
+    }
+
+    func showApple2FA(loginFields: LoginFields) {
+        self.loginFields = loginFields
+        signInAppleAccount()
+    }
+
+    func authFailedWithError(message: String) {
+        displayErrorAlert(message, sourceTag: .loginApple)
     }
 }


### PR DESCRIPTION
Fixes #233 

This PR fixes the black screen bug. 

PR to test on WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/13827

### Summary

After the Jetpack install flow, the user is asked to sign in again. The LoginEmailViewController is presented, and there text and a link below the email field that says, "Don't have an account? Sign up"

Tapping the "Sign up" link pushes the 3 button view instead of presenting the 3 button view. Pushing the nav creates the black screen (seen in Figure 2 below).

### Steps to Reproduce
1. Have a self-hosted site that doesn't have Jetpack connected. (This also works if you go to the site, Jetpack > and scroll to the bottom to find the "Disconnect" button and click it.)
2. Log out of the WPiOS app if you are logged in.
3. Log into the app through the self-hosted flow: Login > enter site address text link button
4. After completing the login flow, go to the Notifications tab
5. Follow the Jetpack install flow. Once it is successful, it will ask you to set up Jetpack. 
6. The "Set up" Jetpack button should navigate you to the email login screen. (See Figure 1 below) 
7. Tap the "Sign up" text link button.
**Expected:** the 3 button view appears as an overlay to the email login screen. (See Figure 3)
**Actual:** the 3 button view is pushed and the background is black.

**Figure 1**
<img src="https://user-images.githubusercontent.com/1062444/78581772-ef164e80-77f9-11ea-951d-a354c31dbfc7.png" width="350" />

**Figure 2**
<img src="https://user-images.githubusercontent.com/1062444/78581815-fc333d80-77f9-11ea-8795-977a5612d41f.png" width="350" />

**Figure 3**
<img src="https://user-images.githubusercontent.com/1062444/78588663-a1ebaa00-7804-11ea-939f-d664569536d8.png" width="350" />