### PR TITLE
UL&S: SiteCredentialsViewController username and password fields

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.21.0-beta.1"
+  s.version       = "1.21.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.21.0-beta.2"
+  s.version       = "1.21.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.6"
+  s.version       = "1.20.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0-beta.7"
+  s.version       = "1.20.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -60,7 +60,7 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                         comment: "Instruction text on the login's email address screen."),
             siteLoginInstructions: NSLocalizedString("Enter the address of the WordPress site you'd like to connect.",
                                                      comment: "Instruction text on the login's site addresss screen."),
-			siteCredentialInstructions: NSLocalizedString("Enter your account information for %@",
+			siteCredentialInstructions: NSLocalizedString("Enter your account information for %@.",
 														  comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                     comment: "The button title text when there is a next step for logging in or signing up."),

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -26,6 +26,10 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let findSiteButtonTitle: String
     public let resetPasswordButtonTitle: String
 
+	/// Placeholder text for textfields.
+	///
+	public let usernamePlaceholder: String
+
     /// Designated initializer.
     ///
     public init(emailLoginInstructions: String,
@@ -37,7 +41,8 @@ public struct WordPressAuthenticatorDisplayStrings {
                 resetPasswordButtonTitle: String,
                 gettingStartedTitle: String,
                 logInTitle: String,
-                signUpTitle: String) {
+                signUpTitle: String,
+				usernamePlaceholder: String) {
         self.emailLoginInstructions = emailLoginInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
@@ -48,6 +53,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.gettingStartedTitle = gettingStartedTitle
         self.logInTitle = logInTitle
         self.signUpTitle = signUpTitle
+		self.usernamePlaceholder = usernamePlaceholder
     }
 }
 
@@ -73,7 +79,9 @@ public extension WordPressAuthenticatorDisplayStrings {
             logInTitle: NSLocalizedString("Log In",
                                           comment: "View title during the log in process."),
             signUpTitle: NSLocalizedString("Sign Up",
-                                           comment: "View title during the sign up process.")
+                                           comment: "View title during the sign up process."),
+			usernamePlaceholder: NSLocalizedString("Username",
+												   comment: "Placeholder for the username textfield.")
         )
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -29,6 +29,7 @@ public struct WordPressAuthenticatorDisplayStrings {
 	/// Placeholder text for textfields.
 	///
 	public let usernamePlaceholder: String
+	public let passwordPlaceholder: String
 
     /// Designated initializer.
     ///
@@ -42,7 +43,8 @@ public struct WordPressAuthenticatorDisplayStrings {
                 gettingStartedTitle: String,
                 logInTitle: String,
                 signUpTitle: String,
-				usernamePlaceholder: String) {
+				usernamePlaceholder: String,
+				passwordPlaceholder: String) {
         self.emailLoginInstructions = emailLoginInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
@@ -54,6 +56,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.logInTitle = logInTitle
         self.signUpTitle = signUpTitle
 		self.usernamePlaceholder = usernamePlaceholder
+		self.passwordPlaceholder = passwordPlaceholder
     }
 }
 
@@ -81,7 +84,9 @@ public extension WordPressAuthenticatorDisplayStrings {
             signUpTitle: NSLocalizedString("Sign Up",
                                            comment: "View title during the sign up process."),
 			usernamePlaceholder: NSLocalizedString("Username",
-												   comment: "Placeholder for the username textfield.")
+												   comment: "Placeholder for the username textfield."),
+			passwordPlaceholder: NSLocalizedString("Password",
+												   comment: "Placeholder for the password textfield.")
         )
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -9,6 +9,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let emailLoginInstructions: String
     public let jetpackLoginInstructions: String
     public let siteLoginInstructions: String
+	public let siteCredentialInstructions: String
 
     /// Strings: primary call-to-action button titles.
     ///
@@ -30,6 +31,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public init(emailLoginInstructions: String,
                 jetpackLoginInstructions: String,
                 siteLoginInstructions: String,
+				siteCredentialInstructions: String,
                 continueButtonTitle: String,
                 findSiteButtonTitle: String,
                 resetPasswordButtonTitle: String,
@@ -39,6 +41,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.emailLoginInstructions = emailLoginInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
+		self.siteCredentialInstructions = siteCredentialInstructions
         self.continueButtonTitle = continueButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
@@ -57,6 +60,8 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                         comment: "Instruction text on the login's email address screen."),
             siteLoginInstructions: NSLocalizedString("Enter the address of the WordPress site you'd like to connect.",
                                                      comment: "Instruction text on the login's site addresss screen."),
