### PR TITLE
ULS: Adding new VC to be displayed for both Google flows

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.17.0-beta.9"
+  s.version       = "1.17.0-beta.10"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */; };
 		98C9195B2308E3DA00A90E12 /* AppleAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */; };
 		98D9A4B12474A526002E491C /* GoogleAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */; };
+		98ED483624802F8F00992B2D /* GoogleAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ED483424802F8F00992B2D /* GoogleAuthViewController.swift */; };
+		98ED48392480300500992B2D /* GoogleAuthViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98ED48382480300500992B2D /* GoogleAuthViewController.storyboard */; };
 		B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */; };
 		B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */; };
 		B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B501C040208FC52500D1E58F /* LoginFacadeTests.m */; };
@@ -168,6 +170,8 @@
 		98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPHelpIndicatorView.swift; sourceTree = "<group>"; };
 		98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthenticator.swift; sourceTree = "<group>"; };
 		98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleAuthenticator.swift; sourceTree = "<group>"; };
+		98ED483424802F8F00992B2D /* GoogleAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthViewController.swift; sourceTree = "<group>"; };
+		98ED48382480300500992B2D /* GoogleAuthViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GoogleAuthViewController.storyboard; sourceTree = "<group>"; };
 		AE612958059F9E80B54138B3 /* Pods-WordPressAuthenticatorTests.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release-internal.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release-internal.xcconfig"; sourceTree = "<group>"; };
 		B0D7D40BC1DE2D367761AD86 /* Pods-WordPressAuthenticatorTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginFieldsValidationTests.swift; sourceTree = "<group>"; };
@@ -362,6 +366,8 @@
 			isa = PBXGroup;
 			children = (
 				98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */,
+				98ED483424802F8F00992B2D /* GoogleAuthViewController.swift */,
+				98ED48382480300500992B2D /* GoogleAuthViewController.storyboard */,
 			);
 			path = "Unified Auth";
 			sourceTree = "<group>";
@@ -761,6 +767,7 @@
 				B56090CA208A4F5400399AE4 /* NUXButtonView.storyboard in Resources */,
 				B560911E208A555E00399AE4 /* Signup.storyboard in Resources */,
 				B5609118208A555600399AE4 /* SearchTableViewCell.xib in Resources */,
+				98ED48392480300500992B2D /* GoogleAuthViewController.storyboard in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
 				B5609137208A563800399AE4 /* EmailMagicLink.storyboard in Resources */,
 				3FFF2FC123D7ED7C00D38C77 /* EmailClients.plist in Resources */,
@@ -926,6 +933,7 @@
 				B5609120208A555E00399AE4 /* SignupNavigationController.swift in Sources */,
 				B5609143208A563800399AE4 /* LoginSocialErrorViewController.swift in Sources */,
 				B56090F8208A533200399AE4 /* WordPressAuthenticator+Notifications.swift in Sources */,
