### PR TITLE
UL&S: Remove .showSignupEmail segue

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.15.0-beta.7"
+  s.version       = "1.16.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -26,7 +26,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
         case showWPComLogin
-        case showSignupEmail
         case showUsernames
         case showLoginMethod
     }

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -140,14 +140,6 @@
             </objects>
             <point key="canvasLocation" x="451" y="714"/>
         </scene>
-        <!--Signup Email Entry-->
-        <scene sceneID="gjg-iE-qSx">
-            <objects>
-                <viewControllerPlaceholder storyboardName="Signup" referencedIdentifier="SignupEmailViewController" id="klu-4U-PyL" userLabel="Signup Email Entry" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="OWM-SL-SwW" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2387" y="-231"/>
-        </scene>
         <!--Login Email View Controller-->
         <scene sceneID="w6Y-pB-a3f">
             <objects>
@@ -347,7 +339,6 @@
                         <outlet property="instructionLabel" destination="DKR-9c-zZQ" id="2Rj-ad-hnL"/>
                         <outlet property="submitButton" destination="OZC-xf-OAn" id="k1c-SJ-qiK"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="ySQ-EM-6JI"/>
-                        <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wWl-qb-1Yp" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1421,7 +1412,7 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="5hL-j3-eMs"/>
-        <segue reference="0ao-yi-yZI"/>
+        <segue reference="ySQ-EM-6JI"/>
         <segue reference="JN3-Ck-2w7"/>
     </inferredMetricsTieBreakers>
     <resources>


### PR DESCRIPTION
Fixes #264 
Ref. #182 

Remove the `showSignupEmail` case from the `SegueIdentifiers` enum. Programmatically navigate to the `SignupEmailViewController` in the `Signup.storyboard`. 

This case is used in 1 area:
1. WPiOS signup, after a successful Jetpack Install flow.

### To set up
1. Check out this branch
2. `bundle exec pod install`
3. Build the project
4. Check out the `develop` branch of WPiOS
5. Point to the local pod develop in WPiOS podfile
6. `rake dependencies`
7. Build and run

### To test
1. Have a self-hosted site that is disconnected from Jetpack (or was never connected in the first place, both work).
2. Log in using the self-hosted flow.
3. Go to the Notifications tab.
4. Go through the Jetpack Install flow. 
5. After successfully installing Jetpack, you'll be asked to Login or Signup. Choose the `Sign up` text link.
6. The 3-button view will appear. Tap "Sign up with Email".
7. **Expected:** the button navigates you to the sign up email view controller. (The text will read, "To create your new WordPress.com account, please enter your email address.")

#### Screenshots
| Step 5 | Step 6 | Step 7 |
| --- | --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/80835228-f55cd800-8bb7-11ea-9903-d8c6ce587e34.png"><img src="https://user-images.githubusercontent.com/1062444/80835228-f55cd800-8bb7-11ea-9903-d8c6ce587e34.png" /></a> | <a href="https://user-images.githubusercontent.com/1062444/80835269-073e7b00-8bb8-11ea-91d4-aede3e591802.png"><img src="https://user-images.githubusercontent.com/1062444/80835269-073e7b00-8bb8-11ea-91d4-aede3e591802.png" /></a> | <a href="https://user-images.githubusercontent.com/1062444/80835290-11607980-8bb8-11ea-9b1c-659e4280d791.png"><img src="https://user-images.githubusercontent.com/1062444/80835290-11607980-8bb8-11ea-9b1c-659e4280d791.png" /></a> |


