### PR TITLE
ULS: 2FA initial view

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.21.0"
+  s.version       = "1.22.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		3FFF2FC323D7F53200D38C77 /* AppSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFF2FC223D7F53200D38C77 /* AppSelector.swift */; };
 		7A7A9B9CD2D81959F9AB9AF6 /* Pods_WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C736FF243DE333FCAB1C2614 /* Pods_WordPressAuthenticator.framework */; };
 		982C8E7923021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982C8E7823021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift */; };
+		988AD8A324CB839900BD045E /* TwoFAViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988AD8A224CB839900BD045E /* TwoFAViewController.swift */; };
+		988AD8A724CB8C0400BD045E /* TwoFA.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 988AD8A624CB8C0300BD045E /* TwoFA.storyboard */; };
 		98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */; };
 		98C9195B2308E3DA00A90E12 /* AppleAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */; };
 		98CF18F7248725370047B66C /* GoogleSignupConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CF18F6248725370047B66C /* GoogleSignupConfirmationViewController.swift */; };
@@ -179,6 +181,8 @@
 		5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressAuthenticatorTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F7217C3F7A6285D9C6CF786 /* Pods-WordPressAuthenticator.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-internal.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-internal.xcconfig"; sourceTree = "<group>"; };
 		982C8E7823021C20003F1BA0 /* LoginPrologueLoginMethodViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginPrologueLoginMethodViewController.swift; sourceTree = "<group>"; };
+		988AD8A224CB839900BD045E /* TwoFAViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoFAViewController.swift; sourceTree = "<group>"; };
+		988AD8A624CB8C0300BD045E /* TwoFA.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TwoFA.storyboard; sourceTree = "<group>"; };
 		98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPHelpIndicatorView.swift; sourceTree = "<group>"; };
 		98C9195A2308E3D900A90E12 /* AppleAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthenticator.swift; sourceTree = "<group>"; };
 		98CF18F6248725370047B66C /* GoogleSignupConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSignupConfirmationViewController.swift; sourceTree = "<group>"; };
@@ -393,6 +397,15 @@
 				CEC77C6424854EE400FB9050 /* View Related */,
 			);
 			path = "Unified Auth";
