### PR TITLE
UL&S: Add TextFieldTableViewCell to SiteAddressViewController

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.19.0-beta.1"
+  s.version       = "1.19.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.19.0-beta.2"
+  s.version       = "1.19.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -123,6 +123,8 @@
 		CE30A2A722579F4100DF3CDA /* LoginUsernamePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */; };
 		CE30A2A92257C60500DF3CDA /* WordPressOrgCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */; };
 		CE30A2AD2257CECC00DF3CDA /* AuthenticatorCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */; };
+		CE9091F72499549500AB50BD /* TextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */; };
+		CE9091F82499549500AB50BD /* TextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */; };
 		CEC77C6624854F2E00FB9050 /* SiteAddressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC77C6524854F2E00FB9050 /* SiteAddressViewController.swift */; };
 		CEC77C6824854F3E00FB9050 /* SiteAddress.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CEC77C6724854F3E00FB9050 /* SiteAddress.storyboard */; };
 		CEDE0D93242011E000CB3345 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */; };
@@ -289,6 +291,8 @@
 		CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginUsernamePasswordViewController.swift; sourceTree = "<group>"; };
 		CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentials.swift; sourceTree = "<group>"; };
 		CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatorCredentials.swift; sourceTree = "<group>"; };
+		CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewCell.swift; sourceTree = "<group>"; };
+		CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextFieldTableViewCell.xib; sourceTree = "<group>"; };
 		CEC77C6524854F2E00FB9050 /* SiteAddressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteAddressViewController.swift; sourceTree = "<group>"; };
 		CEC77C6724854F3E00FB9050 /* SiteAddress.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SiteAddress.storyboard; sourceTree = "<group>"; };
 		CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
@@ -691,6 +695,8 @@
 			children = (
 				CE00B6E8248AD72E00A91173 /* InstructionTableViewCell.swift */,
 				CE00B6E9248AD72E00A91173 /* InstructionTableViewCell.xib */,
+				CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */,
+				CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -811,6 +817,7 @@
 				B5E07FF4208FD13800657A9A /* Assets.xcassets in Resources */,
 				B56090CA208A4F5400399AE4 /* NUXButtonView.storyboard in Resources */,
 				B560911E208A555E00399AE4 /* Signup.storyboard in Resources */,
+				CE9091F82499549500AB50BD /* TextFieldTableViewCell.xib in Resources */,
 				CEC77C6824854F3E00FB9050 /* SiteAddress.storyboard in Resources */,
 				B5609118208A555600399AE4 /* SearchTableViewCell.xib in Resources */,
 				98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */,
@@ -991,6 +998,7 @@
 				B5609116208A555600399AE4 /* LoginTextField.swift in Sources */,
 				B56090E2208A4F9D00399AE4 /* WPNUXSecondaryButton.m in Sources */,
 				B56090E6208A4F9D00399AE4 /* WPNUXPrimaryButton.m in Sources */,
