### PR TITLE
UL&S: Remove `showURLUsernamePassword` 

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.13.0-beta.1"
+  s.version       = "1.13.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -25,7 +25,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     // MARK: associated type for NUXSegueHandler
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
-        case showURLUsernamePassword
         case showWPUsernamePassword
         case showSelfHostedLogin
         case showWPComLogin

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -361,7 +361,7 @@
         <!--Login Self Hosted View Controller-->
         <scene sceneID="b2O-iW-wfB">
             <objects>
-                <viewController storyboardIdentifier="selfHosted" useStoryboardIdentifierAsRestorationIdentifier="YES" id="SZS-o3-1P7" customClass="LoginSelfHostedViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController id="SZS-o3-1P7" customClass="LoginSelfHostedViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Yjk-Cc-Bxb"/>
                         <viewControllerLayoutGuide type="bottom" id="Ktl-It-Kmo"/>
@@ -1425,11 +1425,6 @@
             <point key="canvasLocation" x="-460" y="1248"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="icon-password-field" width="18" height="22"/>
-        <image name="icon-url-field" width="18" height="22"/>
-        <image name="icon-username-field" width="18" height="18"/>
-    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="N3P-wt-Rn3"/>
         <segue reference="Njv-lY-Lyi"/>
@@ -1437,4 +1432,9 @@
         <segue reference="4SK-mG-U33"/>
         <segue reference="iD4-VS-n3M"/>
     </inferredMetricsTieBreakers>
+    <resources>
+        <image name="icon-password-field" width="18" height="22"/>
+        <image name="icon-url-field" width="18" height="22"/>
+        <image name="icon-username-field" width="18" height="18"/>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -360,7 +360,7 @@
         <!--Login Self Hosted View Controller-->
         <scene sceneID="b2O-iW-wfB">
             <objects>
-                <viewController id="SZS-o3-1P7" customClass="LoginSelfHostedViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginSelfHostedViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="SZS-o3-1P7" customClass="LoginSelfHostedViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Yjk-Cc-Bxb"/>
                         <viewControllerLayoutGuide type="bottom" id="Ktl-It-Kmo"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1144,7 +1144,6 @@
                         <outlet property="siteAddressHelpButton" destination="roL-ID-k8n" id="QB2-ri-X5V"/>
                         <outlet property="siteURLField" destination="ZrT-CY-qD7" id="561-Zw-Ja9"/>
                         <outlet property="submitButton" destination="ltO-hW-mbe" id="wwr-D5-5kK"/>
-                        <segue destination="SZS-o3-1P7" kind="show" identifier="showURLUsernamePassword" id="TkG-0R-c3i"/>
                         <segue destination="iMi-vX-AxR" kind="show" identifier="showWPUsernamePassword" id="dtm-iK-PLb"/>
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="5hL-j3-eMs"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="8p6-rS-9Ml"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -351,7 +351,6 @@
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="ySQ-EM-6JI"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="bK1-J1-hfT"/>
                         <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
-                        <segue destination="SZS-o3-1P7" kind="show" identifier="showURLUsernamePassword" id="4SK-mG-U33"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wWl-qb-1Yp" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1429,7 +1428,6 @@
         <segue reference="N3P-wt-Rn3"/>
         <segue reference="Njv-lY-Lyi"/>
         <segue reference="UV4-XI-c0q"/>
-        <segue reference="4SK-mG-U33"/>
         <segue reference="iD4-VS-n3M"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -413,14 +413,14 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         guard let vc = LoginSelfHostedViewController.instantiate(from: .login) else {
             DDLogError("Failed to navigate from LoginEmailViewController to LoginSelfHostedViewController")
-                return
-            }
+            return
+        }
 
-            vc.loginFields = loginFields
-            vc.dismissBlock = dismissBlock
-            vc.errorToPresent = errorToPresent
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
 
-            navigationController?.pushViewController(vc, animated: true)
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     override open func displayRemoteError(_ error: Error) {

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -403,13 +403,24 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     }
 
     /// Configures loginFields to log into wordpress.com and
-    /// navigates to the selfhosted username/password form. Displays the specified
-    /// error message when the new view controller appears.
+    /// navigates to the selfhosted username/password form.
+    /// Displays the specified error message when the new
+    /// view controller appears.
     ///
     @objc func showSelfHostedUsernamePasswordAndError(_ error: Error) {
         loginFields.siteAddress = "https://wordpress.com"
         errorToPresent = error
-        performSegue(withIdentifier: .showURLUsernamePassword, sender: self)
+
+        guard let vc = LoginSelfHostedViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginEmailViewController to LoginSelfHostedViewController")
+                return
+            }
+
+            vc.loginFields = loginFields
+            vc.dismissBlock = dismissBlock
+            vc.errorToPresent = errorToPresent
+
+            navigationController?.pushViewController(vc, animated: true)
     }
 
     override open func displayRemoteError(_ error: Error) {

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -258,7 +258,16 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     ///
     @objc func showSelfHostedUsernamePassword() {
         configureViewLoading(false)
-        performSegue(withIdentifier: .showURLUsernamePassword, sender: self)
+        guard let vc = LoginSelfHostedViewController.instantiate(from: .login) else {
+           DDLogError("Failed to navigate from LoginEmailViewController to LoginSelfHostedViewController")
+               return
+           }
+
+       vc.loginFields = loginFields
+       vc.dismissBlock = dismissBlock
+       vc.errorToPresent = errorToPresent
+
+       navigationController?.pushViewController(vc, animated: true)
     }
 
     /// Break away from the self-hosted flow.


### PR DESCRIPTION
Fixes #239 
Ref #182 

This PR removes all references to the segue `.showURLUsernamePassword` and programmatically navigates the user to the `LoginSelfHostedViewController`. There is 1 area where the segue has been removed:

1. WPiOS login
(Note that WCiOS doesn't use this specific segue. Theirs is coming next.)

### To Test - WPiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WPiOS PR to run the changes: https://github.com/wordpress-mobile/WordPress-iOS/pull/13896