### PR TITLE
Refactor Google login logic

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.17.0-beta.4"
+  s.version       = "1.17.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		982C8E7923021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982C8E7823021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift */; };
 		98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */; };
 		98C9195B2308E3DA00A90E12 /* AppleAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */; };
+		98D9A4B12474A526002E491C /* GoogleAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */; };
 		B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */; };
 		B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */; };
 		B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B501C040208FC52500D1E58F /* LoginFacadeTests.m */; };
@@ -166,6 +167,7 @@
 		982C8E7823021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginPrologueLoginMethodViewController.swift; sourceTree = "<group>"; };
 		98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPHelpIndicatorView.swift; sourceTree = "<group>"; };
 		98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthenticator.swift; sourceTree = "<group>"; };
+		98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleAuthenticator.swift; sourceTree = "<group>"; };
 		AE612958059F9E80B54138B3 /* Pods-WordPressAuthenticatorTests.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release-internal.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release-internal.xcconfig"; sourceTree = "<group>"; };
 		B0D7D40BC1DE2D367761AD86 /* Pods-WordPressAuthenticatorTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginFieldsValidationTests.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 			isa = PBXGroup;
 			children = (
 				98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */,
+				98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */,
 				B5609126208A563600399AE4 /* EmailMagicLink.storyboard */,
 				B560912E208A563700399AE4 /* Login.storyboard */,
 				B5609125208A563600399AE4 /* Login2FAViewController.swift */,
@@ -981,6 +984,7 @@
 				B56090EF208A527000399AE4 /* WPStyleGuide+Login.swift in Sources */,
 				B56090D0208A4F5400399AE4 /* NUXViewControllerBase.swift in Sources */,
 				3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */,
+				98D9A4B12474A526002E491C /* GoogleAuthenticator.swift in Sources */,
 				B56090DE208A4F9D00399AE4 /* WPWalkthroughOverlayView.m in Sources */,
 				B560910A208A54F800399AE4 /* WordPressComAccountService.swift in Sources */,
 				B56090FA208A533200399AE4 /* WordPressAuthenticator.swift in Sources */,

