### PR TITLE
ULS: Add new style struct for unified styles 

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.18.0-beta.4"
+  s.version       = "1.18.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -40,6 +40,10 @@ import AuthenticationServices
     ///
     public let style: WordPressAuthenticatorStyle
 
+    /// Authenticator's Styles for unified flows.
+    ///
+    public let unifiedStyle: WordPressAuthenticatorUnifiedStyle?
+    
     /// Authenticator's Display Images.
     ///
     public let displayImages: WordPressAuthenticatorDisplayImages
@@ -69,10 +73,12 @@ import AuthenticationServices
     ///
     private init(configuration: WordPressAuthenticatorConfiguration,
                  style: WordPressAuthenticatorStyle,
+                 unifiedStyle: WordPressAuthenticatorUnifiedStyle?,
                  displayImages: WordPressAuthenticatorDisplayImages,
                  displayStrings: WordPressAuthenticatorDisplayStrings) {
         self.configuration = configuration
         self.style = style
+        self.unifiedStyle = unifiedStyle
         self.displayImages = displayImages
         self.displayStrings = displayStrings
     }
@@ -81,6 +87,7 @@ import AuthenticationServices
     ///
     public static func initialize(configuration: WordPressAuthenticatorConfiguration,
                                   style: WordPressAuthenticatorStyle,
+                                  unifiedStyle: WordPressAuthenticatorUnifiedStyle?,
                                   displayImages: WordPressAuthenticatorDisplayImages = .defaultImages,
                                   displayStrings: WordPressAuthenticatorDisplayStrings = .defaultStrings) {
         guard privateInstance == nil else {
@@ -89,6 +96,7 @@ import AuthenticationServices
 
         privateInstance = WordPressAuthenticator(configuration: configuration,
                                                  style: style,
+                                                 unifiedStyle: unifiedStyle,
                                                  displayImages: displayImages,
                                                  displayStrings: displayStrings)
     }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -111,3 +111,20 @@ public struct WordPressAuthenticatorStyle {
         self.statusBarStyle = statusBarStyle
     }
 }
+
+// MARK: - WordPress Unified Authenticator Styles
+//
+// Styles specifically for the unified auth flows.
+//
+public struct WordPressAuthenticatorUnifiedStyle {
+
+    /// Style: Auth view background colors
+    ///
+    public let viewControllerBackgroundColor: UIColor
+
+    /// Designated initializer
+    ///
+    public init(viewControllerBackgroundColor: UIColor) {
+        self.viewControllerBackgroundColor = viewControllerBackgroundColor
+    }
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -22,6 +22,16 @@ final class SiteAddressViewController: LoginViewController {
         submitButton?.setTitle(primaryTitle, for: .normal)
         submitButton?.setTitle(primaryTitle, for: .highlighted)
     }
+    
+    override func styleBackground() {
+        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
+                super.styleBackground()
+                return
+        }
+
+        view.backgroundColor = unifiedBackgroundColor
+    }
+    
 }
 
 


### PR DESCRIPTION
Ref: #182 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14242

This adds a new `WordPressAuthenticatorUnifiedStyle` to contain styles specific to the unified flows.

Right now, it only contains the view background color as that's all that's needed. We'll add to it as more styles are required.

The initial idea was for the style to be set according to the unified flows being enabled/disabled. However, just because a unified flow is enabled doesn't mean that's what's being presented. Meaning if the new background color were used in `LoginViewController`, the background color will change for _all_ views, not just the specific unified ones.

Instead, each `ViewController` in unified paths will have to override `styleBackground` so it gets the right color when it's displayed.

In the future, this can probably be set globally again and removed from each VC. But for now, since we're mixing flows, this should work.