### PR TITLE
Secure text entry button: Update when value is set.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.14.0"
+  s.version       = "1.15.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -60,7 +60,8 @@ NSInteger const LeftImageSpacing = 8;
     }
 }
 
--(void)setRightView:(UIView *)rightView {
+-(void)setRightView:(UIView *)rightView
+{
     if (self.trailingViewWidth > 0) {
         rightView.frame = [self frameForTrailingView];
         rightView.contentMode = [self isLayoutLeftToRight] ? UIViewContentModeRight : UIViewContentModeLeft;
@@ -74,6 +75,12 @@ NSInteger const LeftImageSpacing = 8;
         }
     }
     [super setRightView:rightView];
+}
+
+- (void)setShowSecureTextEntryToggle:(BOOL)showSecureTextEntryToggle
+{
+    _showSecureTextEntryToggle = showSecureTextEntryToggle;
+    [self configureSecureTextEntryToggle];
 }
 
 - (void)commonInit


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/13939

This updates the secure text entry button whenever the `showSecureTextEntryToggle` flag is set. 
Previously, the button would only update initially, when the xib was loaded. This change allows the icon to be set after the initial load.

Specifically, for the WPiOS Signup Epilogue:

<img width="400" alt="Screen Shot 2020-04-22 at 8 53 06 PM" src="https://user-images.githubusercontent.com/1816888/80053932-5101d400-84db-11ea-9a7e-165f72555b13.png">


Can tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13973