### PR TITLE
Use refactored Google login from email entry view

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.17.0-beta.5"
+  s.version       = "1.17.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
@@ -56,9 +56,8 @@ class GoogleAuthenticator: NSObject {
 // MARK: - Private Extension
 
 private extension GoogleAuthenticator {
-    
-    
-    /// Initiates the Google authenication flow.
+
+    /// Initiates the Google authentication flow.
     ///   - viewController: The UIViewController that Google is being presented from.
     ///                     Required by Google SDK.
     func requestAuthorization(from viewController: UIViewController) {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import Lottie
 import WordPressShared
 import WordPressUI
-import GoogleSignIn
 import WordPressKit
 
 class LoginPrologueViewController: LoginViewController {


### PR DESCRIPTION
Ref #282 

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/284 refactored the Google login logic into `GoogleAuthenticator`. 

This change:
- Updates `LoginEmailViewController` to use `GoogleAuthenticator` instead of `LoginViewController` for the Google login logic.
- Removes the Google login methods from `LoginViewController`, and updates `LoginEmailViewController` to handle Google login responses itself.

Can be tested with WCiOS PR: https://github.com/woocommerce/woocommerce-ios/pull/2341