### PR TITLE
ULS: Use NY font for large titles

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ def wordpress_authenticator_pods
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7.0'
   pod 'WordPressKit', '~> 4.0-beta.0' # Don't change this until we hit 5.0 in WPKit
-  pod 'WordPressShared', '~> 1.0-beta.0' # Don't change this until we hit 2.0 in WPShared
+  pod 'WordPressShared', '~> 1.9-beta' # Don't change this until we hit 2.0 in WPShared
 
 
   ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.9.0-beta.1)
     - wpxmlrpc (= 0.8.5)
-  - WordPressShared (1.9.0-beta.1):
+  - WordPressShared (1.9.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.0)
@@ -76,7 +76,7 @@ DEPENDENCIES:
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
   - WordPressKit (~> 4.0-beta.0)
-  - WordPressShared (~> 1.0-beta.0)
+  - WordPressShared (~> 1.9-beta)
   - WordPressUI (~> 1.7.0)
 
 SPEC REPOS:
@@ -124,10 +124,10 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPressKit: cf04f034a376fe54a44edff62c3bd0ece5ef13a6
-  WordPressShared: bc1a056b5d4da040e3addf4f510c0de67651ab1b
+  WordPressShared: 423779c24b1f8f2ee06d1068d30c7d2ea51ca813
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 476081b12ced1593942b9e2caae1118dc34c5e52
+PODFILE CHECKSUM: 775ba7a5cdd3898266fc4cbd425969c587cc4781
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.19.0"
+  s.version       = "1.20.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -44,5 +44,5 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressKit', '~> 4.0-beta.0' # Don't change this until we hit 5.0 in WPKit
-  s.dependency 'WordPressShared', '~> 1.0-beta.0' # Don't change this until we hit 2.0 in WPShared
+  s.dependency 'WordPressShared', '~> 1.9-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -81,8 +81,6 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     private func styleNavigationBar() {
         
-        let largeTitleTextColor = WordPressAuthenticator.shared.unifiedStyle?.largeTitleTextColor ?? WordPressAuthenticator.shared.style.instructionColor
-        
         var navBarBackgroundColor: UIColor
         var navButtonTextColor: UIColor
         var hideBottomBorder: Bool
@@ -100,11 +98,15 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             hideBottomBorder = true
         }
 
+        let largeTitleTextColor = WordPressAuthenticator.shared.unifiedStyle?.largeTitleTextColor ?? WordPressAuthenticator.shared.style.instructionColor
+        let largeTitleFont = WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold)
+        let largeTitleTextAttributes:[NSAttributedString.Key: Any] = [.foregroundColor: largeTitleTextColor,
+                                                                      .font: largeTitleFont]
         if #available(iOS 13.0, *) {
             let appearance = UINavigationBarAppearance()
             appearance.shadowColor = hideBottomBorder ? .clear : .separator
             appearance.backgroundColor = navBarBackgroundColor
-            appearance.largeTitleTextAttributes = [.foregroundColor: largeTitleTextColor]
+            appearance.largeTitleTextAttributes = largeTitleTextAttributes
             UIBarButtonItem.appearance().tintColor = navButtonTextColor
             
             UINavigationBar.appearance().standardAppearance = appearance
@@ -113,7 +115,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         } else {
             let appearance = UINavigationBar.appearance()
             appearance.barTintColor = navBarBackgroundColor
-            appearance.largeTitleTextAttributes = [.foregroundColor: largeTitleTextColor]
+            appearance.largeTitleTextAttributes = largeTitleTextAttributes
             UIBarButtonItem.appearance().tintColor = navButtonTextColor
         }
 


### PR DESCRIPTION
Ref: #315 

This updates the navigation bar's large title font to use the New York font.

<kbd><img width="472" alt="auth" src="https://user-images.githubusercontent.com/1816888/86839134-45479780-c05e-11ea-8666-889db0221e63.png"></kbd>

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14433