### PR TITLE
Relax Lottie version constraint to allow host app updates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ def wordpress_authenticator_pods
   pod 'Alamofire', '4.8'
   pod 'CocoaLumberjack', '3.5.2'
   pod 'GoogleSignIn', '5.0.2'
-  pod 'lottie-ios', '3.1.6'
+  pod 'lottie-ios', '~> 3.0'
   pod 'NSURL+IDN', '0.4'
   pod 'SVProgressHUD', '2.2.5'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -68,7 +68,7 @@ DEPENDENCIES:
   - Expecta (= 1.0.6)
   - GoogleSignIn (= 5.0.2)
   - Gridicons (~> 1.0)
-  - lottie-ios (= 3.1.6)
+  - lottie-ios (~> 3.0)
   - "NSURL+IDN (= 0.4)"
   - OCMock (~> 3.4)
   - OHHTTPStubs (= 8.0.0)
@@ -128,6 +128,6 @@ SPEC CHECKSUMS:
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 476081b12ced1593942b9e2caae1118dc34c5e52
+PODFILE CHECKSUM: 83c06840d3188d46f0dbfae4861094275a25a919
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency '1PasswordExtension', '1.8.6'
   s.dependency 'Alamofire', '4.8'
   s.dependency 'CocoaLumberjack', '~> 3.5'
-  s.dependency 'lottie-ios', '3.1.6'
+  s.dependency 'lottie-ios', '~> 3.0'
   s.dependency 'NSURL+IDN', '0.4'
   s.dependency 'SVProgressHUD', '2.2.5'
 


### PR DESCRIPTION
Allow the host app to use any version of Lottie compatible with this library without needing to update this repo.