### PR TITLE
UL&S: SiteCredentialsViewController: OnePassword function on username for iOS 12 users

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.21.0-beta.3"
+  s.version       = "1.21.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -36,7 +36,8 @@ extension WPStyleGuide {
     }
 
     /// Adds a 1password button to a WPWalkthroughTextField, if available
-    ///
+    /// - Note: this is for the old UI.
+	///
     class func configureOnePasswordButtonForTextfield(_ textField: WPWalkthroughTextField, target: NSObject, selector: Selector) {
         guard OnePasswordFacade.isOnePasswordEnabled else {
             return
@@ -44,6 +45,7 @@ extension WPStyleGuide {
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)
+		onePasswordButton.tintColor = WordPressAuthenticator.shared.style.primaryNormalBorderColor
         onePasswordButton.sizeToFit()
 
         onePasswordButton.accessibilityLabel =
@@ -56,7 +58,8 @@ extension WPStyleGuide {
     }
 
     /// Adds a 1password button to a stack view, if available
-    ///
+    /// - Note: this is for the old UI.
+	///
     class func configureOnePasswordButtonForStackView(_ stack: UIStackView, target: NSObject, selector: Selector) {
         guard OnePasswordFacade.isOnePasswordEnabled else {
             return
@@ -64,6 +67,7 @@ extension WPStyleGuide {
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)
+		onePasswordButton.tintColor = WordPressAuthenticator.shared.style.primaryNormalBorderColor
         onePasswordButton.sizeToFit()
         onePasswordButton.setContentHuggingPriority(.required, for: .horizontal)
         onePasswordButton.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -74,14 +78,16 @@ extension WPStyleGuide {
     }
 
     /// Adds a 1password button to a UITextField, if available
-    ///
-    class func configureOnePasswordButtonForTextfield(_ textField: UITextField?, target: NSObject, selector: Selector) {
-        guard OnePasswordFacade.isOnePasswordEnabled else {
-            return
-        }
+    /// - Note: this is for the Unified styles.
+	///
+	class func configureOnePasswordButtonForTextfield(_ textField: UITextField?, tintColor: UIColor?, target: NSObject, selector: Selector) {
+//        guard OnePasswordFacade.isOnePasswordEnabled else {
+//            return
+//        }
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)
+		onePasswordButton.tintColor = tintColor
         onePasswordButton.sizeToFit()
 
         onePasswordButton.accessibilityLabel =

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -81,9 +81,9 @@ extension WPStyleGuide {
     /// - Note: this is for the Unified styles.
 	///
 	class func configureOnePasswordButtonForTextfield(_ textField: UITextField?, tintColor: UIColor?, target: NSObject, selector: Selector) {
-//        guard OnePasswordFacade.isOnePasswordEnabled else {
-//            return
-//        }
+        guard OnePasswordFacade.isOnePasswordEnabled else {
+            return
+        }
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -73,6 +73,26 @@ extension WPStyleGuide {
         onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
     }
 
+	/// Adds a 1password button to a UITextField, if available
+	///
+	class func configureOnePasswordButtonForTextfield(_ textField: UITextField?, target: NSObject, selector: Selector) {
+		guard OnePasswordFacade.isOnePasswordEnabled else {
+			return
+		}
+
+		let onePasswordButton = UIButton(type: .custom)
+		onePasswordButton.setImage(.onePasswordImage, for: .normal)
+		onePasswordButton.sizeToFit()
+
+		onePasswordButton.accessibilityLabel =
+			NSLocalizedString("Fill with password manager", comment: "The password manager button in login pages. The button opens a dialog showing which password manager to use (e.g. 1Password, LastPass). ")
+
+		textField?.rightView = onePasswordButton
+		textField?.rightViewMode = .always
+
+		onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
+	}
+
     /// Configures a plain text button with default styles.
     ///
     class func configureTextButton(_ button: UIButton) {

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -67,7 +67,7 @@ extension WPStyleGuide {
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)
-		textField.tintColor = WordPressAuthenticator.shared.style.secondaryNormalBorderColor
+		onePasswordButton.tintColor = WordPressAuthenticator.shared.style.secondaryNormalBorderColor
         onePasswordButton.sizeToFit()
         onePasswordButton.setContentHuggingPriority(.required, for: .horizontal)
         onePasswordButton.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -73,25 +73,25 @@ extension WPStyleGuide {
         onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
     }
 
-	/// Adds a 1password button to a UITextField, if available
-	///
-	class func configureOnePasswordButtonForTextfield(_ textField: UITextField?, target: NSObject, selector: Selector) {
-		guard OnePasswordFacade.isOnePasswordEnabled else {
-			return
-		}
+    /// Adds a 1password button to a UITextField, if available
+    ///
+    class func configureOnePasswordButtonForTextfield(_ textField: UITextField?, target: NSObject, selector: Selector) {
+        guard OnePasswordFacade.isOnePasswordEnabled else {
+            return
+        }
 
-		let onePasswordButton = UIButton(type: .custom)
-		onePasswordButton.setImage(.onePasswordImage, for: .normal)
-		onePasswordButton.sizeToFit()
+        let onePasswordButton = UIButton(type: .custom)
+        onePasswordButton.setImage(.onePasswordImage, for: .normal)
+        onePasswordButton.sizeToFit()
 
-		onePasswordButton.accessibilityLabel =
-			NSLocalizedString("Fill with password manager", comment: "The password manager button in login pages. The button opens a dialog showing which password manager to use (e.g. 1Password, LastPass). ")
+        onePasswordButton.accessibilityLabel =
+            NSLocalizedString("Fill with password manager", comment: "The password manager button in login pages. The button opens a dialog showing which password manager to use (e.g. 1Password, LastPass). ")
 
-		textField?.rightView = onePasswordButton
-		textField?.rightViewMode = .always
+        textField?.rightView = onePasswordButton
+        textField?.rightViewMode = .always
 
-		onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
-	}
+        onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
+    }
 
     /// Configures a plain text button with default styles.
     ///
@@ -170,7 +170,7 @@ extension WPStyleGuide {
         } else {
             // Create an attributed string that contains the Google icon + button text.
             googleAttachment.bounds = CGRect(x: 0, y: (NUXButton.titleFont.capHeight - Constants.googleIconButtonSize) / 2,
-                                            width: Constants.googleIconButtonSize, height: Constants.googleIconButtonSize)
+                                             width: Constants.googleIconButtonSize, height: Constants.googleIconButtonSize)
 
             let buttonString = NSMutableAttributedString(attachment: googleAttachment)
             //  Add leading non-breaking spaces to separate the button text from the Google logo.

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -45,7 +45,7 @@ extension WPStyleGuide {
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)
-		onePasswordButton.tintColor = WordPressAuthenticator.shared.style.primaryNormalBorderColor
+		textField.tintColor = WordPressAuthenticator.shared.style.secondaryNormalBorderColor
         onePasswordButton.sizeToFit()
 
         onePasswordButton.accessibilityLabel =
@@ -67,7 +67,7 @@ extension WPStyleGuide {
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)
-		onePasswordButton.tintColor = WordPressAuthenticator.shared.style.primaryNormalBorderColor
+		textField.tintColor = WordPressAuthenticator.shared.style.secondaryNormalBorderColor
         onePasswordButton.sizeToFit()
         onePasswordButton.setContentHuggingPriority(.required, for: .horizontal)
         onePasswordButton.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/WordPressAuthenticator/Resources/Assets.xcassets/onepassword-button.imageset/Contents.json
+++ b/WordPressAuthenticator/Resources/Assets.xcassets/onepassword-button.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "onepassword-button.pdf"
+      "filename" : "onepassword-button.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -22,12 +22,10 @@ final class TextFieldTableViewCell: UITableViewCell {
 	/// - Note: we have to manually add an action to the textfield
 	///	        because the delegate method `textFieldDidChangeSelection(_ textField: UITextField)`
 	///         is only available to iOS 13+. When we no longer support iOS 12,
-	///			`registerTextFieldAction`, `textFieldDidChangeSelection`, and `siteURLHandler` can
+	///			`registerTextFieldAction`, `textFieldDidChangeSelection`, and `onChangeSelectionHandler` can
 	///			be deleted in favor of adding the delegate method to SiteAddressViewController.
 	@IBAction func registerTextFieldAction() {
-		if textfieldStyle == .url {
-			textFieldDidChangeSelection()
-		}
+		onChangeSelectionHandler?(textField)
 	}
 
 	/// Internal properties.
@@ -43,7 +41,7 @@ final class TextFieldTableViewCell: UITableViewCell {
 		}
 	}
 
-	public var siteURLHandler: ((_ sender: UITextField) -> Void)?
+	public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
 	public var onePasswordHandler: (() -> Void)?
     public static let reuseIdentifier = "TextFieldTableViewCell"
 
@@ -108,7 +106,7 @@ private extension TextFieldTableViewCell {
 	/// Call the handler when the textfield changes.
 	///
 	@objc func textFieldDidChangeSelection() {
-		siteURLHandler?(textField)
+		onChangeSelectionHandler?(textField)
 	}
 
 	/// Sets up a 1Password button if 1Password is available and user is on iOS 12.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -17,6 +17,10 @@ final class TextFieldTableViewCell: UITableViewCell {
         return 1.0 / UIScreen.main.scale
     }
 
+	/// Internal properties.
+	///
+	@objc var onePasswordButton: UIButton!
+
     /// Public properties.
     ///
     @IBOutlet public weak var textField: UITextField! // public so it can be the first responder
@@ -26,6 +30,7 @@ final class TextFieldTableViewCell: UITableViewCell {
 		}
 	}
 
+	public var onePasswordHandler: (() -> Void)?
     public static let reuseIdentifier = "TextFieldTableViewCell"
 
     override func awakeFromNib() {
@@ -74,6 +79,7 @@ private extension TextFieldTableViewCell {
 		case .username:
 			textField.keyboardType = .default
 			textField.returnKeyType = .next
+			setupOnePasswordButtonIfNeeded()
 		case .password:
 			textField.keyboardType = .default
 			textField.returnKeyType = .continue
@@ -82,6 +88,25 @@ private extension TextFieldTableViewCell {
 			configureSecureTextEntryToggle()
         }
     }
+
+	/// Sets up a 1Password button if 1Password is available and user is on iOS 12.
+	///
+	@objc func setupOnePasswordButtonIfNeeded() {
+		if #available(iOS 13, *) {
+			// no-op, we rely on the key icon in the keyboard to initiate a password manager.
+		} else {
+			let tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
+			// iOS 12 and lower, display the OnePassword button.
+			WPStyleGuide.configureOnePasswordButtonForTextfield(textField,
+																tintColor: tintColor,
+																target: self,
+																selector: #selector(onePasswordTapped(_:)))
+		}
+	}
+
+	@objc func onePasswordTapped(_ sender: UIButton) {
+		onePasswordHandler?()
+	}
 }
 
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -12,10 +12,23 @@ final class TextFieldTableViewCell: UITableViewCell {
 	private var secureTextEntryToggle: UIButton?
 	private var secureTextEntryImageVisible: UIImage?
 	private var secureTextEntryImageHidden: UIImage?
+	private var textfieldStyle: TextFieldStyle = .url
 
     private var hairlineBorderWidth: CGFloat {
         return 1.0 / UIScreen.main.scale
     }
+
+	/// Register an action for the SiteAddress URL textfield.
+	/// - Note: we have to manually add an action to the textfield
+	///	        because the delegate method `textFieldDidChangeSelection(_ textField: UITextField)`
+	///         is only available to iOS 13+. When we no longer support iOS 12,
+	///			`registerTextFieldAction`, `textFieldDidChangeSelection`, and `siteURLHandler` can
+	///			be deleted in favor of adding the delegate method to SiteAddressViewController.
+	@IBAction func registerTextFieldAction() {
+		if textfieldStyle == .url {
+			textFieldDidChangeSelection()
+		}
+	}
 
 	/// Internal properties.
 	///
@@ -30,6 +43,7 @@ final class TextFieldTableViewCell: UITableViewCell {
 		}
 	}
 
+	public var siteURLHandler: ((_ sender: UITextField) -> Void)?
 	public var onePasswordHandler: (() -> Void)?
     public static let reuseIdentifier = "TextFieldTableViewCell"
 
@@ -44,6 +58,7 @@ final class TextFieldTableViewCell: UITableViewCell {
 	/// - Parameter placeholder: the placeholder text, if any
 	///
     public func configureTextFieldStyle(with style: TextFieldStyle = .url, and placeholder: String?) {
+		textfieldStyle = style
         applyTextFieldStyle(style)
         textField.placeholder = placeholder
     }
@@ -76,6 +91,7 @@ private extension TextFieldTableViewCell {
         case .url:
             textField.keyboardType = .URL
 			textField.returnKeyType = .continue
+			registerTextFieldAction()
 		case .username:
 			textField.keyboardType = .default
 			textField.returnKeyType = .next
@@ -88,6 +104,12 @@ private extension TextFieldTableViewCell {
 			configureSecureTextEntryToggle()
         }
     }
+
+	/// Call the handler when the textfield changes.
+	///
+	@objc func textFieldDidChangeSelection() {
+		siteURLHandler?(textField)
+	}
 
 	/// Sets up a 1Password button if 1Password is available and user is on iOS 12.
 	///

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -24,6 +24,9 @@
                         </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <textInputTraits key="textInputTraits" autocorrectionType="no"/>
+                        <connections>
+                            <action selector="registerTextFieldAction" destination="KGk-i7-Jjw" eventType="editingChanged" id="h5O-aC-vsv"/>
+                        </connections>
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="40b-u3-ydU" userLabel="border view">
                         <rect key="frame" x="16" y="61" width="304" height="1"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -24,12 +24,19 @@ class TextLinkButtonTableViewCell: UITableViewCell {
 		button.titleLabel?.adjustsFontForContentSizeCategory = true
 	}
 
-    public func configureButton(text: String?) {
+	public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits? = .button) {
         button.setTitle(text, for: .normal)
 
         let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
         let buttonHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
+		button.accessibilityTraits = accessibilityTraits
     }
+
+	/// Toggle button enabled / disabled
+	///
+	public func toggleButton(_ isEnabled: Bool) {
+		button.isEnabled = isEnabled
+	}
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -243,7 +243,7 @@ private extension SiteAddressViewController {
         // Save a reference to the first textField so it can becomeFirstResponder.
         siteURLField = cell.textField
 		cell.textField.delegate = self
-		cell.siteURLHandler = { [weak self] textfield in
+		cell.onChangeSelectionHandler = { [weak self] textfield in
 			self?.loginFields.siteAddress = textfield.nonNilTrimmedText()
 			self?.configureSubmitButton(animating: false)
 		}

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -42,6 +42,7 @@ final class SiteAddressViewController: LoginViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+		siteURLField?.text = loginFields.siteAddress
         configureSubmitButton(animating: false)
     }
 
@@ -160,13 +161,6 @@ extension SiteAddressViewController: NUXKeyboardResponder {
 // MARK: - TextField Delegate conformance
 extension SiteAddressViewController: UITextFieldDelegate {
 
-	/// Store the site address as it changes
-	///
-	func textFieldDidChangeSelection(_ textField: UITextField) {
-		loginFields.siteAddress = textField.nonNilTrimmedText()
-		configureSubmitButton(animating: false)
-	}
-
 	/// Handle the keyboard `return` button action.
 	///
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -249,6 +243,11 @@ private extension SiteAddressViewController {
         // Save a reference to the first textField so it can becomeFirstResponder.
         siteURLField = cell.textField
 		cell.textField.delegate = self
+		cell.siteURLHandler = { [weak self] textfield in
+			self?.loginFields.siteAddress = textfield.nonNilTrimmedText()
+			self?.configureSubmitButton(animating: false)
+		}
+
         SigninEditingState.signinEditingStateActive = true
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -279,7 +279,7 @@ private extension SiteCredentialsViewController {
 			passwordField?.placeholder = nil
 		}
 
-//		forgotPasswordButton.accessibilityTraits = .link
+		forgotPasswordButton.accessibilityTraits = .link
 	}
 
 	// MARK: - Private Constants

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -110,6 +110,16 @@ class SiteCredentialsViewController: LoginViewController {
 		}
     }
 
+	/// No-op. Required by the SigninWPComSyncHandler protocol but the self-hosted
+    /// controller's implementation does not use safari saved credentials.
+    ///
+    override func updateSafariCredentialsIfNeeded() {}
+
+	/// No-op. Required by LoginFacade.
+	func displayLoginMessage(_ message: String) {}
+}
+
+
 // MARK: - UITableViewDataSource
 extension SiteCredentialsViewController: UITableViewDataSource {
     /// Returns the number of rows in a section.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -193,6 +193,7 @@ private extension SiteCredentialsViewController {
         let cells = [
             TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
 			TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib(),
+			TextLinkButtonTableViewCell.reuseIdentifier: TextLinkButtonTableViewCell.loadNib()
         ]
 
         for (reuseIdentifier, nib) in cells {
@@ -203,7 +204,7 @@ private extension SiteCredentialsViewController {
 	/// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-		rows = [.instructions, .username, .password]
+		rows = [.instructions, .username, .password, .forgotPassword]
     }
 
 	/// Configure cells.
@@ -216,6 +217,8 @@ private extension SiteCredentialsViewController {
 			configureUsernameTextField(cell)
 		case let cell as TextFieldTableViewCell where row == .password:
 			configurePasswordTextField(cell)
+		case let cell as TextLinkButtonTableViewCell:
+			configureForgotPassword(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -249,6 +252,25 @@ private extension SiteCredentialsViewController {
 		cell.textField.delegate = self
 	}
 
+	/// Configure the forgot password cell.
+	///
+	func configureForgotPassword(_ cell: TextLinkButtonTableViewCell) {
+		cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle)
+		cell.actionHandler = { [weak self] in
+			guard let self = self else {
+				return
+			}
+
+			// If information is currently processing, ignore button tap.
+			guard self.enableSubmit(animating: false) else {
+				return
+			}
+
+			WordPressAuthenticator.openForgotPasswordURL(self.loginFields)
+			WordPressAuthenticator.track(.loginForgotPasswordClicked)
+		}
+	}
+
 	/// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
 	///
 	func configureForAccessibility() {
@@ -276,6 +298,7 @@ private extension SiteCredentialsViewController {
         case instructions
 		case username
 		case password
+		case forgotPassword
 
         var reuseIdentifier: String {
             switch self {
@@ -285,6 +308,8 @@ private extension SiteCredentialsViewController {
 				return TextFieldTableViewCell.reuseIdentifier
 			case .password:
 				return TextFieldTableViewCell.reuseIdentifier
+			case .forgotPassword:
+				return TextLinkButtonTableViewCell.reuseIdentifier
 			}
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -9,14 +9,15 @@ class SiteCredentialsViewController: LoginViewController {
 	/// Private properties.
     ///
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
-
-    // Required property declaration for `NUXKeyboardResponder` but unused here.
-    var verticalCenterConstraint: NSLayoutConstraint?
-
-    private var rows = [Row]()
+	private var rows = [Row]()
 	private weak var usernameField: UITextField?
 	private weak var passwordField: UITextField?
+
+	/// Internal properties.
+	///
+	@IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+    // Required property declaration for `NUXKeyboardResponder` but unused here.
+    var verticalCenterConstraint: NSLayoutConstraint?
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -26,6 +26,13 @@ class SiteCredentialsViewController: LoginViewController {
         }
     }
 
+	override var loginFields: LoginFields {
+        didSet {
+            // Clear the password (if any) from LoginFields
+            loginFields.password = ""
+        }
+    }
+
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -100,6 +100,15 @@ class SiteCredentialsViewController: LoginViewController {
     }
 }
 
+	/// Set error messages and reload the table to display them.
+	///
+	override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
+		if errorMessage != message {
+			errorMessage = message
+			shouldChangeVoiceOverFocus = moveVoiceOverFocus
+			tableView.reloadData()
+		}
+    }
 
 // MARK: - UITableViewDataSource
 extension SiteCredentialsViewController: UITableViewDataSource {
@@ -191,7 +200,15 @@ private extension SiteCredentialsViewController {
 	/// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-		rows = [.instructions, .username, .password, .forgotPassword]
+		rows = [.instructions, .username, .password]
+
+		if errorMessage != nil {
+             rows.append(.errorMessage)
+         }
+
+        if WordPressAuthenticator.shared.configuration.displayHintButtons {
+            rows.append(.forgotPassword)
+        }
     }
 
 	/// Configure cells.
@@ -206,6 +223,8 @@ private extension SiteCredentialsViewController {
 			configurePasswordTextField(cell)
 		case let cell as TextLinkButtonTableViewCell:
 			configureForgotPassword(cell)
+		case let cell as TextLabelTableViewCell where row == .errorMessage:
+			configureErrorLabel(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -284,6 +303,12 @@ private extension SiteCredentialsViewController {
 		}
 	}
 
+    /// Configure the error message cell.
+    ///
+    func configureErrorLabel(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: errorMessage, style: .error)
+    }
+
 	/// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
 	///
 	func configureForAccessibility() {
@@ -310,6 +335,7 @@ private extension SiteCredentialsViewController {
 		case username
 		case password
 		case forgotPassword
+		case errorMessage
 
         var reuseIdentifier: String {
             switch self {
@@ -321,6 +347,8 @@ private extension SiteCredentialsViewController {
 				return TextFieldTableViewCell.reuseIdentifier
 			case .forgotPassword:
 				return TextLinkButtonTableViewCell.reuseIdentifier
+			case .errorMessage:
+				return TextLabelTableViewCell.reuseIdentifier
 			}
         }
     }
@@ -328,6 +356,8 @@ private extension SiteCredentialsViewController {
 
 
 // MARK: - Instance Methods
+/// Implementation methods copied from LoginSelfHostedViewController.
+///
 extension SiteCredentialsViewController {
 	/// Sanitize and format the site address we show to users.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -247,7 +247,7 @@ private extension SiteCredentialsViewController {
 	/// Configure the forgot password cell.
 	///
 	func configureForgotPassword(_ cell: TextLinkButtonTableViewCell) {
-		cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle)
+		cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle, accessibilityTrait: .link)
 		cell.actionHandler = { [weak self] in
 			guard let self = self else {
 				return
@@ -278,8 +278,6 @@ private extension SiteCredentialsViewController {
 			usernameField?.placeholder = nil
 			passwordField?.placeholder = nil
 		}
-
-		forgotPasswordButton.accessibilityTraits = .link
 	}
 
 	// MARK: - Private Constants

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -16,6 +16,7 @@ class SiteCredentialsViewController: LoginViewController {
 	/// Internal properties.
 	///
 	@IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+	@objc var onePasswordButton: UIButton!
     // Required property declaration for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -55,10 +55,20 @@ class SiteCredentialsViewController: LoginViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+		configureSubmitButton(animating: false)
+
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
         configureViewForEditingIfNeeded()
+
+		// Tracks go here. Old event: WordPressAuthenticator.track(.loginUsernamePasswordFormViewed)
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        unregisterForKeyboardEvents()
+    }
+
 
 	// MARK: - Overrides
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -20,6 +20,12 @@ class SiteCredentialsViewController: LoginViewController {
     // Required property declaration for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?
 
+	override var sourceTag: WordPressSupportSourceTag {
+        get {
+            return .loginUsernamePassword
+        }
+    }
+
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -38,6 +38,30 @@ class SiteCredentialsViewController: LoginViewController {
 
     }
 
+	/// Sets up a 1Password button if 1Password is available and user is on iOS 12.
+	///
+   @objc func setupOnePasswordButtonIfNeeded() {
+		if #available(iOS 13, *) {
+		   // no-op, we rely on the key icon in the keyboard to initiate a password manager.
+		} else {
+			// iOS 12 and lower, display the OnePassword button.
+			WPStyleGuide.configureOnePasswordButtonForTextfield(usernameField,
+																target: self,
+																selector: #selector(handleOnePasswordTapped(_:)))
+		}
+   }
+
+	@objc func handleOnePasswordTapped(_ sender: UIButton) {
+        view.endEditing(true)
+
+        WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sender, loginFields: loginFields) { [unowned self] (loginFields) in
+            self.usernameField?.text = loginFields.username
+            self.passwordField?.text = loginFields.password
+            self.validateForm()
+        }
+    }
+
+	// MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -47,6 +71,7 @@ class SiteCredentialsViewController: LoginViewController {
 		localizePrimaryButton()
 		registerTableViewCells()
 		loadRows()
+		setupOnePasswordButtonIfNeeded()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -72,6 +72,7 @@ class SiteCredentialsViewController: LoginViewController {
 		registerTableViewCells()
 		loadRows()
 		setupOnePasswordButtonIfNeeded()
+		configureForAccessibility()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -246,6 +247,25 @@ private extension SiteCredentialsViewController {
 									 and: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder)
 		passwordField = cell.textField
 		cell.textField.delegate = self
+	}
+
+	/// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
+	///
+	func configureForAccessibility() {
+		usernameField?.accessibilityLabel =
+			NSLocalizedString("Username", comment: "Accessibility label for the username text field in the self-hosted login page.")
+		passwordField?.accessibilityLabel =
+			NSLocalizedString("Password", comment: "Accessibility label for the password text field in the self-hosted login page.")
+
+		if UIAccessibility.isVoiceOverRunning {
+			// Remove the placeholder if VoiceOver is running. VoiceOver speaks the label and the
+			// placeholder together. In this case, both labels and placeholders are the same so it's
+			// like VoiceOver is reading the same thing twice.
+			usernameField?.placeholder = nil
+			passwordField?.placeholder = nil
+		}
+
+//		forgotPasswordButton.accessibilityTraits = .link
 	}
 
 	// MARK: - Private Constants

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -9,9 +9,11 @@ class SiteCredentialsViewController: LoginViewController {
 	/// Private properties.
     ///
     @IBOutlet private weak var tableView: UITableView!
-	private var rows = [Row]()
 	private weak var usernameField: UITextField?
 	private weak var passwordField: UITextField?
+	private var rows = [Row]()
+	private var errorMessage: String?
+	private var shouldChangeVoiceOverFocus: Bool = false
 
 	/// Internal properties.
 	///

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -235,6 +235,11 @@ private extension SiteCredentialsViewController {
 				self.validateForm()
 			}
 		}
+
+		cell.onChangeSelectionHandler = { [weak self] textfield in
+			self?.loginFields.username = textfield.nonNilTrimmedText()
+			self?.configureSubmitButton(animating: false)
+		}
 	}
 
 	/// Configure the password textfield cell.
@@ -244,6 +249,10 @@ private extension SiteCredentialsViewController {
 									 and: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder)
 		passwordField = cell.textField
 		cell.textField.delegate = self
+		cell.onChangeSelectionHandler = { [weak self] textfield in
+			self?.loginFields.password = textfield.nonNilTrimmedText()
+			self?.configureSubmitButton(animating: false)
+		}
 	}
 
 	/// Configure the forgot password cell.


### PR DESCRIPTION
Closes #322 

This PR adds the OnePassword functionality to the TextFieldTableViewCell for the site URL textfield. While testing on iOS 12 I discovered a bug where the SiteAddressViewController's Continue button would not enable after typing in a URL. I accidentally used a textfield delegate method that was available for iOS 13 only. So instead I created an IBAction in the TextFieldTableCell and attached it directly to the textfield. 

I also fixed a bug where the OnePassword icon was displaying in the wrong color on the old UI.

WPiOS Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14511

**Concerns**
@Gio2018 I'd like your opinion on this PR too, if you have a moment. I had to go back to using tuples to pass some of the actions from the textfield in TextFieldTableViewCell because a delegate method was not available in iOS 12. I'm not sure that splitting the textfield actions between the Cell and the ViewController is a good idea. I think it will be confusing to the next person who edits it, but I don't know what to do to make it clearer.

### To test
1. `bundle exec pod install` to ensure pods are up to date. If you get an error, try `bundle exec pod update WordPressKit`
2. Build and run (no errors)
3. Use the test PR https://github.com/wordpress-mobile/WordPress-iOS/pull/14511