### PR TITLE
Bump pod version.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.4"
+  s.version       = "1.20.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
Now that the 1.19.1 release has been merged into `develop`, this is just to create a new beta version that includes that fix in 1.20 (the nav bar color https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/314).

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14451