### PR TITLE
Remove showUsernames segue name.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.15.0"
+  s.version       = "1.16.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -27,7 +27,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     public enum SegueIdentifier: String {
         case showWPComLogin
         case showSignupEmail
-        case showUsernames
         case showLoginMethod
     }
 


### PR DESCRIPTION
Fixes: #257 

This removes the `showUsernames` segue name, which was used in WPiOS Signup Epilogue. 

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14048