### PR TITLE
Relax internal dependency constaints in Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,9 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7.0'
-  pod 'WordPressKit', '~> 5.0.0-beta.1'
-  pod 'WordPressShared', '~> 1.9.0-beta.1'
+  pod 'WordPressKit', '~> 4.0-beta.0' # Don't change this until we hit 5.0 in WPKit
+  pod 'WordPressShared', '~> 1.0-beta.0' # Don't change this until we hit 2.0 in WPShared
+
 
   ## Third party libraries
   ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.4.0)
-  - WordPressKit (5.0.0-beta.1):
+  - WordPressKit (4.10.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -75,8 +75,8 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 5.0.0-beta.1)
-  - WordPressShared (~> 1.9.0-beta.1)
+  - WordPressKit (~> 4.0-beta.0)
+  - WordPressShared (~> 1.0-beta.0)
   - WordPressUI (~> 1.7.0)
 
 SPEC REPOS:
@@ -123,11 +123,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressKit: 48ef1d76727cde146db44097cfb89852b171aa72
+  WordPressKit: 5205224c1a7b878b74149ab9eef1b5e89b1b20f8
   WordPressShared: bc1a056b5d4da040e3addf4f510c0de67651ab1b
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 326efb1141f938a0c9d270f88375459deced22fd
+PODFILE CHECKSUM: 476081b12ced1593942b9e2caae1118dc34c5e52
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Relaxes the dependency constraints in the Podfile to match the change to the Podspec.

When building for local development, this should prevent constantly changing the Podfile every time we change a dependency.