### PR TITLE
UL&S: Remove .showWPUsernamePassword

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.13.0-beta.4"
+  s.version       = "1.14.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -25,7 +25,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     // MARK: associated type for NUXSegueHandler
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
-        case showWPUsernamePassword
         case showWPComLogin
         case startMagicLinkFlow
         case showMagicLink

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1142,7 +1142,6 @@
                         <outlet property="siteAddressHelpButton" destination="roL-ID-k8n" id="QB2-ri-X5V"/>
                         <outlet property="siteURLField" destination="ZrT-CY-qD7" id="561-Zw-Ja9"/>
                         <outlet property="submitButton" destination="ltO-hW-mbe" id="wwr-D5-5kK"/>
-                        <segue destination="iMi-vX-AxR" kind="show" identifier="showWPUsernamePassword" id="dtm-iK-PLb"/>
                         <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="5hL-j3-eMs"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="8p6-rS-9Ml"/>
                     </connections>
@@ -1422,9 +1421,9 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="N3P-wt-Rn3"/>
-        <segue reference="UV4-XI-c0q"/>
-        <segue reference="swV-lc-6gI"/>
+        <segue reference="5hL-j3-eMs"/>
+        <segue reference="8p6-rS-9Ml"/>
+        <segue reference="JN3-Ck-2w7"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="icon-password-field" width="18" height="22"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -3,7 +3,7 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -1154,7 +1154,7 @@
         <!--Login Username Password View Controller-->
         <scene sceneID="b9v-Sc-w6J">
             <objects>
-                <viewController storyboardIdentifier="wpUsernamePassword" useStoryboardIdentifierAsRestorationIdentifier="YES" id="iMi-vX-AxR" customClass="LoginUsernamePasswordViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginUsernamePasswordViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="iMi-vX-AxR" customClass="LoginUsernamePasswordViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="De3-R2-Sm2"/>
                         <viewControllerLayoutGuide type="bottom" id="NPl-SI-4X2"/>
@@ -1424,7 +1424,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="N3P-wt-Rn3"/>
         <segue reference="UV4-XI-c0q"/>
-        <segue reference="iD4-VS-n3M"/>
+        <segue reference="swV-lc-6gI"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="icon-password-field" width="18" height="22"/>

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -296,15 +296,22 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         performSegue(withIdentifier: .showLoginMethod, sender: self)
     }
 
+    /// Ref. https://git.io/JfJ4s - settings for Woo.
+    /// After a site address has been validated,
+    /// display the 3 button view login options.
+    ///
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
         
         if let vc = segue.destination as? LoginPrologueLoginMethodViewController {
             vc.transitioningDelegate = self
-            
+
+            // Continue with WordPress.com button action
             vc.emailTapped = { [weak self] in
                 self?.showWPUsernamePassword()
             }
+
+            // Continue with Google button action
             vc.googleTapped = { [weak self] in
                 guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
                     DDLogError("Failed to navigate to SignupGoogleViewController")
@@ -313,6 +320,8 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
 
                 self?.navigationController?.pushViewController(toVC, animated: true)
             }
+
+            // Sign In With Apple (SIWA) button action
             vc.appleTapped = { [weak self] in
                 self?.appleTapped()
             }

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -275,7 +275,17 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     ///
     @objc func showWPUsernamePassword() {
         configureViewLoading(false)
-        performSegue(withIdentifier: .showWPUsernamePassword, sender: self)
+
+        guard let vc = LoginUsernamePasswordViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginSiteAddressViewController to LoginUsernamePasswordViewController")
+                return
+            }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     /// Break away from the self-hosted flow.


### PR DESCRIPTION
Fixes #244 
Ref #182 

This PR removes all references to the segue `.showWPUsernamePassword` and programmatically navigates the user to the `LoginUsernamePasswordViewController`. There is 1 area where the segue has been removed:

1. WCiOS login
(No, WPiOS doesn't use this specific segue.)

### To Test - WCiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WCiOS PR to run the changes: https://github.com/woocommerce/woocommerce-ios/pull/2151