### PR TITLE
UL&S: Remove .startMagicLinkFlow segue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def wordpress_authenticator_pods
   ## ====================
   ##
   pod 'Gridicons', '~> 1.0'
-  pod 'WordPressUI', '~> 1.5.0-beta'
+  pod 'WordPressUI', '~> 1.5.4-beta'
   pod 'WordPressKit', '~> 4.8.0'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def wordpress_authenticator_pods
   ## ====================
   ##
   pod 'Gridicons', '~> 1.0'
-  pod 'WordPressUI', '~> 1.5.2'
+  pod 'WordPressUI', '~> 1.5.0-beta'
   pod 'WordPressKit', '~> 4.8.0'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPressKit (~> 4.8.0)
   - WordPressShared (~> 1.8.16)
-  - WordPressUI (~> 1.5.0-beta)
+  - WordPressUI (~> 1.5.4-beta)
 
 SPEC REPOS:
   trunk:
@@ -122,6 +122,6 @@ SPEC CHECKSUMS:
   WordPressUI: 3fb26abb771534e6eb545a53c1e02a35830d051d
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 87b002a89556dca2a84f7c32ddc1c2047b13dbda
+PODFILE CHECKSUM: bac3545d372dd4e32543a371945e1df6c796188b
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPressShared (1.8.16):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.5.2)
+  - WordPressUI (1.5.4-beta.3)
   - wpxmlrpc (0.8.5)
 
 DEPENDENCIES:
@@ -73,7 +73,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPressKit (~> 4.8.0)
   - WordPressShared (~> 1.8.16)
-  - WordPressUI (~> 1.5.2)
+  - WordPressUI (~> 1.5.0-beta)
 
 SPEC REPOS:
   trunk:
@@ -119,9 +119,9 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPressKit: 84045e236949248632a2c644149e5657733011bb
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
-  WordPressUI: 70cc58a253c352330b23cd8fa6dd6a2021570e18
+  WordPressUI: 3fb26abb771534e6eb545a53c1e02a35830d051d
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 8e0158473c1f3e6910b3b417c2f53fee11dc0bfc
+PODFILE CHECKSUM: 87b002a89556dca2a84f7c32ddc1c2047b13dbda
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 4.4'
-  s.dependency 'WordPressUI', '~> 1.5.4'
+  s.dependency 'WordPressUI', '~> 1.5.4-beta'
   s.dependency 'WordPressKit', '~> 4.8.0'
   s.dependency 'WordPressShared', '~> 1.8.16'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 4.4'
-  s.dependency 'WordPressUI', '~> 1.5.0'
+  s.dependency 'WordPressUI', '~> 1.5.4'
   s.dependency 'WordPressKit', '~> 4.8.0'
   s.dependency 'WordPressShared', '~> 1.8.16'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 4.4'
-  s.dependency 'WordPressUI', '~> 1.5.2'
+  s.dependency 'WordPressUI', '~> 1.5.0'
   s.dependency 'WordPressKit', '~> 4.8.0'
   s.dependency 'WordPressShared', '~> 1.8.16'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.15.0-beta.1"
+  s.version       = "1.15.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -26,7 +26,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
         case showWPComLogin
-        case startMagicLinkFlow
         case showMagicLink
         case showDomains
         case showCreateSite

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -346,7 +346,6 @@
                         <outlet property="inputStack" destination="JdU-yW-tzf" id="99m-CN-GKR"/>
                         <outlet property="instructionLabel" destination="DKR-9c-zZQ" id="2Rj-ad-hnL"/>
                         <outlet property="submitButton" destination="OZC-xf-OAn" id="k1c-SJ-qiK"/>
-                        <segue destination="Kvo-Y2-yhG" kind="show" identifier="startMagicLinkFlow" id="db9-5R-Qq7"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="ySQ-EM-6JI"/>
                         <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
                     </connections>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -903,7 +903,7 @@
         <!--Login Link Request View Controller-->
         <scene sceneID="lHx-fY-p45">
             <objects>
-                <viewController storyboardIdentifier="LoginLinkRequestViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Kvo-Y2-yhG" customClass="LoginLinkRequestViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginLinkRequestViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Kvo-Y2-yhG" customClass="LoginLinkRequestViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="q8R-wf-TMO"/>
                         <viewControllerLayoutGuide type="bottom" id="h4a-j8-84P"/>
@@ -1422,7 +1422,7 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="5hL-j3-eMs"/>
-        <segue reference="8p6-rS-9Ml"/>
+        <segue reference="0ao-yi-yZI"/>
         <segue reference="JN3-Ck-2w7"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -339,11 +339,20 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-    /// Proceeds along the "magic link" sign-in flow, showing a form that let's
+    /// Proceeds along the "magic link" sign-in flow, showing a form that lets
     /// the user request a magic link.
     ///
     func requestLink() {
-        performSegue(withIdentifier: .startMagicLinkFlow, sender: self)
+        guard let vc = LoginLinkRequestViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginEmailViewController to LoginLinkRequestViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 
 


### PR DESCRIPTION
Fixes #255  
Ref #182 

This PR removes all references to the segue `.startMagicLinkFlow` and programmatically navigates the user to the `LoginLinkViewController`. There are 2 areas where the segue has been removed:

1. WPiOS login
2. WCiOS login

### To Test - WPiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WPiOS PR to run the changes: https://github.com/wordpress-mobile/WordPress-iOS/pull/14003

### To Test - WCiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WCiOS PR to run the changes: https://github.com/woocommerce/woocommerce-ios/pull/2201