### PR TITLE
Fix the nav bar's normal title color.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.19.0"
+  s.version       = "1.19.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -105,6 +105,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             appearance.shadowColor = hideBottomBorder ? .clear : .separator
             appearance.backgroundColor = navBarBackgroundColor
             appearance.largeTitleTextAttributes = [.foregroundColor: largeTitleTextColor]
+            appearance.titleTextAttributes = [.foregroundColor: WordPressAuthenticator.shared.style.primaryTitleColor]
             UIBarButtonItem.appearance().tintColor = navButtonTextColor
             
             UINavigationBar.appearance().standardAppearance = appearance
@@ -114,6 +115,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             let appearance = UINavigationBar.appearance()
             appearance.barTintColor = navBarBackgroundColor
             appearance.largeTitleTextAttributes = [.foregroundColor: largeTitleTextColor]
+            appearance.titleTextAttributes = [.foregroundColor: WordPressAuthenticator.shared.style.primaryTitleColor]
             UIBarButtonItem.appearance().tintColor = navButtonTextColor
         }
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14404

This sets the navigation bar's normal title color to `primaryTitleColor` (which the host apps set as `white`). While the normal title is not shown in the Auth views, its settings are carried over to the host app. Because the color wasn't explicitly set in Auth, it defaulted to black. 

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14418