### PR TITLE
UL&S: Remove .showCreateSite segue

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.15.0-beta.6"
+  s.version       = "1.15.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -26,7 +26,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
         case showWPComLogin
-        case showCreateSite
         case showSignupEmail
         case showUsernames
         case showLoginMethod


### PR DESCRIPTION
Fixes #262
Ref. #182 

This PR removes the case `showCreateSite` that is declared in the `SegueIdentifiers` enum and was not used in any of the host apps nor the Authenticator classes. 

### To test

I'm unsure how to test this other than doing a search for `showCreateSite` in each of the host apps (which returns only a result for NUXViewController).