+			sourceTree = "<group>";
+		};
+		988AD89F24CB820200BD045E /* 2FA */ = {
+			isa = PBXGroup;
+			children = (
+				988AD8A224CB839900BD045E /* TwoFAViewController.swift */,
+				988AD8A624CB8C0300BD045E /* TwoFA.storyboard */,
+			);
+			path = 2FA;
 			sourceTree = "<group>";
 		};
 		98CF18F5248725130047B66C /* Google */ = {
@@ -688,6 +701,7 @@
 		CEC77C6424854EE400FB9050 /* View Related */ = {
 			isa = PBXGroup;
 			children = (
+				988AD89F24CB820200BD045E /* 2FA */,
 				98CF18F5248725130047B66C /* Google */,
 				CEC77C70248AB0C700FB9050 /* Reusable Views */,
 				CEFE241E24B666AA00B46DC5 /* Site Address */,
@@ -836,6 +850,7 @@
 				B560911E208A555E00399AE4 /* Signup.storyboard in Resources */,
 				CE9091F82499549500AB50BD /* TextFieldTableViewCell.xib in Resources */,
 				CEC77C6824854F3E00FB9050 /* SiteAddress.storyboard in Resources */,
+				988AD8A724CB8C0400BD045E /* TwoFA.storyboard in Resources */,
 				B5609118208A555600399AE4 /* SearchTableViewCell.xib in Resources */,
 				98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
@@ -1003,6 +1018,7 @@
 				B56090F7208A533200399AE4 /* WordPressAuthenticator+Errors.swift in Sources */,
 				B56090D2208A4F5400399AE4 /* NUXButton.swift in Sources */,
 				CE1B18C920EEC2C200BECC3F /* SocialService.swift in Sources */,
+				988AD8A324CB839900BD045E /* TwoFAViewController.swift in Sources */,
 				CE6BCD2E24A3A235001BCDC5 /* TextLabelTableViewCell.swift in Sources */,
 				B56090D3208A4F5400399AE4 /* NUXLinkAuthViewController.swift in Sources */,
 				B5609120208A555E00399AE4 /* SignupNavigationController.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -20,6 +20,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let gettingStartedTitle: String
     public let logInTitle: String
     public let signUpTitle: String
+    public let waitingForGoogleTitle: String
 
     /// Strings: secondary call-to-action button titles.
     ///
@@ -43,6 +44,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 gettingStartedTitle: String,
                 logInTitle: String,
                 signUpTitle: String,
+                waitingForGoogleTitle: String,
 				usernamePlaceholder: String,
 				passwordPlaceholder: String) {
         self.emailLoginInstructions = emailLoginInstructions
@@ -55,6 +57,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.gettingStartedTitle = gettingStartedTitle
         self.logInTitle = logInTitle
         self.signUpTitle = signUpTitle
+        self.waitingForGoogleTitle = waitingForGoogleTitle
 		self.usernamePlaceholder = usernamePlaceholder
 		self.passwordPlaceholder = passwordPlaceholder
     }
@@ -83,6 +86,8 @@ public extension WordPressAuthenticatorDisplayStrings {
                                           comment: "View title during the log in process."),
             signUpTitle: NSLocalizedString("Sign Up",
                                            comment: "View title during the sign up process."),
+            waitingForGoogleTitle: NSLocalizedString("Waiting...",
+                                                     comment: "View title during the Google auth process."),
 			usernamePlaceholder: NSLocalizedString("Username",
 												   comment: "Placeholder for the username textfield."),
 			passwordPlaceholder: NSLocalizedString("Password",

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -9,6 +9,7 @@ enum Storyboard: String {
     case siteAddress = "SiteAddress"
     case googleAuth = "GoogleAuth"
     case googleSignupConfirmation = "GoogleSignupConfirmation"
+    case twoFA = "TwoFA"
 
     var instance: UIStoryboard {
         return UIStoryboard(name: self.rawValue, bundle: WordPressAuthenticator.bundle)

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -38,6 +38,14 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
         submitButton?.isEnabled = enableSubmit(animating: animating)
     }
 
+    /// Localize the "Continue" button.
+    ///
+    func localizePrimaryButton() {
+        let primaryTitle = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
+        submitButton?.setTitle(primaryTitle, for: .normal)
+        submitButton?.setTitle(primaryTitle, for: .highlighted)
+    }
+    
     open func enableSubmit(animating: Bool) -> Bool {
         return !animating
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFA.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFA.storyboard
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--TwoFA View Controller-->
+        <scene sceneID="7Rf-Qz-qsw">
+            <objects>
+                <viewController storyboardIdentifier="TwoFAViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="TwoFAViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFS-Ic-byk" userLabel="Containing View">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <sections/>
+                                        <connections>
+                                            <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
+                                            <outlet property="delegate" destination="aQT-Gx-U3x" id="2xB-Wr-Hdh"/>
+                                        </connections>
+                                    </tableView>
+                                    <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xwA-rd-6jO" userLabel="Button background view">
+                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottomMargin" secondItem="ClH-Cn-49d" secondAttribute="bottom" constant="8" id="3Ba-yg-JKx"/>
+                                            <constraint firstItem="ClH-Cn-49d" firstAttribute="top" secondItem="xwA-rd-6jO" secondAttribute="topMargin" constant="8" id="GgD-0x-Aud"/>
+                                        </constraints>
+                                        <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="xwA-rd-6jO" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottomMargin" constant="8" id="85d-XY-Mr8"/>
+                                    <constraint firstItem="xwA-rd-6jO" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="Bkw-QJ-Tbe"/>
+                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" constant="16" id="Bpv-qx-bHc"/>
+                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" constant="16" id="Rnp-SF-SGh"/>
+                                    <constraint firstItem="xwA-rd-6jO" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="gkZ-OV-HMi"/>
+                                    <constraint firstItem="xwA-rd-6jO" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="wBE-xi-42q"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
+                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
+                            <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
+                    </view>
+                    <connections>
+                        <outlet property="submitButton" destination="ClH-Cn-49d" id="kBa-QN-0oH"/>
+                        <outlet property="tableView" destination="KLl-Uz-wEP" id="MGk-sG-xGv"/>
+                        <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
+                        <outlet property="tableViewTrailingConstraint" destination="7MD-ux-8i0" id="jbD-Z7-rAn"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ipm-G3-kY7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-162.40000000000001" y="20.239880059970016"/>
+        </scene>
+    </scenes>
+</document>

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -1,0 +1,60 @@
+import UIKit
+
+final class TwoFAViewController: LoginViewController {
+
+    // MARK: - Properties
+    @IBOutlet private weak var tableView: UITableView!
+    
+    // support tag
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
+        styleNavigationBar(forUnified: true)
+        
+        // Store default margin, and size table for the view.
+        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
+        setTableViewMargins(forWidth: view.frame.width)
+        
+        localizePrimaryButton()
+    }
+    
+    // MARK: - Overrides
+
+    /// Style individual ViewController backgrounds, for now.
+    ///
+    override func styleBackground() {
+        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
+            super.styleBackground()
+            return
+        }
+
+        view.backgroundColor = unifiedBackgroundColor
+    }
+    
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ??
+               WordPressAuthenticator.shared.style.statusBarStyle
+    }
+
+}
+
+// MARK: - UITableViewDataSource
+
+extension TwoFAViewController: UITableViewDataSource {
+    /// Returns the number of rows in a section.
+    ///
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // TODO: update when real cells are added.
+        return 1
+    }
+
+    /// Configure cells delegate method.
+    ///
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // TODO: update when real cells are added.
+        return UITableViewCell()
+    }
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -4,10 +4,9 @@ final class TwoFAViewController: LoginViewController {
 
     // MARK: - Properties
     @IBOutlet private weak var tableView: UITableView!
-    
-    // support tag
-    
-    
+
+    // TODO: add support tag
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -23,8 +22,6 @@ final class TwoFAViewController: LoginViewController {
     
     // MARK: - Overrides
 
-    /// Style individual ViewController backgrounds, for now.
-    ///
     override func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
             super.styleBackground()
@@ -44,6 +41,7 @@ final class TwoFAViewController: LoginViewController {
 // MARK: - UITableViewDataSource
 
 extension TwoFAViewController: UITableViewDataSource {
+
     /// Returns the number of rows in a section.
     ///
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -57,4 +55,5 @@ extension TwoFAViewController: UITableViewDataSource {
         // TODO: update when real cells are added.
         return UITableViewCell()
     }
+
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -12,8 +12,7 @@ final class TwoFAViewController: LoginViewController {
 
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
-        
-        // Store default margin, and size table for the view.
+
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
         

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
@@ -82,14 +82,10 @@ extension GoogleAuthViewController: GoogleAuthenticatorDelegate {
     func googleNeedsMultifactorCode(loginFields: LoginFields) {
         self.loginFields = loginFields
 
-        guard let vc = Login2FAViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from GoogleAuthViewController to Login2FAViewController")
+        guard let vc = TwoFAViewController.instantiate(from: .twoFA) else {
+            DDLogError("Failed to navigate from GoogleAuthViewController to TwoFAViewController")
             return
         }
-
-        vc.loginFields = loginFields
-        vc.dismissBlock = dismissBlock
-        vc.errorToPresent = errorToPresent
 
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
@@ -17,12 +17,33 @@ class GoogleAuthViewController: LoginViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        navigationItem.title = WordPressAuthenticator.shared.displayStrings.waitingForGoogleTitle
+        styleNavigationBar(forUnified: true)
+
         titleLabel?.text = NSLocalizedString("Waiting for Google to complete…", comment: "Message shown on screen while waiting for Google to finish its signup process.")
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         showGoogleScreenIfNeeded()
+    }
+
+    // MARK: - Overrides
+
+    /// Style individual ViewController backgrounds, for now.
+    ///
+    override func styleBackground() {
+        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
+            super.styleBackground()
+            return
+        }
+
+        view.backgroundColor = unifiedBackgroundColor
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
 
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -180,13 +180,6 @@ extension SiteAddressViewController: UITextFieldDelegate {
 
 // MARK: - Private methods
 private extension SiteAddressViewController {
-    /// Localize the "Continue" button.
-    ///
-    func localizePrimaryButton() {
-        let primaryTitle = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
-        submitButton?.setTitle(primaryTitle, for: .normal)
-        submitButton?.setTitle(primaryTitle, for: .highlighted)
-    }
 
     /// Registers all of the available TableViewCells.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -214,14 +214,6 @@ extension SiteCredentialsViewController: UITextFieldDelegate {
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
 
-	/// Localize the "Continue" button.
-    ///
-    func localizePrimaryButton() {
-        let primaryTitle = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
-        submitButton?.setTitle(primaryTitle, for: .normal)
-        submitButton?.setTitle(primaryTitle, for: .highlighted)
-    }
-
 	/// Registers all of the available TableViewCells.
     ///
     func registerTableViewCells() {


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/336
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14530

This adds an initial unified 2FA view. It simply contains an empty table, the `Continue` button, and is styled for the unified flows.

<kbd>![2fa_view](https://user-images.githubusercontent.com/1816888/88595108-a0e2c080-d01f-11ea-8380-262f727c3a99.png)</kbd>

For now, it is only displayed from the unified Google flow, for accounts:
- That _do not_ have a WP password set.
- _Does_ have WP 2FA enabled.

Also, the unified Google view has been updated to match the unified style.
- The nav bar, status bar, and background color are the unified colors.
- The nav title is `Waiting...`.

<kbd>![waiting_for_google](https://user-images.githubusercontent.com/1816888/88594376-4f860180-d01e-11ea-9ced-e96d9dd75e2d.png)</kbd>
