### PR TITLE
ULS: Adjust table widths for iPad

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.21.0-beta.4"
+  s.version       = "1.21.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddress.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddress.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -11,7 +11,7 @@
         <!--Site Address View Controller-->
         <scene sceneID="7Rf-Qz-qsw">
             <objects>
-                <viewController storyboardIdentifier="SiteAddressViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="SiteAddressViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SiteAddressViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="SiteAddressViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -30,7 +30,7 @@
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xwA-rd-6jO" userLabel="Button background view">
                                         <rect key="frame" x="0.0" y="591" width="375" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
                                                 <rect key="frame" x="16" y="16" width="343" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
@@ -48,19 +48,16 @@
                                         <constraints>
                                             <constraint firstAttribute="bottomMargin" secondItem="ClH-Cn-49d" secondAttribute="bottom" constant="8" id="3Ba-yg-JKx"/>
                                             <constraint firstItem="ClH-Cn-49d" firstAttribute="top" secondItem="xwA-rd-6jO" secondAttribute="topMargin" constant="8" id="GgD-0x-Aud"/>
-                                            <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="VfW-kE-aWC" secondAttribute="leading" constant="16" id="Gkk-b0-7jz"/>
-                                            <constraint firstItem="VfW-kE-aWC" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" constant="16" id="hy1-OF-2TN"/>
                                         </constraints>
                                         <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
                                     </view>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="dFS-Ic-byk" secondAttribute="top" id="1r4-f4-2JD"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottomMargin" constant="8" id="85d-XY-Mr8"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="Bkw-QJ-Tbe"/>
-                                    <constraint firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="K3l-1m-yA1"/>
-                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="Tbb-lk-1Cg"/>
+                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" constant="16" id="Bpv-qx-bHc"/>
+                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" constant="16" id="Rnp-SF-SGh"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="gkZ-OV-HMi"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="wBE-xi-42q"/>
                                 </constraints>
@@ -68,7 +65,10 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
+                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
@@ -79,6 +79,8 @@
                         <outlet property="bottomContentConstraint" destination="Dva-c1-u2U" id="cA6-Wt-5oj"/>
                         <outlet property="submitButton" destination="ClH-Cn-49d" id="kBa-QN-0oH"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="ntt-cX-m20"/>
+                        <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
+                        <outlet property="tableViewTrailingConstraint" destination="7MD-ux-8i0" id="jbD-Z7-rAn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ipm-G3-kY7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -88,7 +90,7 @@
         <!--Site Credentials View Controller-->
         <scene sceneID="SNM-jM-Hwx">
             <objects>
-                <viewController storyboardIdentifier="SiteCredentialsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="y6V-vh-KSr" customClass="SiteCredentialsViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SiteCredentialsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="y6V-vh-KSr" customClass="SiteCredentialsViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rzp-ZY-4sV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -107,7 +109,7 @@
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YGp-eK-oRp" userLabel="Button background view">
                                         <rect key="frame" x="0.0" y="591" width="375" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bUY-a5-oHJ" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bUY-a5-oHJ" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
                                                 <rect key="frame" x="16" y="16" width="343" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="v9D-Cw-nFD"/>
@@ -125,8 +127,6 @@
                                         <constraints>
                                             <constraint firstItem="bUY-a5-oHJ" firstAttribute="top" secondItem="YGp-eK-oRp" secondAttribute="topMargin" constant="8" id="7ST-0h-lCv"/>
                                             <constraint firstAttribute="bottomMargin" secondItem="bUY-a5-oHJ" secondAttribute="bottom" constant="8" id="CIb-xr-SzK"/>
-                                            <constraint firstItem="Hd0-aR-a4s" firstAttribute="trailing" secondItem="bUY-a5-oHJ" secondAttribute="trailing" constant="16" id="sf0-Wf-wP3"/>
-                                            <constraint firstItem="bUY-a5-oHJ" firstAttribute="leading" secondItem="Hd0-aR-a4s" secondAttribute="leading" constant="16" id="toq-jo-Ce0"/>
                                         </constraints>
                                         <viewLayoutGuide key="safeArea" id="Hd0-aR-a4s"/>
                                     </view>
