### PR TITLE
UL&S: Navigate to a blank SiteCredentialsViewController

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.6"
+  s.version       = "1.20.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.4"
+  s.version       = "1.20.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.5"
+  s.version       = "1.20.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		CE6BCD2F24A3A235001BCDC5 /* TextLabelTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE6BCD2D24A3A235001BCDC5 /* TextLabelTableViewCell.xib */; };
 		CE6BCD3824A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BCD3624A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.swift */; };
 		CE6BCD3924A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE6BCD3724A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib */; };
+		CE73475624B77A3800A22660 /* SiteCredentialsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE73475524B77A3800A22660 /* SiteCredentialsViewController.swift */; };
 		CE9091F72499549500AB50BD /* TextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */; };
 		CE9091F82499549500AB50BD /* TextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */; };
 		CE9091FE249A720E00AB50BD /* UIView+AuthHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9091FD249A720E00AB50BD /* UIView+AuthHelpers.swift */; };
@@ -294,6 +295,7 @@
 		CE6BCD2D24A3A235001BCDC5 /* TextLabelTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TextLabelTableViewCell.xib; sourceTree = "<group>"; };
 		CE6BCD3624A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextLinkButtonTableViewCell.swift; sourceTree = "<group>"; };
 		CE6BCD3724A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TextLinkButtonTableViewCell.xib; sourceTree = "<group>"; };
+		CE73475524B77A3800A22660 /* SiteCredentialsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialsViewController.swift; sourceTree = "<group>"; };
 		CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewCell.swift; sourceTree = "<group>"; };
 		CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextFieldTableViewCell.xib; sourceTree = "<group>"; };
 		CE9091FD249A720E00AB50BD /* UIView+AuthHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+AuthHelpers.swift"; sourceTree = "<group>"; };
@@ -711,6 +713,7 @@
 			children = (
 				CEC77C6524854F2E00FB9050 /* SiteAddressViewController.swift */,
 				CEC77C6724854F3E00FB9050 /* SiteAddress.storyboard */,
+				CE73475524B77A3800A22660 /* SiteCredentialsViewController.swift */,
 			);
 			path = "Site Address";
 			sourceTree = "<group>";
