### PR TITLE
Remove support for `showLoginOptionsFromSiteAddress`.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.16.0"
+  s.version       = "1.17.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -51,12 +51,6 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let showLoginOptions: Bool
 
-    /// Flag indicating if the login options button view should be displayed in the site address flow.
-    /// If enabled, the options button view will be displayed after the site address has been entered
-    /// and verified.
-    ///
-    let showLoginOptionsFromSiteAddress: Bool
-    
     /// Flag indicating if the Sign In With Apple option should be displayed.
     ///
     let enableSignInWithApple: Bool
@@ -78,7 +72,6 @@ public struct WordPressAuthenticatorConfiguration {
                  googleLoginScheme: String,
                  userAgent: String,
                  showLoginOptions: Bool = false,
-                 showLoginOptionsFromSiteAddress: Bool = false,
                  enableSignInWithApple: Bool = false,
                  enableUnifiedAuth: Bool = false) {
 
@@ -93,7 +86,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginScheme = googleLoginScheme
         self.userAgent = userAgent
         self.showLoginOptions = showLoginOptions
-        self.showLoginOptionsFromSiteAddress = showLoginOptionsFromSiteAddress
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
     }

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -233,15 +233,8 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                     self.showSelfHostedUsernamePassword()
                     return
                 }
-                
-                if WordPressAuthenticator.shared.configuration.showLoginOptionsFromSiteAddress {
-                    // If WCiOS has enabled the configuration, display
-                    // the "3 button view" on receiving a valid site address.
-                    self.showLoginMethods()
-                } else {
-                    self.showWPUsernamePassword()
-                }
 
+                self.showWPUsernamePassword()
                 return
             }
 
@@ -288,49 +281,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         vc.errorToPresent = errorToPresent
 
         navigationController?.pushViewController(vc, animated: true)
-    }
-
-    /// Ref. https://git.io/JfJ4s - settings for Woo.
-    /// After a site address has been validated,
-    /// display the 3 button view login options.
-    ///
-    @objc func showLoginMethods() {
-        configureViewLoading(false)
-
-        guard let vc = LoginPrologueLoginMethodViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate to LoginPrologueLoginMethodViewController from LoginSiteAddressViewController")
-            return
-        }
-
-        vc.transitioningDelegate = self
-
-        // Continue with WordPress.com button action
-        vc.emailTapped = { [weak self] in
-            self?.showWPUsernamePassword()
-        }
-
-        // Continue with Google button action
-        vc.googleTapped = { [weak self] in
-            guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
-                DDLogError("Failed to navigate to SignupGoogleViewController")
-                return
-            }
-
-            self?.navigationController?.pushViewController(toVC, animated: true)
-        }
-
-        // Sign In With Apple (SIWA) button action
-        vc.appleTapped = { [weak self] in
-            self?.appleTapped()
-        }
-
-        vc.modalPresentationStyle = .custom
-        navigationController?.present(vc, animated: true, completion: nil)
-    }
-
-    private func appleTapped() {
-        AppleAuthenticator.sharedInstance.delegate = self
-        AppleAuthenticator.sharedInstance.showFrom(viewController: self)
     }
 
     /// Whether the form can be submitted.
@@ -406,35 +356,5 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
 
     @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
         keyboardWillHide(notification)
-    }
-}
-
-/// The Site Address VC conforms to the AppleAuth delegate so that the 3 button view
-/// can be presented after a successful Site Address was submitted.
-/// See also: WordPressAuthenticatorConfiguration.showLoginOptionsFromSiteAddress.
-///
-extension LoginSiteAddressViewController: AppleAuthenticatorDelegate {
-
-    func showWPComLogin(loginFields: LoginFields) {
-        self.loginFields = loginFields
-        guard let vc = LoginWPComViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from Sign in with Apple to LoginWPComViewController")
-            return
-        }
-
-        vc.loginFields = self.loginFields
-        vc.dismissBlock = dismissBlock
-        vc.errorToPresent = errorToPresent
-
-        navigationController?.pushViewController(vc, animated: true)
-    }
-
-    func showApple2FA(loginFields: LoginFields) {
-        self.loginFields = loginFields
-        signInAppleAccount()
-    }
-    
-    func authFailedWithError(message: String) {
-        displayErrorAlert(message, sourceTag: .loginApple)
     }
 }


### PR DESCRIPTION
With https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/112/, the ability to show the login options button view from the Site Address view was added because it was expected Woo would utilize it. However, Woo never transitioned to this flow, and now the code is unused. In addition, the new [Unified Auth](https://wp.me/p91TBi-2F7) login flows differ, so it will never be used.

This change removes that code.

To test:
Since `showLoginOptionsFromSiteAddress` was never adopted by any host app, there is no change. So just verify log in by site address works as expected.

- In Woo and/or WordPress, change Podfile's Auth to point to this branch.
- When logging in, select log in by site address.
- After entering a valid site address, verify the Username/Password view is displayed.

| ![woo](https://user-images.githubusercontent.com/1816888/82250881-85658600-9909-11ea-8b88-31c7e0f54672.png) | ![wp](https://user-images.githubusercontent.com/1816888/82250902-8ac2d080-9909-11ea-9aab-451da0312e9e.png) |
|--------|-------|