+				98ED483624802F8F00992B2D /* GoogleAuthViewController.swift in Sources */,
 				B56090EA208A51D000399AE4 /* LoginFields+Validation.swift in Sources */,
 				CE1B18CC20EEC32400BECC3F /* WordPressComCredentials.swift in Sources */,
 				98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -64,7 +64,11 @@ public struct WordPressAuthenticatorConfiguration {
     /// Flag indicating if the unified login by Site Address flow should display.
     ///
     let enableUnifiedSiteAddress: Bool
-    
+
+    /// Flag indicating if the unified Google flow should display.
+    ///
+    let enableUnifiedGoogle: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -80,7 +84,8 @@ public struct WordPressAuthenticatorConfiguration {
                  showLoginOptions: Bool = false,
                  enableSignInWithApple: Bool = false,
                  enableUnifiedAuth: Bool = false,
-                 enableUnifiedSiteAddress: Bool = false) {
+                 enableUnifiedSiteAddress: Bool = false,
+                 enableUnifiedGoogle: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -96,5 +101,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
         self.enableUnifiedSiteAddress = enableUnifiedAuth && enableUnifiedSiteAddress
+        self.enableUnifiedGoogle = enableUnifiedAuth && enableUnifiedGoogle
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
@@ -57,6 +57,9 @@ extension WordPressSupportSourceTag {
     public static var wpComSignupWaitingForGoogle: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "wpComSignupWaitingForGoogle", origin: "origin:signup-waiting-for-google")
     }
+    public static var wpComAuthWaitingForGoogle: WordPressSupportSourceTag {
+        return WordPressSupportSourceTag(name: "wpComAuthWaitingForGoogle", origin: "origin:auth-waiting-for-google")
+    }
     public static var wpComSignupMagicLink: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "wpComSignupMagicLink", origin: "origin:signup-magic-link")
     }

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -6,6 +6,7 @@ enum Storyboard: String {
     case login = "Login"
     case signup = "Signup"
     case emailMagicLink = "EmailMagicLink"
+    case googleAuth = "GoogleAuthViewController"
 
     var instance: UIStoryboard {
         return UIStoryboard(name: self.rawValue, bundle: WordPressAuthenticator.bundle)

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -213,12 +213,12 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             }
 
             vc.googleTapped = { [weak self] in
-                guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
-                    DDLogError("Failed to navigate to SignupGoogleViewController")
+                guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
+                    self?.presentGoogleSignupView()
                     return
                 }
 
-                self?.navigationController?.pushViewController(toVC, animated: true)
+                self?.presentUnifiedGoogleView()
             }
 
             vc.appleTapped = { [weak self] in
@@ -480,8 +480,33 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     }
 
     @objc func googleTapped() {
-        GoogleAuthenticator.sharedInstance.loginDelegate = self
-        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
+            GoogleAuthenticator.sharedInstance.loginDelegate = self
+            GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
+            return
+        }
+
+        presentUnifiedGoogleView()
+    }
+
+    // Shows the VC that handles both Google login & signup.
+    private func presentUnifiedGoogleView() {
+        guard let toVC = GoogleAuthViewController.instantiate(from: .googleAuth) else {
+            DDLogError("Failed to navigate to GoogleAuthViewController from LoginPrologueVC")
+            return
+        }
+        
+        navigationController?.pushViewController(toVC, animated: true)
+    }
+
+    // Shows the VC that handles only Google signup.
+    private func presentGoogleSignupView() {
+        guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
+            DDLogError("Failed to navigate to SignupGoogleViewController from LoginEmailVC")
+            return
+        }
+
+        navigationController?.pushViewController(toVC, animated: true)
     }
 
     @IBAction func handleTextFieldDidChange(_ sender: UITextField) {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -142,12 +142,12 @@ class LoginPrologueViewController: LoginViewController {
         }
 
         vc.googleTapped = { [weak self] in
-            guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
-                DDLogError("Failed to navigate to SignupGoogleViewController")
+            guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
+                self?.presentGoogleSignupView()
                 return
             }
 
-            self?.navigationController?.pushViewController(toVC, animated: true)
+            self?.presentUnifiedGoogleView()
         }
 
         vc.appleTapped = { [weak self] in
@@ -163,10 +163,35 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func googleTapped() {
-        GoogleAuthenticator.sharedInstance.loginDelegate = self
-        GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
+            GoogleAuthenticator.sharedInstance.loginDelegate = self
+            GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
+            return
+        }
+
+        presentUnifiedGoogleView()
     }
 
