### PR TITLE
ULS: Don't show host app icon in unified nav bar.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.1"
+  s.version       = "1.20.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -139,16 +139,22 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
     }
 
 
-    // MARK: - Navbar Help and WP Logo methods
+    // MARK: - Navbar Help and App Logo methods
 
-    /// Adds the WP logo to the nav controller
+    /// Adds the app logo to the nav controller
     ///
-    public func addWordPressLogoToNavController() {
+    public func addAppLogoToNavController() {
         let image = WordPressAuthenticator.shared.style.navBarImage
         let imageView = UIImageView(image: image.imageWithTintColor(UIColor.white))
         navigationItem.titleView = imageView
     }
 
+    /// Removes the app logo from the nav controller
+    ///
+    public func removeAppLogoFromNavController() {
+        navigationItem.titleView = nil
+    }
+    
     /// Whenever the WordPressAuthenticator Delegate returns true, when `shouldDisplayHelpButton` is queried, we'll proceed
     /// and attach the Help Button to the navigationController.
     ///

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -58,7 +58,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
         super.viewDidLoad()
 
         view.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
-        addWordPressLogoToNavController()
+        addAppLogoToNavController()
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -43,7 +43,6 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         styleNavigationBar()
         
         displayError(message: "")
-        setupNavBarIcon()
         styleBackground()
         styleInstructions()
 
@@ -61,8 +60,8 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     /// Places the WordPress logo in the navbar
     ///
-    func setupNavBarIcon() {
-        addWordPressLogoToNavController()
+    func setupNavBarIcon(showIcon: Bool = true) {
+        showIcon ? addAppLogoToNavController() : removeAppLogoFromNavController()
     }
 
     /// Styles the view's background color. Defaults to WPStyleGuide.lightGrey()
@@ -88,11 +87,13 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         switch navigationItem.largeTitleDisplayMode {
         // Original nav bar style
         case .never:
+            setupNavBarIcon()
             navButtonTextColor = WordPressAuthenticator.shared.style.navButtonTextColor
             navBarBackgroundColor = WordPressAuthenticator.shared.style.navBarBackgroundColor
             hideBottomBorder = false
         // Unified nav bar style
         default:
+            setupNavBarIcon(showIcon: false)
             navButtonTextColor = WordPressAuthenticator.shared.unifiedStyle?.navButtonTextColor ?? WordPressAuthenticator.shared.style.navButtonTextColor
             navBarBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.navBarBackgroundColor ?? WordPressAuthenticator.shared.style.navBarBackgroundColor
             hideBottomBorder = true


### PR DESCRIPTION
Ref: #315 

This removes the host app icon from the unified flow's navigation bar.

**New flows:**
<img width="521" alt="new" src="https://user-images.githubusercontent.com/1816888/86854704-281ec300-c076-11ea-83f0-3cea14354e3f.png">

**Old flows:**
<img width="520" alt="old" src="https://user-images.githubusercontent.com/1816888/86854696-2523d280-c076-11ea-8d72-9d7125d1d769.png">

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14435

