### PR TITLE
1.17.0-beta.2 - Update WordPressUI to 1.7.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def wordpress_authenticator_pods
   ## ====================
   ##
   pod 'Gridicons', '~> 1.0'
-  pod 'WordPressUI', '~> 1.6.0'
+  pod 'WordPressUI', '~> 1.7.0'
   pod 'WordPressKit', '~> 4.8.0'
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
   # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPressShared (1.8.16):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.6.0)
+  - WordPressUI (1.7.0)
   - wpxmlrpc (0.8.5)
 
 DEPENDENCIES:
@@ -73,7 +73,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPressKit (~> 4.8.0)
   - WordPressShared (~> 1.8.16)
-  - WordPressUI (~> 1.6.0)
+  - WordPressUI (~> 1.7.0)
 
 SPEC REPOS:
   trunk:
@@ -119,9 +119,9 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPressKit: 84045e236949248632a2c644149e5657733011bb
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
-  WordPressUI: cbe8cce4bd529caf5969750c34ba2d2026a342a9
+  WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: e68f66f05425f60cfb486a87151d902b6e3bc781
+PODFILE CHECKSUM: 88fea7959453679084608726a841091493009bd3
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.17.0-beta.1"
+  s.version       = "1.17.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 4.4'
-  s.dependency 'WordPressUI', '~> 1.6.0'
+  s.dependency 'WordPressUI', '~> 1.7.0'
   s.dependency 'WordPressKit', '~> 4.8.0'
   s.dependency 'WordPressShared', '~> 1.8.16'
 end


### PR DESCRIPTION
Update develop with the latest WordPressUI 1.7.0

This should is the same change as the 1.16.1 release: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/278