### PR TITLE
Refactor Google signup logic

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.17.0-beta.7"
+  s.version       = "1.17.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
@@ -29,12 +29,14 @@ protocol GoogleAuthenticatorSignupDelegate {
     // Google account signup was successful.
     func googleFinishedSignup(credentials: AuthenticatorCredentials, loginFields: LoginFields)
 
-    // Google account login was successful.
+    // Google account signup redirected to login was successful.
     func googleLoggedInInstead(credentials: AuthenticatorCredentials, loginFields: LoginFields)
 
     // Google account signup failed.
     func googleSignupFailed(error: Error, loginFields: LoginFields)
 
+    // Google account signup cancelled by user.
+    func googleSignupCancelled()
 }
 
 class GoogleAuthenticator: NSObject {
@@ -145,7 +147,7 @@ extension GoogleAuthenticator: GIDSignInDelegate {
             let token = user.authentication.idToken,
             let email = user.profile.email else {
                 
-                // The Google SignIn may have been canceled.
+                // The Google SignIn may have been cancelled.
                 let properties = ["error": error?.localizedDescription ?? ""]
 
                 switch authType {
@@ -155,6 +157,8 @@ extension GoogleAuthenticator: GIDSignInDelegate {
                     track(.signupSocialButtonFailure, properties: properties)
                 }
 
+                // Notify the signupDelegate so the Google Signup view can be dismissed.
+                signupDelegate?.googleSignupCancelled()
                 return
         }
         

--- a/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
@@ -125,7 +125,7 @@ private extension GoogleAuthenticator {
         static let googleConnected = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
         static let googleConnectedError = NSLocalizedString("The Google account \"%@\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
         static let googleUnableToConnect = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
-        static let completingSignup = NSLocalizedString("Completing Signup", comment: "Shown while the app waits for the site creation process to complete.")
+        static let processing = NSLocalizedString("Processing Account", comment: "Shown while the app waits for the account process to complete.")
         static let signupFailed = NSLocalizedString("Google sign up failed.", comment: "Message shown on screen after the Google sign up process failed.")
     }
 
@@ -150,12 +150,9 @@ extension GoogleAuthenticator: GIDSignInDelegate {
                 case .login:
                     WordPressAuthenticator.track(.loginSocialButtonFailure, properties: properties as [AnyHashable : Any])
                 case .signup:
-                    // add source?
                     WordPressAuthenticator.track(.signupSocialButtonFailure, error: error)
                 }
 
-                // need to return to delegate. Signup pops the VC.
-                
                 return
         }
         
@@ -245,8 +242,10 @@ private extension GoogleAuthenticator {
     /// Creates a WordPress.com account with the associated Google User + Google Token + Google Email.
     ///
     func createWordPressComUser(user: GIDGoogleUser, token: String, email: String) {
-        // TODO: fix this message
-        SVProgressHUD.show(withStatus: LocalizedText.completingSignup)
+
+        // At this point, we don't know if we're logging in or signing up.
+        // So we'll show a generic message in the HUD.
+        SVProgressHUD.show(withStatus: LocalizedText.processing)
 
         let service = SignupService()
 

--- a/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/GoogleAuthenticator.swift
@@ -1,9 +1,14 @@
 import Foundation
 import GoogleSignIn
 import WordPressKit
+import SVProgressHUD
 
-protocol GoogleAuthenticatorDelegate {
-    
+// Indicate which type of authentication is initiated.
+// TODO: remove when Google auth flows are unified.
+enum GoogleAuthType {
+    case login
+    case signup
+}
 
 protocol GoogleAuthenticatorLoginDelegate {
     // Google account login was successful.
@@ -44,6 +49,7 @@ class GoogleAuthenticator: NSObject {
     private var loginFields = LoginFields()
     private let authConfig = WordPressAuthenticator.shared.configuration
     private let trackSource: [AnyHashable: Any] = ["source": "google"]
+    private var authType: GoogleAuthType = .login
     
     private lazy var loginFacade: LoginFacade = {
         let facade = LoginFacade(dotcomClientID: authConfig.wpcomClientId,
@@ -62,9 +68,11 @@ class GoogleAuthenticator: NSObject {
     ///   - loginFields: LoginFields from the calling view controller.
     ///                  The values are updated during the Google process,
     ///                  and returned to the calling view controller via delegate methods.
-    func showFrom(viewController: UIViewController, loginFields: LoginFields) {
+    ///   - authType: Indicates the type of authentication (login or signup)
+    func showFrom(viewController: UIViewController, loginFields: LoginFields, for authType: GoogleAuthType) {
         self.loginFields = loginFields
         self.loginFields.meta.socialService = SocialServiceName.google
+        self.authType = authType
         requestAuthorization(from: viewController)
     }
     

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -481,7 +481,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     @objc func googleTapped() {
         GoogleAuthenticator.sharedInstance.loginDelegate = self
-        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields)
+        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
     }
 
     @IBAction func handleTextFieldDidChange(_ sender: UITextField) {

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -570,7 +570,7 @@ extension LoginEmailViewController: AppleAuthenticatorDelegate {
 
 }
 
-// MARK: - GoogleAuthenticatorDelegate
+// MARK: - GoogleAuthenticatorLoginDelegate
 
 extension LoginEmailViewController: GoogleAuthenticatorLoginDelegate {
 

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -480,7 +480,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     }
 
     @objc func googleTapped() {
-        GoogleAuthenticator.sharedInstance.delegate = self
+        GoogleAuthenticator.sharedInstance.loginDelegate = self
         GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields)
     }
 
@@ -572,7 +572,7 @@ extension LoginEmailViewController: AppleAuthenticatorDelegate {
 
 // MARK: - GoogleAuthenticatorDelegate
 
-extension LoginEmailViewController: GoogleAuthenticatorDelegate {
+extension LoginEmailViewController: GoogleAuthenticatorLoginDelegate {
 
     func googleFinishedLogin(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
         self.loginFields = loginFields
@@ -611,7 +611,7 @@ extension LoginEmailViewController: GoogleAuthenticatorDelegate {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    func googleRemoteError(errorTitle: String, errorDescription: String, loginFields: LoginFields) {
+    func googleLoginFailed(errorTitle: String, errorDescription: String, loginFields: LoginFields) {
         self.loginFields = loginFields
         configureViewLoading(false)
 

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -80,8 +80,6 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     }
 
     @objc func handleGoogleButtonTapped() {
-        WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "google"])
-
         dismiss(animated: true)
         googleTapped?()
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -163,7 +163,7 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func googleTapped() {
-        GoogleAuthenticator.sharedInstance.delegate = self
+        GoogleAuthenticator.sharedInstance.loginDelegate = self
         GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields)
     }
 
@@ -200,7 +200,7 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
 
 // MARK: - GoogleAuthenticatorDelegate
 
-extension LoginPrologueViewController: GoogleAuthenticatorDelegate {
+extension LoginPrologueViewController: GoogleAuthenticatorLoginDelegate {
 
     func googleFinishedLogin(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
         self.loginFields = loginFields
@@ -237,7 +237,7 @@ extension LoginPrologueViewController: GoogleAuthenticatorDelegate {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    func googleRemoteError(errorTitle: String, errorDescription: String, loginFields: LoginFields) {
+    func googleLoginFailed(errorTitle: String, errorDescription: String, loginFields: LoginFields) {
         self.loginFields = loginFields
 
         let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription)

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -164,7 +164,7 @@ class LoginPrologueViewController: LoginViewController {
 
     private func googleTapped() {
         GoogleAuthenticator.sharedInstance.loginDelegate = self
-        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields)
+        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
     }
 
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -198,7 +198,7 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
 
 }
 
-// MARK: - GoogleAuthenticatorDelegate
+// MARK: - GoogleAuthenticatorLoginDelegate
 
 extension LoginPrologueViewController: GoogleAuthenticatorLoginDelegate {
 

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -53,7 +53,7 @@ private extension SignupGoogleViewController {
 
 }
 
-// MARK: - GoogleAuthenticatorDelegate
+// MARK: - GoogleAuthenticatorSignupDelegate
 
 extension SignupGoogleViewController: GoogleAuthenticatorSignupDelegate {
 
@@ -72,6 +72,10 @@ extension SignupGoogleViewController: GoogleAuthenticatorSignupDelegate {
         titleLabel?.textColor = WPStyleGuide.errorRed()
         titleLabel?.text = LocalizedText.signupFailed
         displayError(error as NSError, sourceTag: .wpComSignup)
+    }
+
+    func googleSignupCancelled() {
+        navigationController?.popViewController(animated: true)
     }
 
 }

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -1,8 +1,6 @@
-import GoogleSignIn
-import SVProgressHUD
-import WordPressShared
 
-/// View controller that handles the google signup code
+/// View controller that handles the google signup flow
+///
 class SignupGoogleViewController: LoginViewController {
 
     // MARK: - Properties
@@ -20,8 +18,7 @@ class SignupGoogleViewController: LoginViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        titleLabel?.text = NSLocalizedString("Waiting for Google to complete…", comment: "Message shown on screen while waiting for Google to finish its signup process.")
-        WordPressAuthenticator.track(.createAccountInitiated, properties: ["source": "google"])
+        titleLabel?.text = LocalizedText.waitingForGoogle
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -29,134 +26,52 @@ class SignupGoogleViewController: LoginViewController {
         showGoogleScreenIfNeeded()
     }
 
-    private func showGoogleScreenIfNeeded() {
+}
+
+// MARK: - Private Methods
+
+private extension SignupGoogleViewController {
+
+    func showGoogleScreenIfNeeded() {
         guard !hasShownGoogle else {
             return
         }
 
-        showGoogleScreen()
-        hasShownGoogle = true
-    }
-
-    private func showGoogleScreen() {
-        GIDSignIn.sharedInstance().disconnect()
-
         // Flag this as a social sign in.
         loginFields.meta.socialService = .google
 
-        // Configure all the things and sign in.
-        guard let googleSSO = GIDSignIn.sharedInstance() else {
-            DDLogError("Something is very, very, very off. Well done, Google.")
-            return
-        }
+        GoogleAuthenticator.sharedInstance.signupDelegate = self
+        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .signup)
 
-        googleSSO.delegate = self
-        googleSSO.presentingViewController = self
-        googleSSO.clientID = WordPressAuthenticator.shared.configuration.googleLoginClientId
-        googleSSO.serverClientID = WordPressAuthenticator.shared.configuration.googleLoginServerClientId
-
-        googleSSO.signIn()
+        hasShownGoogle = true
     }
+
+    enum LocalizedText {
+        static let waitingForGoogle = NSLocalizedString("Waiting for Google to complete…", comment: "Message shown on screen while waiting for Google to finish its signup process.")
+        static let signupFailed = NSLocalizedString("Google sign up failed.", comment: "Message shown on screen after the Google sign up process failed.")
+    }
+
 }
 
+// MARK: - GoogleAuthenticatorDelegate
 
-// MARK: - GIDSignInDelegate
+extension SignupGoogleViewController: GoogleAuthenticatorSignupDelegate {
 
-extension SignupGoogleViewController: GIDSignInDelegate {
-
-    func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
-        GIDSignIn.sharedInstance().disconnect()
-
-        guard let googleUser = user, let googleToken = googleUser.authentication.idToken, let googleEmail = googleUser.profile.email else {
-            WordPressAuthenticator.track(.signupSocialButtonFailure, error: error)
-            self.navigationController?.popViewController(animated: true)
-            return
-        }
-
-        updateLoginFields(googleUser: googleUser, googleToken: googleToken, googleEmail: googleEmail)
-        createWordPressComUser(googleUser: googleUser, googleToken: googleToken, googleEmail: googleEmail)
-    }
-}
-
-
-// MARK: - WordPress.com Account Creation Methods
-//
-private extension SignupGoogleViewController {
-
-    /// Creates a WordPress.com account with the associated GoogleUser + GoogleToken + GoogleEmail.
-    ///
-    func createWordPressComUser(googleUser: GIDGoogleUser, googleToken: String, googleEmail: String) {
-        SVProgressHUD.show(withStatus: NSLocalizedString("Completing Signup", comment: "Shown while the app waits for the site creation process to complete."))
-
-        let service = SignupService()
-
-        service.createWPComUserWithGoogle(token: googleToken, success: { [weak self] accountCreated, wpcomUsername, wpcomToken in
-
-            let wpcom = WordPressComCredentials(authToken: wpcomToken, isJetpackLogin: false, multifactor: false, siteURL: self?.loginFields.siteAddress ?? "")
-            let credentials = AuthenticatorCredentials(wpcom: wpcom)
-
-            /// New Account: We'll signal the host app right away!
-            ///
-            if accountCreated {
-                SVProgressHUD.dismiss()
-                self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
-                self?.socialSignupWasSuccessful(with: credentials)
-                return
-            }
-
-            /// Existing Account: We'll synchronize all the things before proceeding to the next screen.
-            ///
-            self?.authenticationDelegate.sync(credentials: credentials) {
-                SVProgressHUD.dismiss()
-                self?.wasLoggedInInstead(with: credentials)
-            }
-
-        }, failure: { [weak self] error in
-            SVProgressHUD.dismiss()
-            self?.socialSignupDidFail(with: error)
-        })
-    }
-
-
-    /// Social Signup Successful: Analytics + Pushing the Signup Epilogue.
-    ///
-    func socialSignupWasSuccessful(with credentials: AuthenticatorCredentials) {
-        // This stat is part of a funnel that provides critical information.  Before
-        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
-        WordPressAuthenticator.track(.createdAccount, properties: ["source": "google"])
-        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
-        WordPressAuthenticator.track(.signupSocialSuccess, properties: ["source": "google"])
-
+    func googleFinishedSignup(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        self.loginFields = loginFields
         showSignupEpilogue(for: credentials)
     }
-
-    /// Social Login Successful: Analytics + Pushing the Login Epilogue.
-    ///
-    func wasLoggedInInstead(with credentials: AuthenticatorCredentials) {
-        WordPressAuthenticator.track(.signedIn, properties: ["source": "google"])
-        WordPressAuthenticator.track(.signupSocialToLogin, properties: ["source": "google"])
-        WordPressAuthenticator.track(.loginSocialSuccess, properties: ["source": "google"])
-
+    
+    func googleLoggedInInstead(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        self.loginFields = loginFields
         showLoginEpilogue(for: credentials)
     }
-
-    /// Social Signup Failure: Analytics + UI Updates
-    ///
-    func socialSignupDidFail(with error: Error) {
-
-        let properties = [ "source": "google",
-                           "error": error.localizedDescription
-        ]
-
-        WordPressAuthenticator.track(.signupSocialFailure, properties: properties)
-
-        if (error as? SignupError) == .unknown {
-            navigationController?.popViewController(animated: true)
-            return
-        }
-
+    
+    func googleSignupFailed(error: Error, loginFields: LoginFields) {
+        self.loginFields = loginFields
         titleLabel?.textColor = WPStyleGuide.errorRed()
-        titleLabel?.text = NSLocalizedString("Google sign up failed.", comment: "Message shown on screen after the Google sign up process failed.")
+        titleLabel?.text = LocalizedText.signupFailed
         displayError(error as NSError, sourceTag: .wpComSignup)
     }
+
 }


### PR DESCRIPTION
Ref #282 

This moves the Google Signup logic out of `SignupGoogleViewController` and into `GoogleAuthenticator`. `SignupGoogleViewController` is notified of Google's progress via `GoogleAuthenticatorSignupDelegate` methods.

Regarding the `GoogleAuthenticator` delegates:

Because `AuthenticatorCredentials` is a Swift `struct`, it isn't visible to ObjC. Therefore, I couldn't use one delegate protocol with optional methods. So I created two protocols, containing their own required methods. `GoogleAuthenticatorDelegate` has become `GoogleAuthenticatorLoginDelegate` and `GoogleAuthenticatorSignupDelegate`.

And an honorable mention:

The `SVProgressHUD` that is displayed after selecting a Google account always said `Completing Signup`. That was misleading (and a bit scary) when signup was redirected to login. So I've changed it to the more generic `Processing Account`.

Can tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14196