+				CE9091F72499549500AB50BD /* TextFieldTableViewCell.swift in Sources */,
 				B5609135208A563800399AE4 /* LoginWPComViewController.swift in Sources */,
 				CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */,
 				B5609119208A555600399AE4 /* SiteInfoHeaderView.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -118,13 +118,18 @@ public struct WordPressAuthenticatorStyle {
 //
 public struct WordPressAuthenticatorUnifiedStyle {
 
+    /// Style: Auth view border colors
+    ///
+    public let borderColor: UIColor
+
     /// Style: Auth view background colors
     ///
     public let viewControllerBackgroundColor: UIColor
 
     /// Designated initializer
     ///
-    public init(viewControllerBackgroundColor: UIColor) {
+    public init(borderColor: UIColor, viewControllerBackgroundColor: UIColor) {
+        self.borderColor = borderColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/InstructionTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/InstructionTableViewCell.swift
@@ -6,11 +6,6 @@ import UIKit
 public class InstructionTableViewCell: UITableViewCell {
 
     public static let reuseIdentifier = "InstructionTableViewCell"
-
     @IBOutlet public var instructionLabel: UILabel!
 
-    public override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -13,6 +13,7 @@ class TextFieldTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        borderView.backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor
+        let borderColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
+        borderView.backgroundColor = borderColor
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -12,7 +12,8 @@ class TextFieldTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+
+        borderView.backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -7,7 +7,12 @@ class TextFieldTableViewCell: UITableViewCell {
 
     public static let reuseIdentifier = "TextFieldTableViewCell"
 
+    private var hairlineBorderWidth: CGFloat {
+        return 1.0 / UIScreen.main.scale
+    }
+
     @IBOutlet var borderView: UIView!
+    @IBOutlet var borderWidth: NSLayoutConstraint!
     @IBOutlet var textField: UITextField!
 
     override func awakeFromNib() {
@@ -15,5 +20,6 @@ class TextFieldTableViewCell: UITableViewCell {
 
         let borderColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         borderView.backgroundColor = borderColor
+        borderWidth.constant = hairlineBorderWidth
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -15,11 +15,4 @@ class TextFieldTableViewCell: UITableViewCell {
 
         borderView.backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-    
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+
+/// TextFieldTableViewCell: a textfield in a UITableViewCell.
+///
+class TextFieldTableViewCell: UITableViewCell {
+
+    public static let reuseIdentifier = "TextFieldTableViewCell"
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -1,11 +1,14 @@
 import UIKit
 
 
-/// TextFieldTableViewCell: a textfield in a UITableViewCell.
+/// TextFieldTableViewCell: a textfield with a custom border line in a UITableViewCell.
 ///
 class TextFieldTableViewCell: UITableViewCell {
 
     public static let reuseIdentifier = "TextFieldTableViewCell"
+
+    @IBOutlet var borderView: UIView!
+    @IBOutlet var textField: UITextField!
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -11,19 +11,22 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextFieldTableViewCell" id="KGk-i7-Jjw" customClass="TextFieldTableViewCell" customModule="WordPressAuthenticator">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
-                        <rect key="frame" x="16" y="11" width="288" height="22"/>
+                        <rect key="frame" x="16" y="6" width="288" height="51"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="vu1-24-Omw"/>
+                        </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <textInputTraits key="textInputTraits"/>
+                        <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="40b-u3-ydU" userLabel="border view">
-                        <rect key="frame" x="16" y="37" width="304" height="1"/>
+                        <rect key="frame" x="16" y="61" width="304" height="1"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="CX4-ly-vLV"/>
@@ -34,6 +37,7 @@
                     <constraint firstItem="40b-u3-ydU" firstAttribute="top" secondItem="Kgt-SJ-dhF" secondAttribute="bottom" constant="4" id="KTF-m0-E4R"/>
                     <constraint firstItem="40b-u3-ydU" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="N4M-XD-61a"/>
                     <constraint firstItem="Kgt-SJ-dhF" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="PEL-zz-m9F"/>
+                    <constraint firstAttribute="bottom" secondItem="40b-u3-ydU" secondAttribute="bottom" constant="1" id="UEN-2s-B2F"/>
                     <constraint firstItem="Kgt-SJ-dhF" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="YOF-RY-McU"/>
                     <constraint firstItem="Kgt-SJ-dhF" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="hwS-yc-5fF"/>
                     <constraint firstAttribute="trailing" secondItem="40b-u3-ydU" secondAttribute="trailing" id="ksv-Oh-C77"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextFieldTableViewCell" id="KGk-i7-Jjw" customClass="TextFieldTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextFieldTableViewCell" id="KGk-i7-Jjw" customClass="TextFieldTableViewCell" customModule="WordPressAuthenticator">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
@@ -41,7 +41,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="borderView" destination="40b-u3-ydU" id="r5S-yD-GjJ"/>
+                <outlet property="borderView" destination="40b-u3-ydU" id="nPo-29-w14"/>
                 <outlet property="textField" destination="Kgt-SJ-dhF" id="jbD-ye-JU3"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TextFieldTableViewCell" id="KGk-i7-Jjw" customClass="TextFieldTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="132" y="127"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -41,7 +41,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="borderView" destination="40b-u3-ydU" id="cy8-5K-zlR"/>
+                <outlet property="borderView" destination="40b-u3-ydU" id="r5S-yD-GjJ"/>
                 <outlet property="textField" destination="Kgt-SJ-dhF" id="jbD-ye-JU3"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -17,13 +17,13 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
-                        <rect key="frame" x="16" y="5" width="288" height="34"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
+                        <rect key="frame" x="16" y="11" width="288" height="22"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="40b-u3-ydU" userLabel="border view">
-                        <rect key="frame" x="0.0" y="43" width="320" height="1"/>
+                        <rect key="frame" x="16" y="37" width="304" height="1"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="CX4-ly-vLV"/>
@@ -32,8 +32,8 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="40b-u3-ydU" firstAttribute="top" secondItem="Kgt-SJ-dhF" secondAttribute="bottom" constant="4" id="KTF-m0-E4R"/>
+                    <constraint firstItem="40b-u3-ydU" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="N4M-XD-61a"/>
                     <constraint firstItem="Kgt-SJ-dhF" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="PEL-zz-m9F"/>
-                    <constraint firstItem="40b-u3-ydU" firstAttribute="centerX" secondItem="Kgt-SJ-dhF" secondAttribute="centerX" id="R4K-8z-Via"/>
                     <constraint firstItem="Kgt-SJ-dhF" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="YOF-RY-McU"/>
                     <constraint firstItem="Kgt-SJ-dhF" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="hwS-yc-5fF"/>
                     <constraint firstAttribute="trailing" secondItem="40b-u3-ydU" secondAttribute="trailing" id="ksv-Oh-C77"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -40,6 +40,10 @@
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="borderView" destination="40b-u3-ydU" id="cy8-5K-zlR"/>
+                <outlet property="textField" destination="Kgt-SJ-dhF" id="jbD-ye-JU3"/>
+            </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>
         </tableViewCell>
     </objects>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -10,15 +10,37 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TextFieldTableViewCell" id="KGk-i7-Jjw" customClass="TextFieldTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextFieldTableViewCell" id="KGk-i7-Jjw" customClass="TextFieldTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
+                        <rect key="frame" x="16" y="5" width="288" height="34"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits"/>
+                    </textField>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="40b-u3-ydU" userLabel="border view">
+                        <rect key="frame" x="0.0" y="43" width="320" height="1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="1" id="CX4-ly-vLV"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="40b-u3-ydU" firstAttribute="top" secondItem="Kgt-SJ-dhF" secondAttribute="bottom" constant="4" id="KTF-m0-E4R"/>
+                    <constraint firstItem="Kgt-SJ-dhF" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="PEL-zz-m9F"/>
+                    <constraint firstItem="40b-u3-ydU" firstAttribute="centerX" secondItem="Kgt-SJ-dhF" secondAttribute="centerX" id="R4K-8z-Via"/>
+                    <constraint firstItem="Kgt-SJ-dhF" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="YOF-RY-McU"/>
+                    <constraint firstItem="Kgt-SJ-dhF" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="hwS-yc-5fF"/>
+                    <constraint firstAttribute="trailing" secondItem="40b-u3-ydU" secondAttribute="trailing" id="ksv-Oh-C77"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
-            <point key="canvasLocation" x="132" y="127"/>
+            <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -42,6 +42,7 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="borderView" destination="40b-u3-ydU" id="nPo-29-w14"/>
+                <outlet property="borderWidth" destination="CX4-ly-vLV" id="B0f-nK-stu"/>
                 <outlet property="textField" destination="Kgt-SJ-dhF" id="jbD-ye-JU3"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -113,7 +113,7 @@ extension SiteAddressViewController: UITableViewDataSource {
     /// Configure the textfield cell
     ///
     func configureTextField(_ cell: TextFieldTableViewCell) {
-        cell.textField.placeholder = "Ummm hi"
+        cell.textField.placeholder = NSLocalizedString("example.com", comment: "Site Address placeholder")
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -100,6 +100,7 @@ extension SiteAddressViewController: UITableViewDataSource {
         case let cell as TextFieldTableViewCell:
             configureTextField(cell)
         default:
+            // TODO: return a blank cell when this is ready for review
             fatalError("Error: Did you forget to configure a custom cell?")
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -97,3 +97,23 @@ extension SiteAddressViewController: NUXKeyboardResponder {
         keyboardWillHide(notification)
     }
 }
+
+
+// MARK: - Constants
+extension SiteAddressViewController {
+    /// Rows listed in the order they were created
+    ///
+    enum Row {
+        case instructions
+        case siteAddress
+
+        var reuseIdentifier: String {
+            switch self {
+            case .instructions:
+                return InstructionTableViewCell.reuseIdentifier
+            case .siteAddress:
+                return TextFieldTableViewCell.reuseIdentifier
+            }
+        }
+    }
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -46,8 +46,47 @@ final class SiteAddressViewController: LoginViewController {
 }
 
 
-// MARK: - Private methods
+// MARK: - UITableViewDataSource
+extension SiteAddressViewController: UITableViewDataSource {
+    /// Returns the number of rows in a section
+    ///
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return rows.count
+    }
+
+    /// Configure cells delegate method
+    ///
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+
+// MARK: - UITableViewDelegate conformance
+extension SiteAddressViewController: UITableViewDelegate {
+
+}
+
+
+// MARK: - Keyboard Notifications
+extension SiteAddressViewController: NUXKeyboardResponder {
+    @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
+        keyboardWillShow(notification)
+    }
+
+    @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
+        keyboardWillHide(notification)
+    }
+}
+
+
+
 private extension SiteAddressViewController {
+    // MARK: - Private methods
 
     /// Localize the "Continue" button
     ///
@@ -75,26 +114,6 @@ private extension SiteAddressViewController {
     func loadRows() {
         rows = [.instructions, .siteAddress]
     }
-}
-
-
-// MARK: - UITableViewDataSource
-extension SiteAddressViewController: UITableViewDataSource {
-    /// Returns the number of rows in a section
-    ///
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return rows.count
-    }
-
-    /// Configure cells delegate method
-    ///
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let row = rows[indexPath.row]
-        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
-        configure(cell, for: row, at: indexPath)
-
-        return cell
-    }
 
     /// Configure cells
     ///
@@ -120,29 +139,9 @@ extension SiteAddressViewController: UITableViewDataSource {
     func configureTextField(_ cell: TextFieldTableViewCell) {
         cell.textField.placeholder = NSLocalizedString("example.com", comment: "Site Address placeholder")
     }
-}
 
+    // MARK: - Private Constants
 
-// MARK: - UITableViewDelegate conformance
-extension SiteAddressViewController: UITableViewDelegate {
-
-}
-
-
-// MARK: - Keyboard Notifications
-extension SiteAddressViewController: NUXKeyboardResponder {
-    @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
-        keyboardWillShow(notification)
-    }
-
-    @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
-        keyboardWillHide(notification)
-    }
-}
-
-
-// MARK: - Constants
-extension SiteAddressViewController {
     /// Rows listed in the order they were created
     ///
     enum Row {

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -100,7 +100,7 @@ extension SiteAddressViewController: UITableViewDataSource {
         case let cell as TextFieldTableViewCell:
             configureTextField(cell)
         default:
-            UITableViewCell()
+            DDLogError("Error: Unidentified tableViewCell type found.")
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -23,6 +23,7 @@ final class SiteAddressViewController: LoginViewController {
 
         localizePrimaryButton()
         registerTableViewCells()
+        loadRows()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -50,6 +51,12 @@ final class SiteAddressViewController: LoginViewController {
         for cell in cells {
             tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
         }
+    }
+
+    /// Describes how the tableView rows should be rendered.
+    ///
+    func loadRows() {
+        rows = [.instructions, .siteAddress]
     }
 
     /// Style individual ViewController backgrounds, for now.

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -22,6 +22,7 @@ final class SiteAddressViewController: LoginViewController {
         super.viewDidLoad()
 
         localizePrimaryButton()
+        setRowHeight()
         registerTableViewCells()
         loadRows()
     }
@@ -68,7 +69,9 @@ extension SiteAddressViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate conformance
 extension SiteAddressViewController: UITableViewDelegate {
-
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
 }
 
 
@@ -94,6 +97,13 @@ private extension SiteAddressViewController {
         let primaryTitle = displayStrings.continueButtonTitle
         submitButton?.setTitle(primaryTitle, for: .normal)
         submitButton?.setTitle(primaryTitle, for: .highlighted)
+    }
+
+    /// Sets the row height in the tableView
+    ///
+    func setRowHeight() {
+        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
     }
 
     /// Registers all of the available TableViewCells
@@ -156,5 +166,12 @@ private extension SiteAddressViewController {
                 return TextFieldTableViewCell.reuseIdentifier
             }
         }
+    }
+
+    /// Constants
+    ///
+    struct Constants {
+        // Need a CGFloat not a plain Float
+        static let rowHeight: CGFloat = 44.0
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -74,18 +74,45 @@ final class SiteAddressViewController: LoginViewController {
 
 // MARK: - UITableViewDataSource
 extension SiteAddressViewController: UITableViewDataSource {
+    /// Returns the number of rows in a section
+    ///
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return rows.count
     }
 
+    /// Configure cells delegate method
+    ///
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: InstructionTableViewCell.reuseIdentifier, for: indexPath) as? InstructionTableViewCell else {
-            fatalError()
-        }
-
-        cell.instructionLabel?.text = displayStrings.siteLoginInstructions
+        let row = rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
 
         return cell
+    }
+
+    /// Configure cells
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as InstructionTableViewCell:
+            configureInstruction(cell)
+        case let cell as TextFieldTableViewCell:
+            configureTextField(cell)
+        default:
+            fatalError("Error: Did you forget to configure a custom cell?")
+        }
+    }
+
+    /// Configure the instruction cell
+    ///
+    func configureInstruction(_ cell: InstructionTableViewCell) {
+        cell.instructionLabel?.text = displayStrings.siteLoginInstructions
+    }
+
+    /// Configure the textfield cell
+    ///
+    func configureTextField(_ cell: TextFieldTableViewCell) {
+        cell.textField.placeholder = "Ummm hi"
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -100,8 +100,7 @@ extension SiteAddressViewController: UITableViewDataSource {
         case let cell as TextFieldTableViewCell:
             configureTextField(cell)
         default:
-            // TODO: return a blank cell when this is ready for review
-            fatalError("Error: Did you forget to configure a custom cell?")
+            UITableViewCell()
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -15,7 +15,7 @@ final class SiteAddressViewController: LoginViewController {
         return WordPressAuthenticator.shared.displayStrings
     }
 
-    private(set) var rows = [Row]()
+    private var rows = [Row]()
 
     // MARK: - View lifecycle
     override func viewDidLoad() {
@@ -32,6 +32,22 @@ final class SiteAddressViewController: LoginViewController {
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
     }
+
+    /// Style individual ViewController backgrounds, for now.
+    ///
+    override func styleBackground() {
+        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
+            super.styleBackground()
+            return
+        }
+
+        view.backgroundColor = unifiedBackgroundColor
+    }
+}
+
+
+// MARK: - Private methods
+private extension SiteAddressViewController {
 
     /// Localize the "Continue" button
     ///
@@ -58,17 +74,6 @@ final class SiteAddressViewController: LoginViewController {
     ///
     func loadRows() {
         rows = [.instructions, .siteAddress]
-    }
-
-    /// Style individual ViewController backgrounds, for now.
-    ///
-    override func styleBackground() {
-        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
-            super.styleBackground()
-            return
-        }
-
-        view.backgroundColor = unifiedBackgroundColor
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -15,6 +15,8 @@ final class SiteAddressViewController: LoginViewController {
         return WordPressAuthenticator.shared.displayStrings
     }
 
+    private(set) var rows = [Row]()
+
     // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -45,11 +45,12 @@ final class SiteAddressViewController: LoginViewController {
     ///
     func registerTableViewCells() {
         let cells = [
-            InstructionTableViewCell.self
+            InstructionTableViewCell.reuseIdentifier: InstructionTableViewCell.loadNib(),
+            TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib()
         ]
 
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        for (reuseIdentifier, nib) in cells {
+            tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
         }
     }
 


### PR DESCRIPTION
Ref. #283 

This PR adds a basic textfield inside a tableview cell. The cell should look like the Zeplin designs. This PR also abstracts out the row presentation.

### To test
1. `bundle exec pod install`
2. Build and run
3. Check out the testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14340

<img width="351" alt="Screen Shot 2020-06-17 at 11 29 01 AM" src="https://user-images.githubusercontent.com/1062444/84924164-c7f7bb00-b08d-11ea-8a16-9d9b7672ce5a.png">

**iPhone 11 Pro screenshots**
<a href="https://user-images.githubusercontent.com/1062444/85311821-9e6ad500-b47b-11ea-9c16-e289ca1d524c.png"><img src="https://user-images.githubusercontent.com/1062444/85311821-9e6ad500-b47b-11ea-9c16-e289ca1d524c.png" width="350" /></a>

<a href="https://user-images.githubusercontent.com/1062444/85311854-aaef2d80-b47b-11ea-832b-1e7770c125f4.png"><img src="https://user-images.githubusercontent.com/1062444/85311854-aaef2d80-b47b-11ea-832b-1e7770c125f4.png" width="350" /></a>
