### PR TITLE
UL&S: bug fix: make the TextLinkButtonTableViewCell button word wrap, not truncate

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.19.0-beta.4"
+  s.version       = "1.19.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -18,6 +18,14 @@ class TextLinkButtonTableViewCell: UITableViewCell {
 
     public var actionHandler: (() -> Void)?
 
+	override func awakeFromNib() {
+		super.awakeFromNib()
+
+		button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
+		button.titleLabel?.adjustsFontForContentSizeCategory = true
+		button.titleLabel?.lineBreakMode = .byWordWrapping
+	}
+
     public func configureButton(text: String?) {
         button.setTitle(text, for: .normal)
 
@@ -25,8 +33,5 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         let buttonHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
-
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -21,9 +21,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
 	override func awakeFromNib() {
 		super.awakeFromNib()
 
-		button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
 		button.titleLabel?.adjustsFontForContentSizeCategory = true
-		button.titleLabel?.lineBreakMode = .byWordWrapping
 	}
 
     public func configureButton(text: String?) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
@@ -17,8 +17,9 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ofe-LL-CbC">
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ofe-LL-CbC">
                         <rect key="frame" x="16" y="11" width="288" height="22"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                         <state key="normal" title="Button"/>
                         <connections>
                             <action selector="textLinkButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="nY9-jd-WF5"/>


### PR DESCRIPTION
Ref #283 

Per #308, there is a bug where the button title text was truncating. This PR fixes the truncation.

PR to test fix: https://github.com/wordpress-mobile/WordPress-iOS/pull/14385

Before:
![iphone_large_text](https://user-images.githubusercontent.com/1816888/85751205-9acb8e00-b6c7-11ea-9cb0-2bea5f1c6ef7.png)

After:
<a href="https://user-images.githubusercontent.com/1062444/85781913-d11b0480-b6eb-11ea-9d3d-194a0c1d459b.png"><img src="https://user-images.githubusercontent.com/1062444/85781913-d11b0480-b6eb-11ea-9d3d-194a0c1d459b.png" width="350" /></a>