+    // Shows the VC that handles both Google login & signup.
+    private func presentUnifiedGoogleView() {
+        guard let toVC = GoogleAuthViewController.instantiate(from: .googleAuth) else {
+            DDLogError("Failed to navigate to GoogleAuthViewController from LoginPrologueVC")
+            return
+        }
+        
+        navigationController?.pushViewController(toVC, animated: true)
+    }
+
+    // Shows the VC that handles only Google signup.
+    private func presentGoogleSignupView() {
+        guard let toVC = SignupGoogleViewController.instantiate(from: .signup) else {
+            DDLogError("Failed to navigate to SignupGoogleViewController from LoginPrologueVC")
+            return
+        }
+
+        navigationController?.pushViewController(toVC, animated: true)
+    }
+    
 }
 
 // MARK: - AppleAuthenticatorDelegate

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthViewController.storyboard
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthViewController.storyboard
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Google Auth View Controller-->
+        <scene sceneID="MMt-yQ-y29">
+            <objects>
+                <viewController storyboardIdentifier="GoogleAuthViewController" id="nkP-9y-aas" customClass="GoogleAuthViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="qQD-Kd-Dmk">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="social-signup-waiting" translatesAutoresizingMaskIntoConstraints="NO" id="UWt-Xu-XZp">
+                                <rect key="frame" x="80" y="382.5" width="254" height="141"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="UWt-Xu-XZp" secondAttribute="height" multiplier="273:152" id="rJg-QF-nzN"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Waiting for Google to complete…" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzq-mF-V4b">
+                                <rect key="frame" x="20" y="553.5" width="374" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="GL3-rH-WLV"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="wzq-mF-V4b" firstAttribute="centerX" secondItem="UWt-Xu-XZp" secondAttribute="centerX" id="0LH-s7-5YN"/>
+                            <constraint firstItem="UWt-Xu-XZp" firstAttribute="leading" secondItem="qQD-Kd-Dmk" secondAttribute="leading" constant="80" id="22D-HU-NSr"/>
+                            <constraint firstItem="wzq-mF-V4b" firstAttribute="top" secondItem="UWt-Xu-XZp" secondAttribute="bottom" constant="30" id="PCR-54-cOa"/>
+                            <constraint firstItem="v8C-Wi-7gi" firstAttribute="trailing" secondItem="wzq-mF-V4b" secondAttribute="trailing" constant="20" id="QgU-Ot-BdI"/>
+                            <constraint firstItem="wzq-mF-V4b" firstAttribute="leading" secondItem="v8C-Wi-7gi" secondAttribute="leading" constant="20" id="ZEh-9u-dC6"/>
+                            <constraint firstItem="UWt-Xu-XZp" firstAttribute="centerX" secondItem="v8C-Wi-7gi" secondAttribute="centerX" id="wZC-1Z-50h"/>
+                            <constraint firstItem="UWt-Xu-XZp" firstAttribute="centerY" secondItem="v8C-Wi-7gi" secondAttribute="centerY" id="xAL-22-Ir0"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="v8C-Wi-7gi"/>
+                    </view>
+                    <connections>
+                        <outlet property="titleLabel" destination="wzq-mF-V4b" id="trk-oh-FeK"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LZN-e8-2hh" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-600" y="427"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="social-signup-waiting" width="273" height="152"/>
+    </resources>
+</document>

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthViewController.swift
@@ -1,0 +1,54 @@
+
+/// View controller that handles the google authentication flow
+///
+class GoogleAuthViewController: LoginViewController {
+
+    // MARK: - Properties
+
+    private var hasShownGoogle = false
+    @IBOutlet var titleLabel: UILabel?
+
+    override var sourceTag: WordPressSupportSourceTag {
+        get {
+            return .wpComAuthWaitingForGoogle
+        }
+    }
+
+    // MARK: - View
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        titleLabel?.text = LocalizedText.waitingForGoogle
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        showGoogleScreenIfNeeded()
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension GoogleAuthViewController {
+
+    func showGoogleScreenIfNeeded() {
+        guard !hasShownGoogle else {
+            return
+        }
+
+        // Flag this as a social sign in.
+        loginFields.meta.socialService = .google
+
+        // TODO: kick off GoogleAuthenticator here
+        // GoogleAuthenticator.sharedInstance.signupDelegate = self
+        // GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .signup)
+        // hasShownGoogle = true
+    }
+
+    enum LocalizedText {
+        // TODO: use real message
+        static let waitingForGoogle = NSLocalizedString("I AM LEGEND!!!", comment: "Message shown on screen while waiting for Google to finish its process.")
+    }
+
+}


### PR DESCRIPTION
Ref #282 

To support unified Google flows, this adds:
- An `enableUnifiedGoogle` setting to `WordPressAuthenticatorConfiguration`.
- `GoogleAuthViewController` and storyboard to display a 'waiting for Google' view.
  - This view is the same as is displayed in the current Google _signup_ flow. The UI will be updated later.
  - If `enableUnifiedGoogle` is enabled, `GoogleAuthViewController` will be displayed for both Google login and signup flows.

Caveats:
- Right now, `GoogleAuthViewController` doesn't actually do any Google-y goodness. It just shows a view after selecting either `Continue with Google` option. The intent is for all Google authentication to be facilitated by this view.
- To easily differentiate this view from the old one (displayed in the Google _signup_ flow), the displayed message is `I AM LEGEND!!!`. I will of course change it later, but you certainly know which one you're looking at.  😄

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14211