### PR TITLE
ULS: Set status bar style per view controller displayed

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.21.0-beta.1"
+  s.version       = "1.21.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Info.plist
+++ b/WordPressAuthenticator/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/WordPressAuthenticator/Signin/LoginNavigationController.swift
+++ b/WordPressAuthenticator/Signin/LoginNavigationController.swift
@@ -6,7 +6,7 @@ import WordPressUI
 public class LoginNavigationController: RotationAwareNavigationViewController {
 
     public override var preferredStatusBarStyle: UIStatusBarStyle {
-        return WordPressAuthenticator.shared.style.statusBarStyle
+        return topViewController?.preferredStatusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
 
     public override func pushViewController(_ viewController: UIViewController, animated: Bool) {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -9,10 +9,6 @@ class LoginPrologueViewController: LoginViewController {
     private var buttonViewController: NUXButtonViewController?
     var showCancel = false
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-
     // MARK: - Lifecycle Methods
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -32,7 +32,13 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
         return delegate
     }
-    
+
+    open override var preferredStatusBarStyle: UIStatusBarStyle {
+        // Set to the old style as the default.
+        // Each VC in the unified flows needs to override this to use the unified style.
+        return WordPressAuthenticator.shared.style.statusBarStyle
+    }
+
     // MARK: Lifecycle Methods
 
     override open func viewDidLoad() {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -67,6 +67,10 @@ final class SiteAddressViewController: LoginViewController {
         view.backgroundColor = unifiedBackgroundColor
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
+    }
+
     /// Configures the appearance and state of the submit button.
     ///
     override func configureSubmitButton(animating: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -45,6 +45,11 @@ class SiteCredentialsViewController: LoginViewController {
 
         view.backgroundColor = unifiedBackgroundColor
     }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
+    }
+
 }
 
 


### PR DESCRIPTION
Ref: #315 

This provides the ability to set the status bar style in each view controller.

Since all views use `LoginViewController`, the default style is set there, which is the current style (`WordPressAuthenticator.shared.style.statusBarStyle`).

Each view controller in the unified flows will need to override `preferredStatusBarStyle` and set it to the new style (`WordPressAuthenticator.shared.unifiedStyle.statusBarStyle`). This has been done in the two new Site Address views.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14494
