### PR TITLE
Secure text image: use placeholder color if provided.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.16.0-beta.2"
+  s.version       = "1.16.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.h
@@ -6,6 +6,7 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable BOOL showTopLineSeparator;
 @property (nonatomic) IBInspectable BOOL showSecureTextEntryToggle;
 @property (nonatomic) IBInspectable UIImage *leftViewImage;
+@property (nonatomic) IBInspectable UIColor *secureTextEntryImageColor;
 
 /// Width for the left view. Set to 0 to use the given frame in the view.
 /// Default is: 30

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -1,8 +1,6 @@
 #import "WPWalkthroughTextField.h"
 #import <WordPressShared/WordPressShared.h>
 
-
-
 NSInteger const LeftImageSpacing = 8;
 
 @import Gridicons;
@@ -122,8 +120,10 @@ NSInteger const LeftImageSpacing = 8;
 
     self.secureTextEntryToggle = [UIButton buttonWithType:UIButtonTypeCustom];
     self.secureTextEntryToggle.clipsToBounds = true;
+
     // colors here are overridden in LoginTextField
-    self.secureTextEntryToggle.tintColor = [WPStyleGuide greyLighten10];
+    self.secureTextEntryToggle.tintColor = (self.secureTextEntryImageColor != nil) ? self.secureTextEntryImageColor : [WPStyleGuide greyLighten10];
+
     [self.secureTextEntryToggle addTarget:self action:@selector(secureTextEntryToggleAction:) forControlEvents:UIControlEventTouchUpInside];
 
     [self updateSecureTextEntryToggleImage];

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -5,8 +5,8 @@ open class LoginTextField: WPWalkthroughTextField {
 
     open override func awakeFromNib() {
         super.awakeFromNib()
-
         backgroundColor = WordPressAuthenticator.shared.style.textFieldBackgroundColor
+        secureTextEntryImageColor = WordPressAuthenticator.shared.style.placeholderColor
     }
 
     override open func draw(_ rect: CGRect) {


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/13939

This change sets the secure text image color to either:
- The `placeholderColor` from `WordPressAuthenticatorStyle` if provided.
- The original color (i.e. `greyLighten10`).

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14049