### PR TITLE
UL&S: Remove .showSelfHostedLogin

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.13.0-beta.3"
+  s.version       = "1.13.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -198,8 +198,7 @@ import AuthenticationServices
     /// Returns an instance of LoginSiteAddressViewController: allows the user to log into a WordPress.org website.
     ///
     @objc public class func signinForWPOrg() -> UIViewController {
-        let storyboard = UIStoryboard(name: "Login", bundle: bundle)
-        guard let controller = storyboard.instantiateViewController(withIdentifier: "siteAddress") as? LoginSiteAddressViewController else {
+        guard let controller = LoginSiteAddressViewController.instantiate(from: .login) else {
             fatalError("unable to create wpcom password screen")
         }
 

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -26,7 +26,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
         case showWPUsernamePassword
-        case showSelfHostedLogin
         case showWPComLogin
         case startMagicLinkFlow
         case showMagicLink

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -348,7 +348,6 @@
                         <outlet property="submitButton" destination="OZC-xf-OAn" id="k1c-SJ-qiK"/>
                         <segue destination="Kvo-Y2-yhG" kind="show" identifier="startMagicLinkFlow" id="db9-5R-Qq7"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="ySQ-EM-6JI"/>
-                        <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="bK1-J1-hfT"/>
                         <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
                     </connections>
                 </viewController>
@@ -1423,8 +1422,8 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="5hL-j3-eMs"/>
-        <segue reference="8p6-rS-9Ml"/>
+        <segue reference="N3P-wt-Rn3"/>
+        <segue reference="ySQ-EM-6JI"/>
         <segue reference="swV-lc-6gI"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1423,8 +1423,8 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="N3P-wt-Rn3"/>
-        <segue reference="ySQ-EM-6JI"/>
-        <segue reference="swV-lc-6gI"/>
+        <segue reference="UV4-XI-c0q"/>
+        <segue reference="iD4-VS-n3M"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="icon-password-field" width="18" height="22"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1002,7 +1002,7 @@
         <!--Login Site Address View Controller-->
         <scene sceneID="idG-jg-gxH">
             <objects>
-                <viewController storyboardIdentifier="siteAddress" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="anK-hg-K4j" customClass="LoginSiteAddressViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginSiteAddressViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="anK-hg-K4j" customClass="LoginSiteAddressViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="pmp-Uj-4NW"/>
                         <viewControllerLayoutGuide type="bottom" id="rYV-q2-blN"/>
@@ -1424,10 +1424,10 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="N3P-wt-Rn3"/>
+        <segue reference="5hL-j3-eMs"/>
         <segue reference="Njv-lY-Lyi"/>
-        <segue reference="UV4-XI-c0q"/>
-        <segue reference="iD4-VS-n3M"/>
+        <segue reference="8p6-rS-9Ml"/>
+        <segue reference="swV-lc-6gI"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="icon-password-field" width="18" height="22"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -109,7 +109,6 @@
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>
                     <connections>
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="N3P-wt-Rn3"/>
-                        <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="Njv-lY-Lyi"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="UV4-XI-c0q"/>
                     </connections>
                 </viewController>
@@ -1425,7 +1424,6 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="5hL-j3-eMs"/>
-        <segue reference="Njv-lY-Lyi"/>
         <segue reference="8p6-rS-9Ml"/>
         <segue reference="swV-lc-6gI"/>
     </inferredMetricsTieBreakers>

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -136,8 +136,18 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     }
 
     /// Displays the self-hosted sign in form.
+    ///
     func loginToSelfHostedSite() {
-        performSegue(withIdentifier: .showSelfHostedLogin, sender: self)
+        guard let vc = LoginSiteAddressViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginViewController to LoginSiteAddressViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     /// Validates what is entered in the various form fields and, if valid,


### PR DESCRIPTION
Fixes #241 
Ref #182 

This PR removes all references to the segue `.showSelfHostedLogin` and uses a navController to navigate the user to the `SelfHostedLoginViewController`. There are 2 areas where the segue has been removed:

1. WPiOS login
2. WCiOS login

### To Test - WPiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WPiOS PR to run the changes: https://github.com/wordpress-mobile/WordPress-iOS/pull/13904

### To Test - WCiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WCiOS PR to run the changes: https://github.com/woocommerce/woocommerce-ios/pull/2143