### PR TITLE
Restoring method to handle SIWA passwordless 2FA account login.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.20.0"
+  s.version       = "1.20.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -231,6 +231,19 @@ class LoginPrologueViewController: LoginViewController {
     
 }
 
+// MARK: - LoginFacadeDelegate
+
+extension LoginPrologueViewController {
+
+    // Used by SIWA when logging with with a passwordless, 2FA account.
+    //
+    func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+        configureViewLoading(false)
+        socialNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
+    }
+
+}
+
 // MARK: - AppleAuthenticatorDelegate
 
 extension LoginPrologueViewController: AppleAuthenticatorDelegate {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -382,6 +382,7 @@ extension LoginViewController {
 // MARK: - Social Sign In Handling
 
 extension LoginViewController {
+
     func signInAppleAccount() {
         guard let token = loginFields.meta.socialServiceIDToken else {
             WordPressAuthenticator.track(.loginSocialButtonFailure, properties: ["source": SocialServiceName.apple.rawValue])
@@ -399,6 +400,31 @@ extension LoginViewController {
         loginFields.username = googleEmail
         loginFields.meta.socialServiceIDToken = googleToken
         loginFields.meta.googleUser = googleUser
+    }
+    
+    // Used by SIWA when logging with with a passwordless, 2FA account.
+    //
+    func socialNeedsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+        loginFields.nonceInfo = nonceInfo
+        loginFields.nonceUserID = userID
+        
+        var properties = [AnyHashable:Any]()
+        if let service = loginFields.meta.socialService?.rawValue {
+            properties["source"] = service
+        }
+        
+        WordPressAuthenticator.track(.loginSocial2faNeeded, properties: properties)
+        
+        guard let vc = Login2FAViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
+            return
+        }
+        
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+        
+        navigationController?.pushViewController(vc, animated: true)
     }
     
 }


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14371

This restores the method that handles logins with an account that:
- Has been used to login via SIWA.
- Does not have a WP password set.
- Has 2FA enabled on the WP account.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14504

For reference, this is re-implementing the original fix from https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/309.