@@ -134,11 +134,10 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="bottom" secondItem="HOD-IX-jQc" secondAttribute="bottomMargin" constant="8" id="AHZ-rn-MEN"/>
+                                    <constraint firstItem="bUY-a5-oHJ" firstAttribute="leading" secondItem="msV-bz-Sqp" secondAttribute="leading" constant="16" id="EOR-16-rjC"/>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="trailing" secondItem="HOD-IX-jQc" secondAttribute="trailing" id="FKm-da-ANZ"/>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="top" secondItem="msV-bz-Sqp" secondAttribute="bottom" id="Wt7-Vo-sCx"/>
-                                    <constraint firstAttribute="trailing" secondItem="msV-bz-Sqp" secondAttribute="trailing" id="ZRF-eh-ojb"/>
-                                    <constraint firstItem="msV-bz-Sqp" firstAttribute="leading" secondItem="HOD-IX-jQc" secondAttribute="leading" id="dr1-sl-C06"/>
-                                    <constraint firstItem="msV-bz-Sqp" firstAttribute="top" secondItem="HOD-IX-jQc" secondAttribute="top" id="elE-tI-VfK"/>
+                                    <constraint firstItem="msV-bz-Sqp" firstAttribute="trailing" secondItem="bUY-a5-oHJ" secondAttribute="trailing" constant="16" id="Yeq-i8-mJg"/>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="leading" secondItem="HOD-IX-jQc" secondAttribute="leading" id="piw-Hs-lPT"/>
                                 </constraints>
                             </view>
@@ -147,7 +146,10 @@
                         <constraints>
                             <constraint firstItem="HOD-IX-jQc" firstAttribute="top" secondItem="5Dn-ej-Nhp" secondAttribute="top" id="Iud-8M-zpD"/>
                             <constraint firstItem="5Dn-ej-Nhp" firstAttribute="bottom" secondItem="HOD-IX-jQc" secondAttribute="bottom" id="Qxf-z0-9lF"/>
+                            <constraint firstItem="msV-bz-Sqp" firstAttribute="top" secondItem="5Dn-ej-Nhp" secondAttribute="top" id="Wxv-oA-2Kw"/>
+                            <constraint firstItem="msV-bz-Sqp" firstAttribute="leading" secondItem="5Dn-ej-Nhp" secondAttribute="leading" id="XJE-JH-rvO"/>
                             <constraint firstItem="HOD-IX-jQc" firstAttribute="trailing" secondItem="rzp-ZY-4sV" secondAttribute="trailing" id="bF4-se-bcv"/>
+                            <constraint firstItem="5Dn-ej-Nhp" firstAttribute="trailing" secondItem="msV-bz-Sqp" secondAttribute="trailing" id="odn-ry-dZH"/>
                             <constraint firstItem="HOD-IX-jQc" firstAttribute="leading" secondItem="rzp-ZY-4sV" secondAttribute="leading" id="txP-xH-B39"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="5Dn-ej-Nhp"/>
@@ -156,6 +158,8 @@
                         <outlet property="bottomContentConstraint" destination="Qxf-z0-9lF" id="QCJ-ks-Lz9"/>
                         <outlet property="submitButton" destination="bUY-a5-oHJ" id="AyH-o7-6z2"/>
                         <outlet property="tableView" destination="msV-bz-Sqp" id="UhW-BX-cA3"/>
+                        <outlet property="tableViewLeadingConstraint" destination="XJE-JH-rvO" id="KKt-z5-KD9"/>
+                        <outlet property="tableViewTrailingConstraint" destination="odn-ry-dZH" id="JKu-G5-4Jr"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pmu-qI-bIl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -33,6 +33,10 @@ final class SiteAddressViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 
+        // Store default margin, and size table for the view.
+        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
+        setTableViewMargins(forWidth: view.frame.width)
+
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -29,6 +29,10 @@ class SiteCredentialsViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 
+        // Store default margin, and size table for the view.
+        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
+        setTableViewMargins(forWidth: view.frame.width)
+
 		localizePrimaryButton()
 		registerTableViewCells()
 		loadRows()


### PR DESCRIPTION
Ref: #283 

This adds the ability to resize the table view width based on device size class. The Site Address and Site Credentials views have been updated to use this functionality.
- For the Regular x Regular size class:
  - In portrait, the table is 66% of the view width.
  - In landscape, the table is 50% of the view width.
- For all other size classes, the table is 100% of the view width.

In addition, the Continue button width resizes with the table.

To note, this uses the same logic as the WPiOS [Login Epilogue](https://github.com/wordpress-mobile/WordPress-iOS/pull/13860) and [Signup Epilogue](https://github.com/wordpress-mobile/WordPress-iOS/pull/14018).

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14512