### PR TITLE
ULS: Create Google account

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.18.0-beta.7"
+  s.version       = "1.18.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
@@ -17,7 +17,7 @@ class GoogleAuthViewController: LoginViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        titleLabel?.text = LocalizedText.waitingForGoogle
+        titleLabel?.text = NSLocalizedString("Waiting for Google to complete…", comment: "Message shown on screen while waiting for Google to finish its signup process.")
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -66,16 +66,13 @@ private extension GoogleAuthViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    enum LocalizedText {
-        static let waitingForGoogle = NSLocalizedString("Waiting for Google to complete…", comment: "Message shown on screen while waiting for Google to finish its signup process.")
-        static let signupFailed = NSLocalizedString("Google sign up failed.", comment: "Message shown on screen after the Google sign up process failed.")
-    }
-
 }
 
 // MARK: - GoogleAuthenticatorDelegate
 
 extension GoogleAuthViewController: GoogleAuthenticatorDelegate {
+
+    // MARK: - Login
 
     func googleFinishedLogin(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
         self.loginFields = loginFields
@@ -86,7 +83,7 @@ extension GoogleAuthViewController: GoogleAuthenticatorDelegate {
         self.loginFields = loginFields
 
         guard let vc = Login2FAViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
+            DDLogError("Failed to navigate from GoogleAuthViewController to Login2FAViewController")
             return
         }
 
@@ -101,7 +98,7 @@ extension GoogleAuthViewController: GoogleAuthenticatorDelegate {
         self.loginFields = loginFields
 
         guard let vc = LoginWPComViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from Google Login to LoginWPComViewController (password VC)")
+            DDLogError("Failed to navigate from GoogleAuthViewController to LoginWPComViewController")
             return
         }
 
@@ -122,21 +119,23 @@ extension GoogleAuthViewController: GoogleAuthenticatorDelegate {
         redirectToSignup ? showSignupConfirmationView() :
                            showLoginErrorView(errorTitle: errorTitle, errorDescription: errorDescription)
     }
-    
-    func googleFinishedSignup(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
-        self.loginFields = loginFields
-        showSignupEpilogue(for: credentials)
-    }
-    
-    func googleSignupFailed(error: Error, loginFields: LoginFields) {
-        self.loginFields = loginFields
-        titleLabel?.textColor = WPStyleGuide.errorRed()
-        titleLabel?.text = LocalizedText.signupFailed
-        displayError(error as NSError, sourceTag: .wpComSignup)
-    }
 
     func googleAuthCancelled() {
         navigationController?.popViewController(animated: true)
+    }
+
+    // MARK: - Signup
+
+    func googleFinishedSignup(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        // Here for protocol compliance.
+    }
+
+    func googleLoggedInInstead(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        // Here for protocol compliance.
+    }
+
+    func googleSignupFailed(error: Error, loginFields: LoginFields) {
+        // Here for protocol compliance.
     }
 
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
@@ -46,13 +46,62 @@ private extension GoogleSignupConfirmationViewController {
         submitButton?.accessibilityIdentifier = "Google Signup Email Next Button"
     }
     
-    // MARK: - Button Action Handling
+    // MARK: - Button Handling
 
     @IBAction func handleSubmit() {
-        displayError(message: "Cheers!")
-        // TODO: create account.
-        // TODO: re-enable this when handling added.
-        // configureSubmitButton(animating: true)
+        configureSubmitButton(animating: true)
+        GoogleAuthenticator.sharedInstance.delegate = self
+        GoogleAuthenticator.sharedInstance.createGoogleAccount(loginFields: loginFields)
+    }
+
+}
+
+// MARK: - GoogleAuthenticatorDelegate
+
+extension GoogleSignupConfirmationViewController: GoogleAuthenticatorDelegate {
+    
+    // MARK: - Signup
+    
+    func googleFinishedSignup(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        self.loginFields = loginFields
+        showSignupEpilogue(for: credentials)
+    }
+
+    func googleLoggedInInstead(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        self.loginFields = loginFields
+        showLoginEpilogue(for: credentials)
+    }
+    
+    func googleSignupFailed(error: Error, loginFields: LoginFields) {
+        configureSubmitButton(animating: false)
+        self.loginFields = loginFields
+
+        // Display generic inline error.
+        displayError(message: NSLocalizedString("Google sign up failed.", comment: "Message shown on screen after the Google sign up process failed."))
+        // Display the API error in a Fancy Alert.
+        displayError(error as NSError, sourceTag: .wpComSignup)
+    }
+    
+    // MARK: - Login
+
+    func googleFinishedLogin(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
+        // Here for protocol compliance.
+    }
+    
+    func googleNeedsMultifactorCode(loginFields: LoginFields) {
+        // Here for protocol compliance.
+    }
+    
+    func googleExistingUserNeedsConnection(loginFields: LoginFields) {
+        // Here for protocol compliance.
+    }
+    
+    func googleLoginFailed(errorTitle: String, errorDescription: String, loginFields: LoginFields, unknownUser: Bool) {
+        // Here for protocol compliance.
+    }
+
+    func googleAuthCancelled() {
+        // Here for protocol compliance.
     }
 
 }


### PR DESCRIPTION
Ref: #282 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14258

When `Next` is tapped on the Google Signup Confirmation view, account creation is now attempted. If successful, the Signup Epilogue will be displayed.

On the off chance a user goes off somewhere else and creates a WP account with the selected Google account _while this view is still displayed_, the account will be logged in instead and the Login Epilogue displayed. _Unless_ the user has:
- Enabled 2FA on the WP account.
- Disconnected Google on the WP account.

In these cases, an error alert will be displayed. These should be edge cases, so not really worth the effort in attempting to handle them.

Side note: the way I implemented `GoogleAuthenticatorDelegate` didn't quite work out as planned, which resulted in several no-op delegate methods. I'll look at refactoring that separately.
