### PR TITLE
UL&S: SiteAddressViewController scrolling bug

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.3"
+  s.version       = "1.20.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/SiteAddress.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/SiteAddress.storyboard
@@ -11,7 +11,7 @@
         <!--Site Address View Controller-->
         <scene sceneID="7Rf-Qz-qsw">
             <objects>
-                <viewController storyboardIdentifier="SiteAddressViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="SiteAddressViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SiteAddressViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="SiteAddressViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -19,7 +19,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFS-Ic-byk" userLabel="Containing View">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
-                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
                                         <sections/>
                                         <connections>
@@ -68,8 +68,9 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ljV-kF-TaY" secondAttribute="top" id="CM2-8b-yMQ"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ljV-kF-TaY" secondAttribute="top" id="YEy-EW-XmD"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
                         </constraints>


### PR DESCRIPTION
Ref. #318 

I haven't solved the scrolling issue yet, but the animation is now smoother. 

I thought maybe the tableview touches were getting eaten by the background tap gesture recognizer. Neither of these fixed it:
1. Removing `NUXViewControllerBase` [tap gesture](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/develop/WordPressAuthenticator/NUX/NUXViewControllerBase.swift#L122-L128) that dismisses the keyboard
2. Using `NUXViewControllerBase` tap gesture and setting `tgr.cancelsTouchesInView = false`

Then I thought maybe the top autolayout constraint set to a safe area was causing the problem. That didn't fix the issue either. I thought it might have something to do with the large titles, but my searches aren't returning any results related to my problem.

Any ideas?

| Before | After |
| --- | --- |
| ![siteaddressvc-scroll-bug-original](https://user-images.githubusercontent.com/1062444/86956294-79828d00-c11e-11ea-9d27-fcae50fc8f8a.gif) | ![siteaddressvc-scroll-bug](https://user-images.githubusercontent.com/1062444/86956988-a6836f80-c11f-11ea-80de-ca18829ddfe1.gif) |