### PR TITLE
ULS: Partially styled navigation bar

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.19.0-beta.4"
+  s.version       = "1.19.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -68,6 +68,10 @@ public struct WordPressAuthenticatorStyle {
 
     public let navBarBadgeColor: UIColor
 
+    public let navBarBackgroundColor: UIColor
+    
+    public let navButtonTextColor: UIColor
+
     /// Style: prologue background colors
     ///
     public let prologueBackgroundColor: UIColor
@@ -79,10 +83,10 @@ public struct WordPressAuthenticatorStyle {
     /// Style: status bar style
     ///
     public let statusBarStyle: UIStatusBarStyle
-
+    
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor?, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor?, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, textFieldBackgroundColor: UIColor, buttonViewBackgroundColor: UIColor? = nil, navBarImage: UIImage, navBarBadgeColor: UIColor, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white, statusBarStyle: UIStatusBarStyle = .lightContent) {
+    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor?, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor?, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, textFieldBackgroundColor: UIColor, buttonViewBackgroundColor: UIColor? = nil, navBarImage: UIImage, navBarBadgeColor: UIColor, navBarBackgroundColor: UIColor, navButtonTextColor: UIColor = .white, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white, statusBarStyle: UIStatusBarStyle = .lightContent) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor
@@ -106,6 +110,8 @@ public struct WordPressAuthenticatorStyle {
         self.buttonViewBackgroundColor = buttonViewBackgroundColor ?? viewControllerBackgroundColor
         self.navBarImage = navBarImage
         self.navBarBadgeColor = navBarBadgeColor
+        self.navBarBackgroundColor = navBarBackgroundColor
+        self.navButtonTextColor = navButtonTextColor
         self.prologueBackgroundColor = prologueBackgroundColor
         self.prologueTitleColor = prologueTitleColor
         self.statusBarStyle = statusBarStyle
@@ -138,13 +144,35 @@ public struct WordPressAuthenticatorUnifiedStyle {
     ///
     public let viewControllerBackgroundColor: UIColor
 
+    /// Style: Status bar style. Defaults to `default`.
+    ///
+    public let statusBarStyle: UIStatusBarStyle
+    
+    /// Style: Navigation bar.
+    ///
+    public let navBarBackgroundColor: UIColor
+    public let navButtonTextColor: UIColor
+    public let largeTitleTextColor: UIColor
+    
     /// Designated initializer
     ///
-    public init(borderColor: UIColor, textColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, viewControllerBackgroundColor: UIColor) {
+    public init(borderColor: UIColor,
+                textColor: UIColor,
+                textButtonColor: UIColor,
+                textButtonHighlightColor: UIColor,
+                viewControllerBackgroundColor: UIColor,
+                statusBarStyle: UIStatusBarStyle = .default,
+                navBarBackgroundColor: UIColor,
+                navButtonTextColor: UIColor,
+                largeTitleTextColor: UIColor) {
         self.borderColor = borderColor
         self.textColor = textColor
         self.textButtonColor = textButtonColor
         self.textButtonHighlightColor = textButtonHighlightColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
+        self.statusBarStyle = statusBarStyle
+        self.navBarBackgroundColor = navBarBackgroundColor
+        self.navButtonTextColor = navButtonTextColor
+        self.largeTitleTextColor = largeTitleTextColor
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -86,7 +86,34 @@ public struct WordPressAuthenticatorStyle {
     
     /// Designated initializer
     ///
-    public init(primaryNormalBackgroundColor: UIColor, primaryNormalBorderColor: UIColor?, primaryHighlightBackgroundColor: UIColor, primaryHighlightBorderColor: UIColor?, secondaryNormalBackgroundColor: UIColor, secondaryNormalBorderColor: UIColor, secondaryHighlightBackgroundColor: UIColor, secondaryHighlightBorderColor: UIColor, disabledBackgroundColor: UIColor, disabledBorderColor: UIColor, primaryTitleColor: UIColor, secondaryTitleColor: UIColor, disabledTitleColor: UIColor, textButtonColor: UIColor, textButtonHighlightColor: UIColor, instructionColor: UIColor, subheadlineColor: UIColor, placeholderColor: UIColor, viewControllerBackgroundColor: UIColor, textFieldBackgroundColor: UIColor, buttonViewBackgroundColor: UIColor? = nil, navBarImage: UIImage, navBarBadgeColor: UIColor, navBarBackgroundColor: UIColor, navButtonTextColor: UIColor = .white, prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(), prologueTitleColor: UIColor = .white, statusBarStyle: UIStatusBarStyle = .lightContent) {
+    public init(primaryNormalBackgroundColor: UIColor,
+                primaryNormalBorderColor: UIColor?,
+                primaryHighlightBackgroundColor: UIColor,
+                primaryHighlightBorderColor: UIColor?,
+                secondaryNormalBackgroundColor: UIColor,
+                secondaryNormalBorderColor: UIColor,
+                secondaryHighlightBackgroundColor: UIColor,
+                secondaryHighlightBorderColor: UIColor,
+                disabledBackgroundColor: UIColor,
+                disabledBorderColor: UIColor,
+                primaryTitleColor: UIColor,
+                secondaryTitleColor: UIColor,
+                disabledTitleColor: UIColor,
+                textButtonColor: UIColor,
+                textButtonHighlightColor: UIColor,
+                instructionColor: UIColor,
+                subheadlineColor: UIColor,
+                placeholderColor: UIColor,
+                viewControllerBackgroundColor: UIColor,
+                textFieldBackgroundColor: UIColor,
+                buttonViewBackgroundColor: UIColor? = nil,
+                navBarImage: UIImage,
+                navBarBadgeColor: UIColor,
+                navBarBackgroundColor: UIColor,
+                navButtonTextColor: UIColor = .white,
+                prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(),
+                prologueTitleColor: UIColor = .white,
+                statusBarStyle: UIStatusBarStyle = .lightContent) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
         self.primaryHighlightBackgroundColor = primaryHighlightBackgroundColor

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -39,6 +39,8 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         super.viewDidLoad()
         
         navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.largeTitleDisplayMode = .never
+        styleNavigationBar()
         
         displayError(message: "")
         setupNavBarIcon()
@@ -75,6 +77,46 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         instructionLabel?.font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
         instructionLabel?.adjustsFontForContentSizeCategory = true
         instructionLabel?.textColor = WordPressAuthenticator.shared.style.instructionColor
+    }
+
+    private func styleNavigationBar() {
+        
+        let largeTitleTextColor = WordPressAuthenticator.shared.unifiedStyle?.largeTitleTextColor ?? WordPressAuthenticator.shared.style.instructionColor
+        
+        var navBarBackgroundColor: UIColor
+        var navButtonTextColor: UIColor
+        var hideBottomBorder: Bool
+        
+        switch navigationItem.largeTitleDisplayMode {
+        // Original nav bar style
+        case .never:
+            navButtonTextColor = WordPressAuthenticator.shared.style.navButtonTextColor
+            navBarBackgroundColor = WordPressAuthenticator.shared.style.navBarBackgroundColor
+            hideBottomBorder = false
+        // Unified nav bar style
+        default:
+            navButtonTextColor = WordPressAuthenticator.shared.unifiedStyle?.navButtonTextColor ?? WordPressAuthenticator.shared.style.navButtonTextColor
+            navBarBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.navBarBackgroundColor ?? WordPressAuthenticator.shared.style.navBarBackgroundColor
+            hideBottomBorder = true
+        }
+
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.shadowColor = hideBottomBorder ? .clear : .separator
+            appearance.backgroundColor = navBarBackgroundColor
+            appearance.largeTitleTextAttributes = [.foregroundColor: largeTitleTextColor]
+            UIBarButtonItem.appearance().tintColor = navButtonTextColor
+            
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().compactAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        } else {
+            let appearance = UINavigationBar.appearance()
+            appearance.barTintColor = navBarBackgroundColor
+            appearance.largeTitleTextAttributes = [.foregroundColor: largeTitleTextColor]
+            UIBarButtonItem.appearance().tintColor = navButtonTextColor
+        }
+
     }
 
     func configureViewLoading(_ loading: Bool) {
@@ -374,6 +416,7 @@ extension LoginViewController {
 
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationItem.largeTitleDisplayMode = largeTitleDisplayMode
+        styleNavigationBar()
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddressViewController.swift
@@ -22,6 +22,9 @@ final class SiteAddressViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
+        setLargeTitleDisplayMode(.always)
+
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()


### PR DESCRIPTION
Ref: #182 

This partially updates the navigation bar to the unified style. 
- It is displayed when large titles are enabled.
- Large titles have been enabled on the new Site Address view, so it will show up there.
- When large titles are disabled, the old nav bar style is used.

Specifically what is done:
- The large title color is set from `largeTitleTextColor` .
- The Back button color is set from `navButtonTextColor`.
- The nav bar background color is set from `navBarBackgroundColor`.
- The bottom line on the nav bar is hidden.

And what is not done:
- The 'Help' button is still white (on the white background, you may not see it, but it's there).
- The app icon is still displayed (it's white, so you may not see it, but it's there).
- The large title font has not been updated.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14386