### PR TITLE
Updating WPKit version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.5.2'
-  pod 'WordPressKit', '~> 4.7.0'
-  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+  # pod 'WordPressKit', '~> 4.7.0'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/11771-gravatar_user_not_found'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
   pod 'WordPressShared', '~> 1.8.16'
 

--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.5.2'
-  # pod 'WordPressKit', '~> 4.7.0'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/11771-gravatar_user_not_found'
+  pod 'WordPressKit', '~> 4.8.0-beta.1'
+  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
   pod 'WordPressShared', '~> 1.8.16'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.7.0):
+  - WordPressKit (4.8.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.7.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/11771-gravatar_user_not_found`)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.5.2)
 
@@ -94,10 +94,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: fix/11771-gravatar_user_not_found
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 864eec7eb314cf89e3c7defedf631db87c1af42b
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -117,11 +126,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: 0602e8188245b3267269570d3d78c138e64a4eba
+  WordPressKit: 636f3f7e1c879b22f1d46e61d662ad640161f8b2
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 70cc58a253c352330b23cd8fa6dd6a2021570e18
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: d2a5f1cb57eeb9eb2ac2cb22d29b6b827ccf8ce4
+PODFILE CHECKSUM: db5d0ce73f34dcea3781f77c6dd0bedec53217a2
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/11771-gravatar_user_not_found`)
+  - WordPressKit (~> 4.8.0-beta.1)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.5.2)
 
@@ -94,19 +94,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: fix/11771-gravatar_user_not_found
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 864eec7eb314cf89e3c7defedf631db87c1af42b
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -131,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: 70cc58a253c352330b23cd8fa6dd6a2021570e18
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: db5d0ce73f34dcea3781f77c6dd0bedec53217a2
+PODFILE CHECKSUM: b5a906d2c4561de3ad1b3c684f6043c8ce9f1b14
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.13.0-beta.4"
+  s.version       = "1.13.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 4.4'
   s.dependency 'WordPressUI', '~> 1.5.2'
-  s.dependency 'WordPressKit', '~> 4.7.0'
+  s.dependency 'WordPressKit', '~> 4.8.0-beta.1'
   s.dependency 'WordPressShared', '~> 1.8.16'
 end


### PR DESCRIPTION
With https://github.com/wordpress-mobile/WordPressKit-iOS/pull/241 the WPKit pod version was incremented. WPiOS failed to build because WPAuth depends on WPKit as well. So this simply updates WPKit pod version to make everyone happy!

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13917

Note the `Validate Podspec` test will continue to fail until there is an official WPKit release. I'll update that before merging. But you should be able to test locally successfully.