### PR TITLE
ULS: Unify Google auth flows

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.18.0-beta.3"
+  s.version       = "1.18.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
To accommodate unified Google auth flow:

- There is now a `GoogleAuthenticatorDelegate` that encompasses all delegate methods needed for the unified flow. 
  - This is only used by `GoogleAuthViewController` (the VC for the unified flow).
  - `GoogleAuthenticatorLoginDelegate` and `GoogleAuthenticatorSignupDelegate` remain to support the old separate flows (`LoginPrologueViewController`, `LoginEmailViewController`, `SignupGoogleViewController`) .
- Bonus: The `Processing Account` HUD is now shown in the login flow (previously it was only shown in signup).

With this change, the Google flows are unified. Since `GoogleAuthViewController` is presented from both login and signup, they both use the same flow. 🎉 

There is one path that is not unified yet. 

After a Google account is selected, `GoogleAuthenticator` will first attempt to login. If a WP account does not exist, it does not redirect to signup as there is no logic currently to do so. (That's the point of this project after all, innit? 😄 ) Instead, this view is displayed. This will be addressed in a future PR. Stay tuned!

![login_with_new_acct](https://user-images.githubusercontent.com/1816888/83565908-69064380-a4dc-11ea-96a1-2e65ae3a81de.png)
