### PR TITLE
UL&S: Remove .showDomains

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.15.0-beta.3"
+  s.version       = "1.15.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.15.0-beta.4"
+  s.version       = "1.15.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -26,7 +26,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
         case showWPComLogin
-        case showDomains
         case showCreateSite
         case showSignupEmail
         case showUsernames


### PR DESCRIPTION
Fixes #259 
Ref. #182 

This PR removes the case `showDomains` that is declared in the `SegueIdentifiers` enum and was not used in any of the host apps nor the Authenticator classes. 

### To test

I'm unsure how to test this other than doing a search for `showDomains` in each of the host apps (which returns only a result for NUXViewController).

1. Check out this branch
2. `bundle exec pod install` and ensure there are no errors
3. Check out this branch
4. Build and run (there should be no errors)
5. Check out the `develop` branch of WPiOS 
6. Set WPiOS to point to local pod dev for Authenticator
7. Build and run
8. ???
9. Profit!