### PR TITLE
ULS: Remove support for large title nav bar.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.5"
+  s.version       = "1.20.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -183,7 +183,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
     ///
     public let navBarBackgroundColor: UIColor
     public let navButtonTextColor: UIColor
-    public let largeTitleTextColor: UIColor
+    public let navTitleTextColor: UIColor
     
     /// Designated initializer
     ///
@@ -196,7 +196,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
                 statusBarStyle: UIStatusBarStyle = .default,
                 navBarBackgroundColor: UIColor,
                 navButtonTextColor: UIColor,
-                largeTitleTextColor: UIColor) {
+                navTitleTextColor: UIColor) {
         self.borderColor = borderColor
         self.errorColor = errorColor
         self.textColor = textColor
@@ -206,6 +206,6 @@ public struct WordPressAuthenticatorUnifiedStyle {
         self.statusBarStyle = statusBarStyle
         self.navBarBackgroundColor = navBarBackgroundColor
         self.navButtonTextColor = navButtonTextColor
-        self.largeTitleTextColor = largeTitleTextColor
+        self.navTitleTextColor = navTitleTextColor
     }
 }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -37,12 +37,9 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     override open func viewDidLoad() {
         super.viewDidLoad()
-        
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationItem.largeTitleDisplayMode = .never
-        styleNavigationBar()
-        
+
         displayError(message: "")
+        styleNavigationBar()
         styleBackground()
         styleInstructions()
 
@@ -78,50 +75,48 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         instructionLabel?.textColor = WordPressAuthenticator.shared.style.instructionColor
     }
 
-    private func styleNavigationBar() {
-        
-        var navBarBackgroundColor: UIColor
-        var navButtonTextColor: UIColor
+    func styleNavigationBar(forUnified: Bool = false) {
+
+        var backgroundColor: UIColor
+        var buttonTextColor: UIColor
+        var titleTextColor: UIColor
         var hideBottomBorder: Bool
         
-        switch navigationItem.largeTitleDisplayMode {
-        // Original nav bar style
-        case .never:
-            setupNavBarIcon()
-            navButtonTextColor = WordPressAuthenticator.shared.style.navButtonTextColor
-            navBarBackgroundColor = WordPressAuthenticator.shared.style.navBarBackgroundColor
-            hideBottomBorder = false
-        // Unified nav bar style
-        default:
+        if forUnified {
+            // Unified nav bar style
             setupNavBarIcon(showIcon: false)
-            navButtonTextColor = WordPressAuthenticator.shared.unifiedStyle?.navButtonTextColor ?? WordPressAuthenticator.shared.style.navButtonTextColor
-            navBarBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.navBarBackgroundColor ?? WordPressAuthenticator.shared.style.navBarBackgroundColor
+            backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.navBarBackgroundColor ??
+                              WordPressAuthenticator.shared.style.navBarBackgroundColor
+            buttonTextColor = WordPressAuthenticator.shared.unifiedStyle?.navButtonTextColor ??
+                              WordPressAuthenticator.shared.style.navButtonTextColor
+            titleTextColor = WordPressAuthenticator.shared.unifiedStyle?.navTitleTextColor ??
+                             WordPressAuthenticator.shared.style.primaryTitleColor
             hideBottomBorder = true
+        } else {
+            // Original nav bar style
+            setupNavBarIcon()
+            backgroundColor = WordPressAuthenticator.shared.style.navBarBackgroundColor
+            buttonTextColor = WordPressAuthenticator.shared.style.navButtonTextColor
+            titleTextColor = WordPressAuthenticator.shared.style.primaryTitleColor
+            hideBottomBorder = false
         }
 
-        let largeTitleTextColor = WordPressAuthenticator.shared.unifiedStyle?.largeTitleTextColor ?? WordPressAuthenticator.shared.style.instructionColor
-        let largeTitleFont = WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold)
-        let largeTitleTextAttributes:[NSAttributedString.Key: Any] = [.foregroundColor: largeTitleTextColor,
-                                                                      .font: largeTitleFont]
         if #available(iOS 13.0, *) {
             let appearance = UINavigationBarAppearance()
             appearance.shadowColor = hideBottomBorder ? .clear : .separator
-            appearance.backgroundColor = navBarBackgroundColor
-            appearance.largeTitleTextAttributes = largeTitleTextAttributes
-            appearance.titleTextAttributes = [.foregroundColor: WordPressAuthenticator.shared.style.primaryTitleColor]
-            UIBarButtonItem.appearance().tintColor = navButtonTextColor
+            appearance.backgroundColor = backgroundColor
+            appearance.titleTextAttributes = [.foregroundColor: titleTextColor]
+            UIBarButtonItem.appearance().tintColor = buttonTextColor
             
             UINavigationBar.appearance().standardAppearance = appearance
             UINavigationBar.appearance().compactAppearance = appearance
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
         } else {
             let appearance = UINavigationBar.appearance()
-            appearance.barTintColor = navBarBackgroundColor
-            appearance.largeTitleTextAttributes = largeTitleTextAttributes
-            appearance.titleTextAttributes = [.foregroundColor: WordPressAuthenticator.shared.style.primaryTitleColor]
-            UIBarButtonItem.appearance().tintColor = navButtonTextColor
+            appearance.barTintColor = backgroundColor
+            appearance.titleTextAttributes = [.foregroundColor: titleTextColor]
+            UIBarButtonItem.appearance().tintColor = buttonTextColor
         }
-
     }
 
     func configureViewLoading(_ loading: Bool) {
@@ -406,23 +401,6 @@ extension LoginViewController {
         loginFields.meta.googleUser = googleUser
     }
     
-}
-
-// MARK: - Navigation Bar Large Titles
-
-extension LoginViewController {
-    func setLargeTitleDisplayMode(_ largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode) {
-
-        // prefersLargeTitles needs to always be true if large titles are used anywhere.
-        // In order to show/hide large titles, toggle largeTitleDisplayMode instead of prefersLargeTitles.
-        // This allows the large titles to hide/show correctly, and animate properly when doing so,
-        // when going from a view with large titles to one without, and vice versa.
-        // Ref https://www.morningswiftui.com/blog/fix-large-title-animation-on-ios13
-
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = largeTitleDisplayMode
-        styleNavigationBar()
-    }
 }
 
 // MARK: - LoginSocialError delegate methods

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -31,7 +31,7 @@ final class SiteAddressViewController: LoginViewController {
         super.viewDidLoad()
 
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
-        setLargeTitleDisplayMode(.always)
+        styleNavigationBar(forUnified: true)
 
         localizePrimaryButton()
         registerTableViewCells()


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/318
Ref: #315 

This removes the large titles from the unified flows' navigation bar. It has the same style, except now the title is displayed normally instead of large.

| <img width="355" alt="Screen Shot 2020-07-09 at 2 25 06 PM" src="https://user-images.githubusercontent.com/1816888/87087247-047f8800-c1f0-11ea-9add-82370d3e16cc.png"> | <img width="359" alt="Screen Shot 2020-07-09 at 2 25 50 PM" src="https://user-images.githubusercontent.com/1816888/87087321-1eb96600-c1f0-11ea-897a-f37737318500.png"> |
|--------|-------|

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14453