### PR TITLE
ULS: Update Help button color

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.7"
+  s.version       = "1.20.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -2,7 +2,6 @@ import Gridicons
 import WordPressUI
 
 private enum Constants {
-    static let helpButtonTitleColor = UIColor(white: 1.0, alpha: 0.4)
     static let helpButtonInsets = UIEdgeInsets(top: 0.0, left: 5.0, bottom: 0.0, right: 5.0)
     //Button Item: Custom view wrapping the Help UIbutton
     static let helpButtonItemMarginSpace = CGFloat(-8)
@@ -158,7 +157,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
     /// Whenever the WordPressAuthenticator Delegate returns true, when `shouldDisplayHelpButton` is queried, we'll proceed
     /// and attach the Help Button to the navigationController.
     ///
-    public func setupHelpButtonIfNeeded() {
+    func setupHelpButtonIfNeeded() {
         guard shouldDisplayHelpButton else {
             return
         }
@@ -167,16 +166,33 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         refreshSupportNotificationIndicator()
     }
 
+    /// Sets the Help button text color.
+    ///
+    /// - Parameters:
+    ///     - forUnified: Indicates whether to use text color for the unified auth flows or the original auth flows.
+    ///
+    func setHelpButtonTextColor(forUnified: Bool) {
+        let navButtonTextColor: UIColor = {
+            if forUnified {
+                return WordPressAuthenticator.shared.unifiedStyle?.navButtonTextColor ?? WordPressAuthenticator.shared.style.navButtonTextColor
+            }
+            return WordPressAuthenticator.shared.style.navButtonTextColor
+        }()
+        
+        helpButton.setTitleColor(navButtonTextColor, for: .normal)
+        helpButton.setTitleColor(navButtonTextColor.withAlphaComponent(0.4), for: .highlighted)
+    }
+
+    // MARK: - Helpers
+
     /// Adds the Help Button to the nav controller
     ///
-    public func addHelpButtonToNavController() {
+    private func addHelpButtonToNavController() {
         let barButtonView = createBarButtonView()
         addHelpButton(to: barButtonView)
         addNotificationIndicatorView(to: barButtonView)
         addRightBarButtonItem(with: barButtonView)
     }
-
-    // MARK: - helpers
 
     private func addRightBarButtonItem(with customView: UIView) {
         let spacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
@@ -197,7 +213,8 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
     private func addHelpButton(to superView: UIView) {
         helpButton.setTitle(NSLocalizedString("Help", comment: "Help button"), for: .normal)
-        helpButton.setTitleColor(Constants.helpButtonTitleColor, for: .highlighted)
+        setHelpButtonTextColor(forUnified: false)
+        
         helpButton.on(.touchUpInside) { [weak self] control in
             self?.handleHelpButtonTapped(control)
         }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -85,6 +85,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         if forUnified {
             // Unified nav bar style
             setupNavBarIcon(showIcon: false)
+            setHelpButtonTextColor(forUnified: true)
             backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.navBarBackgroundColor ??
                               WordPressAuthenticator.shared.style.navBarBackgroundColor
             buttonTextColor = WordPressAuthenticator.shared.unifiedStyle?.navButtonTextColor ??
@@ -95,6 +96,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         } else {
             // Original nav bar style
             setupNavBarIcon()
+            setHelpButtonTextColor(forUnified: false)
             backgroundColor = WordPressAuthenticator.shared.style.navBarBackgroundColor
             buttonTextColor = WordPressAuthenticator.shared.style.navButtonTextColor
             titleTextColor = WordPressAuthenticator.shared.style.primaryTitleColor

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -24,6 +24,9 @@ class SiteCredentialsViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
+        styleNavigationBar(forUnified: true)
+
 		localizePrimaryButton()
 		registerTableViewCells()
 		loadRows()


### PR DESCRIPTION
Ref: #315 

This adds functionality to set the `Help` nav button text color based on the nav bar being displayed. It also enables the unified nav bar on the Site Credentials view.

For the unified flows, it is now the same blue as the `Back` button.

<kbd><img width="358" alt="Screen Shot 2020-07-10 at 12 23 19 PM" src="https://user-images.githubusercontent.com/1816888/87186147-394f1600-c2a8-11ea-80b7-d67b95df896c.png"></kbd>

For the original flows, it is still white.

<kbd><img width="356" alt="Screen Shot 2020-07-10 at 12 23 30 PM" src="https://user-images.githubusercontent.com/1816888/87186162-3f44f700-c2a8-11ea-83b8-e5e1e863fd63.png"></kbd>

To note, when tapping `Help` and the `Support` view is displayed, the `Close` button (left bar button) color is incorrect for the unified flow. Stay tuned!

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14457