@@ -992,6 +995,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE73475624B77A3800A22660 /* SiteCredentialsViewController.swift in Sources */,
 				982C8E7923021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift in Sources */,
 				B5609144208A563800399AE4 /* LoginPrologueSignupMethodViewController.swift in Sources */,
 				B56090D1208A4F5400399AE4 /* NUXViewController.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/xcshareddata/xcschemes/WordPressAuthenticator.xcscheme
+++ b/WordPressAuthenticator.xcodeproj/xcshareddata/xcschemes/WordPressAuthenticator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPressAuthenticator.xcodeproj/xcshareddata/xcschemes/WordPressAuthenticator.xcscheme
+++ b/WordPressAuthenticator.xcodeproj/xcshareddata/xcschemes/WordPressAuthenticator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -1,8 +1,8 @@
 import UIKit
 import WordPressShared
 
-/// Part two of the self-hosted sign in flow. A valid site address should be acquired
-/// before presenting this view controller.
+/// Part two of the self-hosted sign in flow. Used by WPiOS and NiOS.
+/// A valid site address should be acquired before presenting this view controller.
 ///
 class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
     @IBOutlet var siteHeaderView: SiteInfoHeaderView!

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -1,8 +1,8 @@
 import UIKit
 import WordPressShared
 
-/// Part two of the self-hosted sign in flow. A valid site address should be acquired
-/// before presenting this view controller.
+/// Part two of the self-hosted sign in flow for WooCommerce.
+/// A valid site address should be acquired before presenting this view controller.
 ///
 class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardResponder {
     @IBOutlet var siteHeaderView: SiteInfoHeaderView!

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressShared
 
-/// Part two of the self-hosted sign in flow. For use by WooCommerce only.
+/// Part two of the self-hosted sign in flow. For use by WCiOS only.
 /// A valid site address should be acquired before presenting this view controller.
 ///
 class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardResponder {

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressShared
 
-/// Part two of the self-hosted sign in flow for WooCommerce.
+/// Part two of the self-hosted sign in flow. For use by WooCommerce only.
 /// A valid site address should be acquired before presenting this view controller.
 ///
 class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardResponder {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddress.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddress.storyboard
@@ -85,5 +85,82 @@
             </objects>
             <point key="canvasLocation" x="-162.40000000000001" y="20.239880059970016"/>
         </scene>
+        <!--Site Credentials View Controller-->
+        <scene sceneID="SNM-jM-Hwx">
+            <objects>
+                <viewController storyboardIdentifier="SiteCredentialsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="y6V-vh-KSr" customClass="SiteCredentialsViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rzp-ZY-4sV">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HOD-IX-jQc" userLabel="Containing View">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="msV-bz-Sqp">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <sections/>
+                                        <connections>
+                                            <outlet property="dataSource" destination="y6V-vh-KSr" id="Jh2-5j-HIR"/>
+                                            <outlet property="delegate" destination="y6V-vh-KSr" id="0cM-sM-O0r"/>
+                                        </connections>
+                                    </tableView>
+                                    <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YGp-eK-oRp" userLabel="Button background view">
+                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bUY-a5-oHJ" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="v9D-Cw-nFD"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleContinueButtonTapped:" destination="y6V-vh-KSr" eventType="touchUpInside" id="qJ4-PC-qO2"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstItem="bUY-a5-oHJ" firstAttribute="top" secondItem="YGp-eK-oRp" secondAttribute="topMargin" constant="8" id="7ST-0h-lCv"/>
+                                            <constraint firstAttribute="bottomMargin" secondItem="bUY-a5-oHJ" secondAttribute="bottom" constant="8" id="CIb-xr-SzK"/>
+                                            <constraint firstItem="Hd0-aR-a4s" firstAttribute="trailing" secondItem="bUY-a5-oHJ" secondAttribute="trailing" constant="16" id="sf0-Wf-wP3"/>
+                                            <constraint firstItem="bUY-a5-oHJ" firstAttribute="leading" secondItem="Hd0-aR-a4s" secondAttribute="leading" constant="16" id="toq-jo-Ce0"/>
+                                        </constraints>
+                                        <viewLayoutGuide key="safeArea" id="Hd0-aR-a4s"/>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="YGp-eK-oRp" firstAttribute="bottom" secondItem="HOD-IX-jQc" secondAttribute="bottomMargin" constant="8" id="AHZ-rn-MEN"/>
+                                    <constraint firstItem="YGp-eK-oRp" firstAttribute="trailing" secondItem="HOD-IX-jQc" secondAttribute="trailing" id="FKm-da-ANZ"/>
+                                    <constraint firstItem="YGp-eK-oRp" firstAttribute="top" secondItem="msV-bz-Sqp" secondAttribute="bottom" id="Wt7-Vo-sCx"/>
+                                    <constraint firstAttribute="trailing" secondItem="msV-bz-Sqp" secondAttribute="trailing" id="ZRF-eh-ojb"/>
+                                    <constraint firstItem="msV-bz-Sqp" firstAttribute="leading" secondItem="HOD-IX-jQc" secondAttribute="leading" id="dr1-sl-C06"/>
+                                    <constraint firstItem="msV-bz-Sqp" firstAttribute="top" secondItem="HOD-IX-jQc" secondAttribute="top" id="elE-tI-VfK"/>
+                                    <constraint firstItem="YGp-eK-oRp" firstAttribute="leading" secondItem="HOD-IX-jQc" secondAttribute="leading" id="piw-Hs-lPT"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="HOD-IX-jQc" firstAttribute="top" secondItem="5Dn-ej-Nhp" secondAttribute="top" id="Iud-8M-zpD"/>
+                            <constraint firstItem="5Dn-ej-Nhp" firstAttribute="bottom" secondItem="HOD-IX-jQc" secondAttribute="bottom" id="Qxf-z0-9lF"/>
+                            <constraint firstItem="HOD-IX-jQc" firstAttribute="trailing" secondItem="rzp-ZY-4sV" secondAttribute="trailing" id="bF4-se-bcv"/>
+                            <constraint firstItem="HOD-IX-jQc" firstAttribute="leading" secondItem="rzp-ZY-4sV" secondAttribute="leading" id="txP-xH-B39"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="5Dn-ej-Nhp"/>
+                    </view>
+                    <connections>
+                        <outlet property="bottomContentConstraint" destination="Qxf-z0-9lF" id="QCJ-ks-Lz9"/>
+                        <outlet property="submitButton" destination="bUY-a5-oHJ" id="AyH-o7-6z2"/>
+                        <outlet property="tableView" destination="msV-bz-Sqp" id="UhW-BX-cA3"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Pmu-qI-bIl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="561" y="20"/>
+        </scene>
     </scenes>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -408,8 +408,8 @@ extension SiteAddressViewController {
     ///
     @objc func showSelfHostedUsernamePassword() {
 		configureViewLoading(false)
-        guard let vc = LoginSelfHostedViewController.instantiate(from: .login) else {
-			DDLogError("Failed to navigate from LoginEmailViewController to LoginSelfHostedViewController")
+		guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
+			DDLogError("Failed to navigate from SiteAddressViewController to SiteAddressViewController")
 			return
 		}
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -409,7 +409,7 @@ extension SiteAddressViewController {
     @objc func showSelfHostedUsernamePassword() {
 		configureViewLoading(false)
 		guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
-			DDLogError("Failed to navigate from SiteAddressViewController to SiteAddressViewController")
+			DDLogError("Failed to navigate from SiteAddressViewController to SiteCredentialsViewController")
 			return
 		}
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -26,6 +26,7 @@ class SiteCredentialsViewController: LoginViewController {
 
         localizePrimaryButton()
         registerTableViewCells()
+		loadRows()
         configureSubmitButton(animating: false)
     }
 }
@@ -52,6 +53,12 @@ private extension SiteCredentialsViewController {
         for (reuseIdentifier, nib) in cells {
             tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
         }
+    }
+
+	/// Describes how the tableView rows should be rendered.
+    ///
+    func loadRows() {
+        rows = [.instructions]
     }
 
 	// MARK: - Private Constants

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -39,7 +39,19 @@ extension SiteCredentialsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return rows.count
     }
+
+    /// Configure cells delegate method.
+    ///
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
 }
+
+
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
 
@@ -68,6 +80,24 @@ private extension SiteCredentialsViewController {
     func loadRows() {
         rows = [.instructions]
     }
+
+	/// Configure cells.
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TextLabelTableViewCell where row == .instructions:
+            configureInstructionLabel(cell)
+        default:
+            DDLogError("Error: Unidentified tableViewCell type found.")
+        }
+    }
+
+	/// Configure the instruction cell.
+    ///
+    func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: "Enter your account information for ", style: .body)
+    }
+
 
 	// MARK: - Private Constants
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+
+/// Part two of the self-hosted sign in flow: username + password. Used by WPiOS and NiOS.
+/// A valid site address should be acquired before presenting this view controller.
+///
+class SiteCredentialsViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 /// Part two of the self-hosted sign in flow: username + password. Used by WPiOS and NiOS.
 /// A valid site address should be acquired before presenting this view controller.
 ///
-class SiteCredentialsViewController: UIViewController {
+class SiteCredentialsViewController: LoginViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -6,10 +6,44 @@ import UIKit
 ///
 class SiteCredentialsViewController: LoginViewController {
 
+	/// Private properties.
+    ///
+    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+
+    // Required property declaration for `NUXKeyboardResponder` but unused here.
+    var verticalCenterConstraint: NSLayoutConstraint?
+
+    private var rows = [Row]()
+
+    // MARK: - Actions
+    @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
+
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
     }
+}
 
+
+// MARK: - Private Methods
+private extension SiteCredentialsViewController {
+
+	// MARK: - Private Constants
+
+    /// Rows listed in the order they were created.
+    ///
+    enum Row {
+        case instructions
+
+        var reuseIdentifier: String {
+            switch self {
+            case .instructions:
+                return TextLabelTableViewCell.reuseIdentifier
+			}
+        }
+    }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -95,7 +95,7 @@ private extension SiteCredentialsViewController {
 	/// Configure the instruction cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
-        cell.configureLabel(text: "Enter your account information for ", style: .body)
+        cell.configureLabel(text: "Enter your account information for pamelanguyen.com", style: .body)
     }
 
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -24,13 +24,22 @@ class SiteCredentialsViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        localizePrimaryButton()
+        configureSubmitButton(animating: false)
     }
 }
 
 
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
+
+	/// Localize the "Continue" button.
+    ///
+    func localizePrimaryButton() {
+        let primaryTitle = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
+        submitButton?.setTitle(primaryTitle, for: .normal)
+        submitButton?.setTitle(primaryTitle, for: .highlighted)
+    }
 
 	// MARK: - Private Constants
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -24,10 +24,10 @@ class SiteCredentialsViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        localizePrimaryButton()
-        registerTableViewCells()
+		localizePrimaryButton()
+		registerTableViewCells()
 		loadRows()
-        configureSubmitButton(animating: false)
+		configureSubmitButton(animating: false)
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -29,6 +29,19 @@ class SiteCredentialsViewController: LoginViewController {
 		loadRows()
 		configureSubmitButton(animating: false)
     }
+
+	// MARK: - Overrides
+
+    /// Style individual ViewController backgrounds, for now.
+    ///
+    override func styleBackground() {
+        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
+            super.styleBackground()
+            return
+        }
+
+        view.backgroundColor = unifiedBackgroundColor
+    }
 }
 
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -32,6 +32,14 @@ class SiteCredentialsViewController: LoginViewController {
 }
 
 
+// MARK: - UITableViewDataSource
+extension SiteCredentialsViewController: UITableViewDataSource {
+    /// Returns the number of rows in a section.
+    ///
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return rows.count
+    }
+}
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -25,6 +25,7 @@ class SiteCredentialsViewController: LoginViewController {
         super.viewDidLoad()
 
         localizePrimaryButton()
+        registerTableViewCells()
         configureSubmitButton(animating: false)
     }
 }
@@ -39,6 +40,18 @@ private extension SiteCredentialsViewController {
         let primaryTitle = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
         submitButton?.setTitle(primaryTitle, for: .normal)
         submitButton?.setTitle(primaryTitle, for: .highlighted)
+    }
+
+	/// Registers all of the available TableViewCells.
+    ///
+    func registerTableViewCells() {
+        let cells = [
+            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib()
+        ]
+
+        for (reuseIdentifier, nib) in cells {
+            tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
+        }
     }
 
 	// MARK: - Private Constants

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -95,7 +95,7 @@ private extension SiteCredentialsViewController {
 	/// Configure the instruction cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
-        cell.configureLabel(text: "Enter your account information for pamelanguyen.com", style: .body)
+        cell.configureLabel(text: "Enter your account information for pamelanguyen.com.", style: .body)
     }
 
 


### PR DESCRIPTION
Ref. #322 
Testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14450

In this PR, a new view controller, `SiteCredentialsViewController`, and the basic UI have been added to the SiteAddress.storyboard. This code should look very similar to the `SiteAddressViewController`, as they share several of the same methods, UI, and IBOutlets.

### To test
1. Check out this branch
2. `bundle exec pod install`
3. Build and run without errors