--- a/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
@@ -1,0 +1,190 @@
+import Foundation
+import GoogleSignIn
+import WordPressKit
+
+protocol GoogleAuthenticatorDelegate {
+    
+    // Logging in with a Google account was successful.
+    func googleFinishedLogin(credentials: AuthenticatorCredentials, loginFields: LoginFields)
+    
+    // Google account login was successful, but a WP 2FA code is required.
+    func googleNeedsMultifactorCode(loginFields: LoginFields)
+    
+    // Google account login was successful, but a WP password is required.
+    func googleExistingUserNeedsConnection(loginFields: LoginFields)
+    
+    // Google account login failed.
+    func googleRemoteError(errorTitle: String, errorDescription: String, loginFields: LoginFields)
+}
+
+class GoogleAuthenticator: NSObject {
+
+    // MARK: - Properties
+
+    static var sharedInstance: GoogleAuthenticator = GoogleAuthenticator()
+    private override init() {}
+    var delegate: GoogleAuthenticatorDelegate?
+
+    private var loginFields = LoginFields()
+    private let authConfig = WordPressAuthenticator.shared.configuration
+    
+    private lazy var loginFacade: LoginFacade = {
+        let facade = LoginFacade(dotcomClientID: authConfig.wpcomClientId,
+                                 dotcomSecret: authConfig.wpcomSecret,
+                                 userAgent: authConfig.userAgent)
+        facade.delegate = self
+        return facade
+    }()
+    
+    // MARK: - Start Authentication
+    
+    /// Public method to initiate the Google auth process.
+    /// - Parameters:
+    ///   - viewController: The UIViewController that Google is being presented from.
+    ///                     Required by Google SDK.
+    ///   - loginFields: LoginFields from the calling view controller.
+    ///                  The values are updated during the Google process,
+    ///                  and returned to the calling view controller via delegate methods.
+    func showFrom(viewController: UIViewController, loginFields: LoginFields) {
+        self.loginFields = loginFields
+        self.loginFields.meta.socialService = SocialServiceName.google
+        requestAuthorization(from: viewController)
+    }
+    
+}
+
+// MARK: - Private Extension
+
+private extension GoogleAuthenticator {
+    
+    
+    /// Initiates the Google authenication flow.
+    ///   - viewController: The UIViewController that Google is being presented from.
+    ///                     Required by Google SDK.
+    func requestAuthorization(from viewController: UIViewController) {
+
+        guard let googleInstance = GIDSignIn.sharedInstance() else {
+            DDLogError("GoogleAuthenticator: Failed to get `GIDSignIn.sharedInstance()`.")
+            return
+        }
+
+        googleInstance.disconnect()
+
+        // This has no effect since we don't use Google UI, but presentingViewController is required, so here we are.
+        googleInstance.presentingViewController = viewController
+        
+        googleInstance.delegate = self
+        googleInstance.clientID = authConfig.googleLoginClientId
+        googleInstance.serverClientID = authConfig.googleLoginServerClientId
+
+        // Start the Google auth process. This presents the Google account selection view.
+        googleInstance.signIn()
+
+        WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "google"])
+    }
+
+    enum LocalizedText {
+        static let googleConnected = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
+        static let googleConnectedError = NSLocalizedString("The Google account \"%@\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
+        static let googleUnableToConnect = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
+    }
+
+}
+
+// MARK: - GIDSignInDelegate
+
+extension GoogleAuthenticator: GIDSignInDelegate {
+
+    func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
+        
+        // Get account information
+        guard let user = user,
+            let token = user.authentication.idToken,
+            let email = user.profile.email else {
+                
+                // The Google SignIn may have been canceled.
+                let properties = ["error": error?.localizedDescription,
+                                  "source": SocialServiceName.google.rawValue]
+                
+                WordPressAuthenticator.track(.loginSocialButtonFailure, properties: properties as [AnyHashable : Any])
+                return
+        }
+        
+        // Save account information to pass back to delegate later.
+        loginFields.emailAddress = email
+        loginFields.username = email
+        loginFields.meta.socialServiceIDToken = token
+        loginFields.meta.googleUser = user
+        
+        // Initiate WP login.
+        loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
+    }
+    
+}
+
+// MARK: - LoginFacadeDelegate
+
+extension GoogleAuthenticator: LoginFacadeDelegate {
+
+    // Logging in with a Google account was successful.
+    func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
+        GIDSignIn.sharedInstance().disconnect()
+        
+        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
+        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
+        
+        let wpcom = WordPressComCredentials(authToken: authToken,
+                                            isJetpackLogin: loginFields.meta.jetpackLogin,
+                                            multifactor: false,
+                                            siteURL: loginFields.siteAddress)
+        let credentials = AuthenticatorCredentials(wpcom: wpcom)
+
+        delegate?.googleFinishedLogin(credentials: credentials, loginFields: loginFields)
+    }
+
+    // Google account login was successful, but a WP 2FA code is required.
+    func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+        GIDSignIn.sharedInstance().disconnect()
+
+        loginFields.nonceInfo = nonceInfo
+        loginFields.nonceUserID = userID
+        
+        var properties = [AnyHashable:Any]()
+        if let service = loginFields.meta.socialService?.rawValue {
+            properties["source"] = service
+        }
+        
+        WordPressAuthenticator.track(.loginSocial2faNeeded, properties: properties)
+        delegate?.googleNeedsMultifactorCode(loginFields: loginFields)
+    }
+
+    // Google account login was successful, but a WP password is required.
+    func existingUserNeedsConnection(_ email: String) {
+        GIDSignIn.sharedInstance().disconnect()
+        
+        loginFields.username = email
+        loginFields.emailAddress = email
+        
+        WordPressAuthenticator.track(.loginSocialAccountsNeedConnecting, properties: ["source": "google"])
+        delegate?.googleExistingUserNeedsConnection(loginFields: loginFields)
+    }
+
+    // Google account login failed.
+    func displayRemoteError(_ error: Error) {
+        GIDSignIn.sharedInstance().disconnect()
+        
+        let errorTitle: String
+        let errorDescription: String
+        if (error as NSError).code == WordPressComOAuthError.unknownUser.rawValue {
+            errorTitle = LocalizedText.googleConnected
+            errorDescription = String(format: LocalizedText.googleConnectedError, loginFields.username)
+            WordPressAuthenticator.track(.loginSocialErrorUnknownUser)
+        } else {
+            errorTitle = LocalizedText.googleUnableToConnect
+            errorDescription = error.localizedDescription
+        }
+        
+        delegate?.googleRemoteError(errorTitle: errorTitle, errorDescription: errorDescription, loginFields: loginFields)
+    }
+    
+}

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -93,7 +93,7 @@ class LoginPrologueViewController: LoginViewController {
 
             // Continue with Google button action
             vc.googleTapped = { [weak self] in
-                self?.googleLoginTapped(withDelegate: self)
+                self?.googleTapped()
             }
 
             // Site address text link button action
@@ -163,6 +163,11 @@ class LoginPrologueViewController: LoginViewController {
         AppleAuthenticator.sharedInstance.showFrom(viewController: self)
     }
 
+    private func googleTapped() {
+        GoogleAuthenticator.sharedInstance.delegate = self
+        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields)
+    }
+
 }
 
 // MARK: - AppleAuthenticatorDelegate
@@ -194,35 +199,54 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
 
 }
 
-// MARK: - Social LoginFacadeDelegate Methods
+// MARK: - GoogleAuthenticatorDelegate
 