+			siteCredentialInstructions: NSLocalizedString("Enter your account information for %@",
+														  comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                     comment: "The button title text when there is a next step for logging in or signing up."),
             findSiteButtonTitle: NSLocalizedString("Find your site address",

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -102,6 +102,9 @@ private extension TextFieldTableViewCell {
 
 		secureTextEntryToggle = UIButton(type: .custom)
 		secureTextEntryToggle?.clipsToBounds = true
+		// The icon should match the border color.
+		let tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
+		secureTextEntryToggle?.tintColor = tintColor
 
 		secureTextEntryToggle?.addTarget(self,
 										 action: #selector(secureTextEntryToggleAction),

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -52,7 +52,6 @@ private extension TextFieldTableViewCell {
     func setCommonTextFieldStyles() {
         textField.font = UIFont.preferredFont(forTextStyle: .body)
         textField.autocorrectionType = .no
-        textField.returnKeyType = .continue
     }
 
     /// Sets the textfield keyboard type and applies common traits.
@@ -62,8 +61,10 @@ private extension TextFieldTableViewCell {
         switch style {
         case .url:
             textField.keyboardType = .URL
+			textField.returnKeyType = .continue
 		case .username:
 			textField.keyboardType = .default
+			textField.returnKeyType = .next
         default:
             setCommonTextFieldStyles()
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -117,9 +117,6 @@ private extension TextFieldTableViewCell {
 	}
 
 	func setSecureTextEntry(_ secureTextEntry: Bool) {
-		// This is a fix for a bug where the text field reverts to a system
-		// serif font if you disable secure text entry while it contains text.
-		textField.font = nil
 		textField.font = UIFont.preferredFont(forTextStyle: .body)
 
 		textField.isSecureTextEntry = secureTextEntry

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -93,7 +93,7 @@ private extension TextFieldTableViewCell {
 	/// Build the show / hide icon in the textfield.
 	///
 	func configureSecureTextEntryToggle() {
-		if showSecureTextEntryToggle == false {
+		guard showSecureTextEntryToggle else {
 			return
 		}
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -62,6 +62,8 @@ private extension TextFieldTableViewCell {
         switch style {
         case .url:
             textField.keyboardType = .URL
+		case .username:
+			textField.keyboardType = .default
         default:
             setCommonTextFieldStyles()
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -5,18 +5,27 @@ import UIKit
 ///
 final class TextFieldTableViewCell: UITableViewCell {
 
-    /// Private properties
+    /// Private properties.
     ///
     @IBOutlet private weak var borderView: UIView!
     @IBOutlet private weak var borderWidth: NSLayoutConstraint!
+	private var secureTextEntryToggle: UIButton?
+	private var secureTextEntryImageVisible: UIImage?
+	private var secureTextEntryImageHidden: UIImage?
 
     private var hairlineBorderWidth: CGFloat {
         return 1.0 / UIScreen.main.scale
     }
 
-    /// Public properties
+    /// Public properties.
     ///
     @IBOutlet public weak var textField: UITextField! // public so it can be the first responder
+	@IBInspectable public var showSecureTextEntryToggle: Bool = false {
+		didSet {
+			configureSecureTextEntryToggle()
+		}
+	}
+
     public static let reuseIdentifier = "TextFieldTableViewCell"
 
     override func awakeFromNib() {
@@ -58,8 +67,6 @@ private extension TextFieldTableViewCell {
     /// - note: Don't assign first responder here. It's too early in the view lifecycle.
     ///
     func applyTextFieldStyle(_ style: TextFieldStyle) {
-		setCommonTextFieldStyles()
-
 		switch style {
         case .url:
             textField.keyboardType = .URL
@@ -70,8 +77,74 @@ private extension TextFieldTableViewCell {
 		case .password:
 			textField.keyboardType = .default
 			textField.returnKeyType = .continue
+			setSecureTextEntry(true)
+			showSecureTextEntryToggle = true
+			configureSecureTextEntryToggle()
         }
     }
+}
+
+
+// MARK: - Secure Text Entry
+/// Methods ported from WPWalkthroughTextField.h/.m
+///
+private extension TextFieldTableViewCell {
+
+	/// Build the show / hide icon in the textfield.
+	///
+	func configureSecureTextEntryToggle() {
+		if showSecureTextEntryToggle == false {
+			return
+		}
+
+		secureTextEntryImageVisible = UIImage.gridicon(.visible)
+		secureTextEntryImageHidden = UIImage.gridicon(.notVisible)
+
+		secureTextEntryToggle = UIButton(type: .custom)
+		secureTextEntryToggle?.clipsToBounds = true
+
+		secureTextEntryToggle?.addTarget(self,
+										 action: #selector(secureTextEntryToggleAction),
+										 for: .touchUpInside)
+
+		updateSecureTextEntryToggleImage()
+		updateSecureTextEntryForAccessibility()
+		textField.rightView = secureTextEntryToggle
+		textField.rightViewMode = .always
+	}
+
+	func setSecureTextEntry(_ secureTextEntry: Bool) {
+		// This is a fix for a bug where the text field reverts to a system
+		// serif font if you disable secure text entry while it contains text.
+		textField.font = nil
+		textField.font = UIFont.preferredFont(forTextStyle: .body)
+
+		textField.isSecureTextEntry = secureTextEntry
+		updateSecureTextEntryToggleImage()
+		updateSecureTextEntryForAccessibility()
+	}
+
+	@objc func secureTextEntryToggleAction(_ sender: Any) {
+		textField.isSecureTextEntry = !textField.isSecureTextEntry
+
+		// Save and re-apply the current selection range to save the cursor position
+		let currentTextRange = textField.selectedTextRange
+		textField.becomeFirstResponder()
+		textField.selectedTextRange = currentTextRange
+		updateSecureTextEntryToggleImage()
+		updateSecureTextEntryForAccessibility()
+	}
+
+	func updateSecureTextEntryToggleImage() {
+		let image = textField.isSecureTextEntry ? secureTextEntryImageHidden : secureTextEntryImageVisible
+		secureTextEntryToggle?.setImage(image, for: .normal)
+		secureTextEntryToggle?.sizeToFit()
+	}
+
+	func updateSecureTextEntryForAccessibility() {
+		secureTextEntryToggle?.accessibilityLabel = Constants.showPassword
+		secureTextEntryToggle?.accessibilityValue = textField.isSecureTextEntry ? Constants.passwordHidden : Constants.passwordShown
+	}
 }
 
 
@@ -85,4 +158,16 @@ extension TextFieldTableViewCell {
         case username
         case password
     }
+
+	struct Constants {
+		/// Accessibility Hints
+		///
+		static let passwordHidden = NSLocalizedString("Hidden",
+													  comment: "Accessibility value if login page's password field is hiding the password (i.e. with asterisks).")
+		static let passwordShown = NSLocalizedString("Shown",
+													 comment: "Accessibility value if login page's password field is displaying the password.")
+		static let showPassword = NSLocalizedString("Show password",
+													comment:"Accessibility label for the 'Show password' button in the login page's password field.")
+
+	}
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -58,15 +58,18 @@ private extension TextFieldTableViewCell {
     /// - note: Don't assign first responder here. It's too early in the view lifecycle.
     ///
     func applyTextFieldStyle(_ style: TextFieldStyle) {
-        switch style {
+		setCommonTextFieldStyles()
+
+		switch style {
         case .url:
             textField.keyboardType = .URL
 			textField.returnKeyType = .continue
 		case .username:
 			textField.keyboardType = .default
 			textField.returnKeyType = .next
-        default:
-            setCommonTextFieldStyles()
+		case .password:
+			textField.keyboardType = .default
+			textField.returnKeyType = .continue
         }
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -19,7 +19,6 @@
                 <subviews>
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
                         <rect key="frame" x="16" y="6" width="288" height="51"/>
-                        <color key="tintColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="vu1-24-Omw"/>
                         </constraints>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -19,6 +19,7 @@
                 <subviews>
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
                         <rect key="frame" x="16" y="6" width="288" height="51"/>
+                        <color key="tintColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="vu1-24-Omw"/>
                         </constraints>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i98-6g-rDP" userLabel="text label">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i98-6g-rDP" userLabel="text label">
                         <rect key="frame" x="16" y="11" width="288" height="22"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -164,7 +164,7 @@ private extension SiteCredentialsViewController {
 	/// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-		rows = [.instructions, .username]
+		rows = [.instructions, .username, .password]
     }
 
 	/// Configure cells.
@@ -175,6 +175,8 @@ private extension SiteCredentialsViewController {
             configureInstructionLabel(cell)
 		case let cell as TextFieldTableViewCell where row == .username:
 			configureUsernameTextField(cell)
+		case let cell as TextFieldTableViewCell where row == .password:
+			configurePasswordTextField(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -196,6 +198,15 @@ private extension SiteCredentialsViewController {
         usernameField = cell.textField
 		cell.textField.delegate = self
         SigninEditingState.signinEditingStateActive = true
+	}
+
+	/// Configure the password textfield cell.
+	///
+	func configurePasswordTextField(_ cell: TextFieldTableViewCell) {
+		cell.configureTextFieldStyle(with: .password,
+									 and: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder)
+		passwordField = cell.textField
+		cell.textField.delegate = self
 	}
 
 	// MARK: - Private Constants

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -15,6 +15,7 @@ class SiteCredentialsViewController: LoginViewController {
     var verticalCenterConstraint: NSLayoutConstraint?
 
     private var rows = [Row]()
+	private weak var firstTextField: UITextField?
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -103,6 +103,23 @@ extension SiteCredentialsViewController: NUXKeyboardResponder {
     }
 }
 
+
+// MARK: - TextField Delegate conformance
+extension SiteCredentialsViewController: UITextFieldDelegate {
+
+	/// Handle the keyboard `return` button action.
+	///
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if textField == usernameField {
+            passwordField?.becomeFirstResponder()
+        } else if textField == passwordField {
+            validateForm()
+        }
+        return true
+    }
+}
+
+
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
 
@@ -180,4 +197,16 @@ private extension SiteCredentialsViewController {
 			}
         }
     }
+}
+
+
+// MARK: - Instance Methods
+extension SiteCredentialsViewController {
+
+	/// Validates what is entered in the various form fields and, if valid,
+	/// proceeds with the submit action.
+	///
+	@objc func validateForm() {
+		validateFormAndLogin()
+	}
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -31,6 +31,19 @@ class SiteCredentialsViewController: LoginViewController {
 		configureSubmitButton(animating: false)
     }
 
+	override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        configureSubmitButton(animating: false)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
+                                  keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
+    }
+
 	// MARK: - Overrides
 
     /// Style individual ViewController backgrounds, for now.
@@ -65,6 +78,17 @@ extension SiteCredentialsViewController: UITableViewDataSource {
     }
 }
 
+
+// MARK: - Keyboard Notifications
+extension SiteCredentialsViewController: NUXKeyboardResponder {
+    @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
+        keyboardWillShow(notification)
+    }
+
+    @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
+        keyboardWillHide(notification)
+    }
+}
 
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -95,7 +95,8 @@ private extension SiteCredentialsViewController {
 	/// Configure the instruction cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
-        cell.configureLabel(text: "Enter your account information for pamelanguyen.com", style: .body)
+		let text = String.localizedStringWithFormat(WordPressAuthenticator.shared.displayStrings.siteCredentialInstructions, loginFields.siteAddress)
+        cell.configureLabel(text: text, style: .body)
     }
 
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -185,7 +185,8 @@ private extension SiteCredentialsViewController {
 	/// Configure the instruction cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
-		let text = String.localizedStringWithFormat(WordPressAuthenticator.shared.displayStrings.siteCredentialInstructions, loginFields.siteAddress)
+		let displayURL = sanitizedSiteAddress(siteAddress: loginFields.siteAddress)
+		let text = String.localizedStringWithFormat(WordPressAuthenticator.shared.displayStrings.siteCredentialInstructions, displayURL)
         cell.configureLabel(text: text, style: .body)
     }
 
@@ -234,6 +235,15 @@ private extension SiteCredentialsViewController {
 
 // MARK: - Instance Methods
 extension SiteCredentialsViewController {
+	/// Sanitize and format the site address we show to users.
+    ///
+    @objc func sanitizedSiteAddress(siteAddress: String) -> String {
+        let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: siteAddress) as NSString
+        if let str = baseSiteUrl.components(separatedBy: "://").last {
+            return str
+        }
+        return siteAddress
+    }
 
 	/// Validates what is entered in the various form fields and, if valid,
 	/// proceeds with the submit action.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -32,13 +32,6 @@ class SiteCredentialsViewController: LoginViewController {
 		localizePrimaryButton()
 		registerTableViewCells()
 		loadRows()
-		configureSubmitButton(animating: false)
-    }
-
-	override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        configureSubmitButton(animating: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -26,6 +26,9 @@ class SiteCredentialsViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+		navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
+        styleNavigationBar(forUnified: true)
+
 		localizePrimaryButton()
 		registerTableViewCells()
 		loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -15,7 +15,8 @@ class SiteCredentialsViewController: LoginViewController {
     var verticalCenterConstraint: NSLayoutConstraint?
 
     private var rows = [Row]()
-	private weak var firstTextField: UITextField?
+	private weak var usernameField: UITextField?
+	private weak var passwordField: UITextField?
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
@@ -144,12 +145,11 @@ private extension SiteCredentialsViewController {
 	///
 	func configureUsernameTextField(_ cell: TextFieldTableViewCell) {
 		cell.configureTextFieldStyle(with: .username, and: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder)
-		// Save a reference to the first textField so it can becomeFirstResponder.
-        firstTextField = cell.textField
+		// Save a reference to the textField so it can becomeFirstResponder.
+        usernameField = cell.textField
 		cell.textField.delegate = self
         SigninEditingState.signinEditingStateActive = true
 	}
-
 
 	// MARK: - Private Constants
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -147,7 +147,7 @@ private extension SiteCredentialsViewController {
 	/// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.instructions]
+		rows = [.instructions, .username]
     }
 
 	/// Configure cells.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -95,6 +95,20 @@ extension SiteCredentialsViewController: UITableViewDataSource {
 }
 
 
+// MARK: - UITableViewDelegate conformance
+extension SiteCredentialsViewController: UITableViewDelegate {
+	/// After a textfield cell is done displaying, remove the textfield reference.
+	///
+	func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+		if rows[indexPath.row] == .username {
+			usernameField = nil
+		} else if rows[indexPath.row] == .password {
+			passwordField = nil
+		}
+	}
+}
+
+
 // MARK: - Keyboard Notifications
 extension SiteCredentialsViewController: NUXKeyboardResponder {
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -67,7 +67,8 @@ private extension SiteCredentialsViewController {
     ///
     func registerTableViewCells() {
         let cells = [
-            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib()
+            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
+			TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib(),
         ]
 
         for (reuseIdentifier, nib) in cells {
@@ -87,6 +88,8 @@ private extension SiteCredentialsViewController {
         switch cell {
         case let cell as TextLabelTableViewCell where row == .instructions:
             configureInstructionLabel(cell)
+		case let cell as TextFieldTableViewCell where row == .username:
+			configureUsernameTextField(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -99,6 +102,16 @@ private extension SiteCredentialsViewController {
         cell.configureLabel(text: text, style: .body)
     }
 
+	/// Configure the username textfield cell.
+	///
+	func configureUsernameTextField(_ cell: TextFieldTableViewCell) {
+		cell.configureTextFieldStyle(with: .username, and: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder)
+		// Save a reference to the first textField so it can becomeFirstResponder.
+        firstTextField = cell.textField
+		cell.textField.delegate = self
+        SigninEditingState.signinEditingStateActive = true
+	}
+
 
 	// MARK: - Private Constants
 
@@ -106,11 +119,14 @@ private extension SiteCredentialsViewController {
     ///
     enum Row {
         case instructions
+		case username
 
         var reuseIdentifier: String {
             switch self {
             case .instructions:
                 return TextLabelTableViewCell.reuseIdentifier
+			case .username:
+				return TextFieldTableViewCell.reuseIdentifier
 			}
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -190,7 +190,8 @@ private extension SiteCredentialsViewController {
 	/// Configure the username textfield cell.
 	///
 	func configureUsernameTextField(_ cell: TextFieldTableViewCell) {
-		cell.configureTextFieldStyle(with: .username, and: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder)
+		cell.configureTextFieldStyle(with: .username,
+									 and: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder)
 		// Save a reference to the textField so it can becomeFirstResponder.
         usernameField = cell.textField
 		cell.textField.delegate = self

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -43,6 +43,7 @@ class SiteCredentialsViewController: LoginViewController {
 
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
+        configureViewForEditingIfNeeded()
     }
 
 	// MARK: - Overrides
@@ -56,6 +57,17 @@ class SiteCredentialsViewController: LoginViewController {
         }
 
         view.backgroundColor = unifiedBackgroundColor
+    }
+
+	/// Configure the view for an editing state. Should only be called from viewWillAppear
+    /// as this method skips animating any change in height.
+    ///
+    @objc func configureViewForEditingIfNeeded() {
+       // Check the helper to determine whether an editing state should be assumed.
+       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+       if SigninEditingState.signinEditingStateActive {
+           usernameField?.becomeFirstResponder()
+       }
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -187,12 +187,15 @@ private extension SiteCredentialsViewController {
     enum Row {
         case instructions
 		case username
+		case password
 
         var reuseIdentifier: String {
             switch self {
             case .instructions:
                 return TextLabelTableViewCell.reuseIdentifier
 			case .username:
+				return TextFieldTableViewCell.reuseIdentifier
+			case .password:
 				return TextFieldTableViewCell.reuseIdentifier
 			}
         }


### PR DESCRIPTION
Ref. #283 

This PR adds the password type to the `TextfieldTableViewCell` and adds the username and password textfields to `SiteCredentialsViewController`. The "Continue" button is not yet implemented because this PR was getting kinda big.

Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14492

1. `bundle exec pod install`
2. Build and run 
3. Visit the test PR to see UI changes