### PR TITLE
Update Kit and Shared pods.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,10 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7.0'
-#  pod 'WordPressKit', '~> 5.0.0-beta.1'
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/update_shared_pod'
-#  pod 'WordPressShared', '~> 1.9.0-beta.1'
-  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'issue/remove_giphy_tracks'
+  pod 'WordPressKit', '~> 5.0.0-beta.1'
+  pod 'WordPressShared', '~> 1.9.0-beta.1'
 
   ## Third party libraries
   ## =====================

--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,10 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7.0'
-  pod 'WordPressKit', '~> 4.9.0'
-  pod 'WordPressShared', '~> 1.8.16'
+#  pod 'WordPressKit', '~> 5.0.0-beta.1'
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/update_shared_pod'
+#  pod 'WordPressShared', '~> 1.9.0-beta.1'
+  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'issue/remove_giphy_tracks'
 
   ## Third party libraries
   ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -75,8 +75,8 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/update_shared_pod`)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `issue/remove_giphy_tracks`)
+  - WordPressKit (~> 5.0.0-beta.1)
+  - WordPressShared (~> 1.9.0-beta.1)
   - WordPressUI (~> 1.7.0)
 
 SPEC REPOS:
@@ -99,24 +99,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
+    - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :branch: issue/update_shared_pod
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-  WordPressShared:
-    :branch: issue/remove_giphy_tracks
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: 6ac31e3d3533baaec9ff1dbf5a240ca76c1dfd23
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-  WordPressShared:
-    :commit: d67ca763c83e561f7058db626c0d99779c1f18fc
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -142,6 +128,6 @@ SPEC CHECKSUMS:
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 5f0d8e96b85a647693797064e22584aa70b23e48
+PODFILE CHECKSUM: 326efb1141f938a0c9d270f88375459deced22fd
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,14 +48,14 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (4.9.0):
+  - WordPressKit (5.0.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
-    - WordPressShared (~> 1.8.16)
+    - WordPressShared (~> 1.9.0-beta.1)
     - wpxmlrpc (= 0.8.5)
-  - WordPressShared (1.8.16):
+  - WordPressShared (1.9.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.0)
@@ -75,8 +75,8 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.9.0)
-  - WordPressShared (~> 1.8.16)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/update_shared_pod`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `issue/remove_giphy_tracks`)
   - WordPressUI (~> 1.7.0)
 
 SPEC REPOS:
@@ -99,10 +99,24 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
-    - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: issue/update_shared_pod
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+  WordPressShared:
+    :branch: issue/remove_giphy_tracks
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: 6ac31e3d3533baaec9ff1dbf5a240ca76c1dfd23
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+  WordPressShared:
+    :commit: d67ca763c83e561f7058db626c0d99779c1f18fc
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -123,11 +137,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: 2e707edd1b28e8dd0f74a40469ca6e7be7b20a70
-  WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
+  WordPressKit: 48ef1d76727cde146db44097cfb89852b171aa72
+  WordPressShared: bc1a056b5d4da040e3addf4f510c0de67651ab1b
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 7ea0ce2ae338bad8d7402dad9daadb5149b601a8
+PODFILE CHECKSUM: 5f0d8e96b85a647693797064e22584aa70b23e48
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.18.0-beta.8"
+  s.version       = "1.18.0-beta.9"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 5.0.2'
   s.dependency 'WordPressUI', '~> 1.7.0'
-  s.dependency 'WordPressKit', '~> 4.9.0'
-  s.dependency 'WordPressShared', '~> 1.8.16'
+  s.dependency 'WordPressKit', '~> 5.0.0-beta.1'
+  s.dependency 'WordPressShared', '~> 1.9.0-beta.1'
 end


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/13803
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14302

This just updates the Shared and Kit pod versions to make the pod chain happy. Note the podspec check with fail until pod releases have been created. You should be able to test locally with the WPiOS PR.