-extension LoginPrologueViewController {
-    
-    override open func displayRemoteError(_ error: Error) {
-        configureViewLoading(false)
-        displayRemoteErrorForGoogle(error)
-    }
-    
-    func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
-        googleFinishedLogin(withGoogleIDToken: googleIDToken, authToken: authToken)
+extension LoginPrologueViewController: GoogleAuthenticatorDelegate {
+
+    func googleFinishedLogin(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        self.loginFields = loginFields
+        syncWPComAndPresentEpilogue(credentials: credentials)
     }
 
-    func existingUserNeedsConnection(_ email: String) {
-        configureViewLoading(false)
-        googleExistingUserNeedsConnection(email)
+    func googleNeedsMultifactorCode(loginFields: LoginFields) {
+        self.loginFields = loginFields
+
+        guard let vc = Login2FAViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 
-    func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
-        configureViewLoading(false)
-        socialNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
+    func googleExistingUserNeedsConnection(loginFields: LoginFields) {
+        self.loginFields = loginFields
+
+        guard let vc = LoginWPComViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from Google Login to LoginWPComViewController (password VC)")
+            return
+        }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 
-}
+    func googleRemoteError(errorTitle: String, errorDescription: String, loginFields: LoginFields) {
+        self.loginFields = loginFields
 
-// MARK: - GIDSignInDelegate
-
-extension LoginPrologueViewController: GIDSignInDelegate {
-    open func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
-        signInGoogleAccount(signIn, didSignInFor: user, withError: error)
+        let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription)
+        let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
+        socialErrorVC.delegate = self
+        socialErrorVC.loginFields = loginFields
+        socialErrorVC.modalPresentationStyle = .fullScreen
+        present(socialErrorNav, animated: true)
     }
+
 }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -360,6 +360,7 @@ extension LoginViewController {
 
 extension LoginViewController {
 
+    // TODO: remove when LoginEmailViewController updated to use GoogleAuthenticator
     @objc func googleLoginTapped(withDelegate delegate: GIDSignInDelegate?) {
         awaitingGoogle = true
         configureViewLoading(true)
@@ -379,6 +380,7 @@ extension LoginViewController {
         WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "google"])
     }
 
+    // TODO: remove when LoginEmailViewController updated to use GoogleAuthenticator
     func displayRemoteErrorForGoogle(_ error: Error) {
 
         if awaitingGoogle {
@@ -417,6 +419,7 @@ extension LoginViewController {
         }
     }
     
+    // TODO: remove when LoginEmailViewController updated to use GoogleAuthenticator
     func googleFinishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
         let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: false, siteURL: loginFields.siteAddress)
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
@@ -428,6 +431,7 @@ extension LoginViewController {
         WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
     }
 
+    // TODO: remove when LoginEmailViewController updated to use GoogleAuthenticator
     func googleExistingUserNeedsConnection(_ email: String) {
         // Disconnect now that we're done with Google.
         GIDSignIn.sharedInstance().disconnect()
@@ -450,6 +454,7 @@ extension LoginViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
+    // TODO: remove when LoginEmailViewController updated to use GoogleAuthenticator
     func socialNeedsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         loginFields.nonceInfo = nonceInfo
         loginFields.nonceUserID = userID
@@ -483,6 +488,7 @@ extension LoginViewController {
         loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.apple.rawValue)
     }
 
+    // TODO: remove when LoginEmailViewController updated to use GoogleAuthenticator
     func signInGoogleAccount(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
         guard let user = user,
             let token = user.authentication.idToken,
@@ -501,6 +507,7 @@ extension LoginViewController {
         loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
     }
     
+    // TODO: remove when LoginEmailViewController updated to use GoogleAuthenticator
     /// Updates the LoginFields structure, with the specified Google User + Token + Email.
     ///
     func updateLoginFields(googleUser: GIDGoogleUser, googleToken: String, googleEmail: String) {


### PR DESCRIPTION
Ref #282 

This moves the code related to Google login to a new `GoogleAuthenticator` class. This replicates the logic previously in `LoginPrologueViewController` + `LoginViewController`. The intent is to remove the dependency on `LoginViewController`, and let the individual initiating VCs handle the login.

Previously, `LoginPrologueViewController` would call `loginFacade:loginToWordPressDotComWithSocialIDToken` to initiate WP login. It would catch the resulting Google login status, and simply call associated methods in `LoginViewController`. `LoginViewController` would then update the UI accordingly.

Now, `GoogleAuthenticator` calls `loginFacade:loginToWordPressDotComWithSocialIDToken`. It catches the resulting Google login status, and calls delegate methods in `LoginPrologueViewController`, which updates the UI itself.

Note: 
`LoginEmailViewController` is still reliant on `LoginViewController`, so the code in `LoginViewController` remains. It will be removed when `LoginEmailViewController` is updated in a future PR.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14164