### PR TITLE
UL&S: Remove .showUsernames

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.15.0-beta.3"
+  s.version       = "1.15.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -29,7 +29,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
         case showDomains
         case showCreateSite
         case showSignupEmail
-        case showUsernames
         case showLoginMethod
     }
 


### PR DESCRIPTION
Fixes #257
Ref. #182 

This PR removes the `.showUsernames` case from the `SegueIdentifiers` enum. This case is used in the WPiOS signup epilogue, so please check WPiOS for the navigation changes.

There is 1 area where this segue has been removed:

1. WPiOS login

### To Test - WPiOS
1. Check out this branch
2. `rake dependencies` and ensure there are no errors
3. Build and run (there should be no errors)
4. Visit the WPiOS PR for the rest of the code changes: tk