### PR TITLE
UL&S: Remove .showLoginMethod

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.16.0-beta.2"
+  s.version       = "1.16.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -26,7 +26,6 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
     /// Segue identifiers to avoid using strings
     public enum SegueIdentifier: String {
         case showWPComLogin
-        case showLoginMethod
     }
 
     override open func viewDidLoad() {

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1411,7 +1411,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="N3P-wt-Rn3"/>
         <segue reference="ySQ-EM-6JI"/>
         <segue reference="JN3-Ck-2w7"/>
     </inferredMetricsTieBreakers>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1233,6 +1233,9 @@
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCX-uI-ruO" userLabel="Title">
                                                                         <rect key="frame" x="0.0" y="0.0" width="281" height="18"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="18" id="Coh-Dn-nk1"/>
+                                                                        </constraints>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -1250,6 +1253,12 @@
                                                                 </subviews>
                                                             </stackView>
                                                         </subviews>
+                                                        <constraints>
+                                                            <constraint firstItem="DWy-yy-er4" firstAttribute="bottom" secondItem="IMk-aA-1GF" secondAttribute="bottomMargin" id="I9F-s9-a8t"/>
+                                                            <constraint firstItem="DWy-yy-er4" firstAttribute="trailing" secondItem="IMk-aA-1GF" secondAttribute="trailingMargin" id="gca-Ce-u6f"/>
+                                                            <constraint firstItem="DWy-yy-er4" firstAttribute="leading" secondItem="Gak-2q-wul" secondAttribute="trailing" constant="10" id="h93-X9-jIc"/>
+                                                            <constraint firstItem="DWy-yy-er4" firstAttribute="top" secondItem="IMk-aA-1GF" secondAttribute="topMargin" id="sNI-Q9-kLs"/>
+                                                        </constraints>
                                                     </stackView>
                                                 </subviews>
                                             </stackView>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1365,7 +1365,7 @@
         <!--Login Prologue Login Method View Controller-->
         <scene sceneID="4ov-Vw-tga">
             <objects>
-                <viewController id="hed-vB-osh" customClass="LoginPrologueLoginMethodViewController" customModule="WordPressAuthenticator" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginPrologueLoginMethodViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hed-vB-osh" customClass="LoginPrologueLoginMethodViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="EBT-D5-afP"/>
                         <viewControllerLayoutGuide type="bottom" id="wML-ff-0Cg"/>
@@ -1411,7 +1411,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="5hL-j3-eMs"/>
+        <segue reference="N3P-wt-Rn3"/>
         <segue reference="ySQ-EM-6JI"/>
         <segue reference="JN3-Ck-2w7"/>
     </inferredMetricsTieBreakers>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -108,7 +108,6 @@
                     </view>
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>
                     <connections>
-                        <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="N3P-wt-Rn3"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="UV4-XI-c0q"/>
                     </connections>
                 </viewController>
@@ -1132,7 +1131,6 @@
                         <outlet property="siteAddressHelpButton" destination="roL-ID-k8n" id="QB2-ri-X5V"/>
                         <outlet property="siteURLField" destination="ZrT-CY-qD7" id="561-Zw-Ja9"/>
                         <outlet property="submitButton" destination="ltO-hW-mbe" id="wwr-D5-5kK"/>
-                        <segue destination="hed-vB-osh" kind="presentation" identifier="showLoginMethod" id="5hL-j3-eMs"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="8p6-rS-9Ml"/>
                     </connections>
                 </viewController>
@@ -1411,7 +1409,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="ySQ-EM-6JI"/>
+        <segue reference="8p6-rS-9Ml"/>
         <segue reference="JN3-Ck-2w7"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -79,7 +79,35 @@ class LoginPrologueViewController: LoginViewController {
                 return
             }
 
-            navigationController?.pushViewController(vc, animated: true)
+            vc.transitioningDelegate = self
+
+            // Continue with WordPress.com button action
+            vc.emailTapped = { [weak self] in
+                guard let toVC = LoginEmailViewController.instantiate(from: .login) else {
+                    DDLogError("Failed to navigate to LoginEmailVC from LoginPrologueVC")
+                    return
+                }
+
+                self?.navigationController?.pushViewController(toVC, animated: true)
+            }
+
+            // Continue with Google button action
+            vc.googleTapped = { [weak self] in
+                self?.googleLoginTapped(withDelegate: self)
+            }
+
+            // Site address text link button action
+            vc.selfHostedTapped = { [weak self] in
+                self?.loginToSelfHostedSite()
+            }
+
+            // Sign In With Apple (SIWA) button action
+            vc.appleTapped = { [weak self] in
+                self?.appleTapped()
+            }
+
+            vc.modalPresentationStyle = .custom
+            navigationController?.present(vc, animated: true, completion: nil)
         } else {
             guard let vc = LoginEmailViewController.instantiate(from: .login) else {
                 DDLogError("Failed to navigate to LoginEmailViewController from LoginPrologueViewController")

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -45,29 +45,6 @@ class LoginPrologueViewController: LoginViewController {
         if let vc = segue.destination as? NUXButtonViewController {
             buttonViewController = vc
         }
-        else if let vc = segue.destination as? LoginPrologueLoginMethodViewController {
-            vc.transitioningDelegate = self
-            
-            vc.emailTapped = { [weak self] in
-                guard let vc = LoginEmailViewController.instantiate(from: .login) else {
-                    DDLogError("Failed to navigate to LoginEmailViewController")
-                    return
-                }
-
-                self?.navigationController?.pushViewController(vc, animated: true)
-            }
-            vc.googleTapped = { [weak self] in
-                self?.googleLoginTapped(withDelegate: self)
-            }
-            vc.selfHostedTapped = { [weak self] in
-                self?.loginToSelfHostedSite()
-            }
-            vc.appleTapped = { [weak self] in
-                self?.appleTapped()
-            }
-
-            vc.modalPresentationStyle = .custom
-        }
     }
 
     private func configureButtonVC() {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -97,7 +97,12 @@ class LoginPrologueViewController: LoginViewController {
 
     private func loginTapped() {
         if WordPressAuthenticator.shared.configuration.showLoginOptions {
-            performSegue(withIdentifier: .showLoginMethod, sender: self)
+            guard let vc = LoginPrologueLoginMethodViewController.instantiate(from: .login) else {
+                DDLogError("Failed to navigate to LoginPrologueLoginMethodViewController from LoginPrologueViewController")
+                return
+            }
+
+            navigationController?.pushViewController(vc, animated: true)
         } else {
             guard let vc = LoginEmailViewController.instantiate(from: .login) else {
                 DDLogError("Failed to navigate to LoginEmailViewController from LoginPrologueViewController")

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -288,46 +288,41 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    /// Break away from the self-hosted flow.
-    /// Display login options for WP.com sites.
-    ///
-    @objc func showLoginMethods() {
-        configureViewLoading(false)
-        performSegue(withIdentifier: .showLoginMethod, sender: self)
-    }
-
     /// Ref. https://git.io/JfJ4s - settings for Woo.
     /// After a site address has been validated,
     /// display the 3 button view login options.
     ///
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        super.prepare(for: segue, sender: sender)
-        
-        if let vc = segue.destination as? LoginPrologueLoginMethodViewController {
-            vc.transitioningDelegate = self
+    @objc func showLoginMethods() {
+        configureViewLoading(false)
 
-            // Continue with WordPress.com button action
-            vc.emailTapped = { [weak self] in
-                self?.showWPUsernamePassword()
-            }
-
-            // Continue with Google button action
-            vc.googleTapped = { [weak self] in
-                guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
-                    DDLogError("Failed to navigate to SignupGoogleViewController")
-                    return
-                }
-
-                self?.navigationController?.pushViewController(toVC, animated: true)
-            }
-
-            // Sign In With Apple (SIWA) button action
-            vc.appleTapped = { [weak self] in
-                self?.appleTapped()
-            }
-            
-            vc.modalPresentationStyle = .custom
+        guard let vc = LoginPrologueLoginMethodViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate to LoginPrologueLoginMethodViewController from LoginSiteAddressViewController")
+            return
         }
+
+        vc.transitioningDelegate = self
+
+        // Continue with WordPress.com button action
+        vc.emailTapped = { [weak self] in
+            self?.showWPUsernamePassword()
+        }
+
+        // Continue with Google button action
+        vc.googleTapped = { [weak self] in
+            guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
+                DDLogError("Failed to navigate to SignupGoogleViewController")
+                return
+            }
+
+            self?.navigationController?.pushViewController(toVC, animated: true)
+        }
+
+        // Sign In With Apple (SIWA) button action
+        vc.appleTapped = { [weak self] in
+            self?.appleTapped()
+        }
+
+        vc.modalPresentationStyle = .custom
     }
 
     private func appleTapped() {

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -235,14 +235,16 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                 }
                 
                 if WordPressAuthenticator.shared.configuration.showLoginOptionsFromSiteAddress {
+                    // If WCiOS has enabled the configuration, display
+                    // the "3 button view" on receiving a valid site address.
                     self.showLoginMethods()
                 } else {
                     self.showWPUsernamePassword()
                 }
-                
+
                 return
             }
-            
+
             self.displayError(message: originalError.localizedDescription)
         })
     }
@@ -279,7 +281,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         guard let vc = LoginUsernamePasswordViewController.instantiate(from: .login) else {
             DDLogError("Failed to navigate from LoginSiteAddressViewController to LoginUsernamePasswordViewController")
                 return
-            }
+        }
 
         vc.loginFields = loginFields
         vc.dismissBlock = dismissBlock
@@ -323,6 +325,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         }
 
         vc.modalPresentationStyle = .custom
+        navigationController?.present(vc, animated: true, completion: nil)
     }
 
     private func appleTapped() {


### PR DESCRIPTION
Closes #270 
Ref. #182 

This PR removes all references to the segue `.showLoginMethod` and programmatically navigates the user to the 3 button view. There are 2 host apps where the segue has been removed:

1. WPiOS logins
2. WCiOS login

### To Test - WPiOS
1. Check out this branch
2. `bundle exec pod install` and ensure there are no errors
3. Build (there should be no errors)
4. Visit the WPiOS PR to run the changes: https://github.com/wordpress-mobile/WordPress-iOS/pull/14057

### To Test - WCiOS
1. Check out this branch
2. `bundle exec pod install` and ensure there are no errors
3. Build (there should be no errors)
4. Visit the WCiOS PR to run the changes: https://github.com/woocommerce/woocommerce-ios/pull/2244