### PR TITLE
ULS: Add content to 2FA view

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.1"
+  s.version       = "1.22.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -10,6 +10,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let jetpackLoginInstructions: String
     public let siteLoginInstructions: String
 	public let siteCredentialInstructions: String
+    public let twoFactorInstructions: String
 
     /// Strings: primary call-to-action button titles.
     ///
@@ -26,12 +27,14 @@ public struct WordPressAuthenticatorDisplayStrings {
     ///
     public let findSiteButtonTitle: String
     public let resetPasswordButtonTitle: String
+    public let textCodeButtonTitle: String
 
 	/// Placeholder text for textfields.
 	///
 	public let usernamePlaceholder: String
 	public let passwordPlaceholder: String
     public let siteAddressPlaceholder: String
+    public let twoFactorCodePlaceholder: String
 
     /// Designated initializer.
     ///
@@ -39,23 +42,28 @@ public struct WordPressAuthenticatorDisplayStrings {
                 jetpackLoginInstructions: String,
                 siteLoginInstructions: String,
 				siteCredentialInstructions: String,
+                twoFactorInstructions: String,
                 continueButtonTitle: String,
                 findSiteButtonTitle: String,
                 resetPasswordButtonTitle: String,
+                textCodeButtonTitle: String,
                 gettingStartedTitle: String,
                 logInTitle: String,
                 signUpTitle: String,
                 waitingForGoogleTitle: String,
 				usernamePlaceholder: String,
-				passwordPlaceholder: String) {
+				passwordPlaceholder: String,
                 siteAddressPlaceholder: String,
+                twoFactorCodePlaceholder: String) {
         self.emailLoginInstructions = emailLoginInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
 		self.siteCredentialInstructions = siteCredentialInstructions
+        self.twoFactorInstructions = twoFactorInstructions
         self.continueButtonTitle = continueButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
+        self.textCodeButtonTitle = textCodeButtonTitle
         self.gettingStartedTitle = gettingStartedTitle
         self.logInTitle = logInTitle
         self.signUpTitle = signUpTitle
@@ -63,6 +71,7 @@ public struct WordPressAuthenticatorDisplayStrings {
 		self.usernamePlaceholder = usernamePlaceholder
 		self.passwordPlaceholder = passwordPlaceholder
         self.siteAddressPlaceholder = siteAddressPlaceholder
+        self.twoFactorCodePlaceholder = twoFactorCodePlaceholder
     }
 }
 
@@ -77,12 +86,17 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                      comment: "Instruction text on the login's site addresss screen."),
 			siteCredentialInstructions: NSLocalizedString("Enter your account information for %@.",
 														  comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
+            twoFactorInstructions: NSLocalizedString("Please enter the verification code from your authenticator app, or tap the link below to receive a code via SMS.",
+                                                     comment: "Instruction text on the two-factor screen."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                     comment: "The button title text when there is a next step for logging in or signing up."),
             findSiteButtonTitle: NSLocalizedString("Find your site address",
                                                    comment: "The hint button's title text to help users find their site address."),
             resetPasswordButtonTitle: NSLocalizedString("Reset your password",
                                                         comment: "The secondary call-to-action button title text, for when the user can't remember their password."),
+            textCodeButtonTitle: NSLocalizedString("Text me a code instead",
+                                                   comment: "The button's title text to send a 2FA code via SMS text message."),
+            
             gettingStartedTitle: NSLocalizedString("Getting Started",
                                                    comment: "View title for initial auth views."),
             logInTitle: NSLocalizedString("Log In",
@@ -94,8 +108,11 @@ public extension WordPressAuthenticatorDisplayStrings {
 			usernamePlaceholder: NSLocalizedString("Username",
 												   comment: "Placeholder for the username textfield."),
 			passwordPlaceholder: NSLocalizedString("Password",
-												   comment: "Placeholder for the password textfield.")
+												   comment: "Placeholder for the password textfield."),
             siteAddressPlaceholder: NSLocalizedString("example.com",
+                                                  comment: "Placeholder for the site url textfield."),
+            twoFactorCodePlaceholder: NSLocalizedString("Authentication code",
+                                                  comment: "Placeholder for the 2FA code textfield.")
         )
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -31,6 +31,7 @@ public struct WordPressAuthenticatorDisplayStrings {
 	///
 	public let usernamePlaceholder: String
 	public let passwordPlaceholder: String
+    public let siteAddressPlaceholder: String
 
     /// Designated initializer.
     ///
@@ -47,6 +48,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 waitingForGoogleTitle: String,
 				usernamePlaceholder: String,
 				passwordPlaceholder: String) {
+                siteAddressPlaceholder: String,
         self.emailLoginInstructions = emailLoginInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
@@ -60,6 +62,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.waitingForGoogleTitle = waitingForGoogleTitle
 		self.usernamePlaceholder = usernamePlaceholder
 		self.passwordPlaceholder = passwordPlaceholder
+        self.siteAddressPlaceholder = siteAddressPlaceholder
     }
 }
 
@@ -92,6 +95,7 @@ public extension WordPressAuthenticatorDisplayStrings {
 												   comment: "Placeholder for the username textfield."),
 			passwordPlaceholder: NSLocalizedString("Password",
 												   comment: "Placeholder for the password textfield.")
+            siteAddressPlaceholder: NSLocalizedString("example.com",
         )
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -1,9 +1,20 @@
 import UIKit
 
+/// TwoFAViewController: view to enter 2FA code.
+///
 final class TwoFAViewController: LoginViewController {
 
     // MARK: - Properties
+    
     @IBOutlet private weak var tableView: UITableView!
+    private weak var codeField: UITextField?
+    
+    private var rows = [Row]()
+    private var errorMessage: String?
+
+    // Required for `NUXKeyboardResponder` but unused here.
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+    var verticalCenterConstraint: NSLayoutConstraint?
 
     // TODO: add support tag
 
@@ -17,8 +28,23 @@ final class TwoFAViewController: LoginViewController {
         setTableViewMargins(forWidth: view.frame.width)
         
         localizePrimaryButton()
+        registerTableViewCells()
+        loadRows()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
+                                  keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
+        configureViewForEditingIfNeeded()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        unregisterForKeyboardEvents()
+    }
+
     // MARK: - Overrides
 
     override func styleBackground() {
@@ -41,18 +67,141 @@ final class TwoFAViewController: LoginViewController {
 
 extension TwoFAViewController: UITableViewDataSource {
 
-    /// Returns the number of rows in a section.
-    ///
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // TODO: update when real cells are added.
-        return 1
+        return rows.count
     }
 
-    /// Configure cells delegate method.
-    ///
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: update when real cells are added.
-        return UITableViewCell()
+        let row = rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+        return cell
     }
 
+}
+
+// MARK: - Keyboard Notifications
+
+extension TwoFAViewController: NUXKeyboardResponder {
+    
+    @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
+        keyboardWillShow(notification)
+    }
+
+    @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
+        keyboardWillHide(notification)
+    }
+
+}
+
+private extension TwoFAViewController {
+
+    /// Registers all of the available TableViewCells.
+    ///
+    func registerTableViewCells() {
+        let cells = [
+            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
+            TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib(),
+            TextLinkButtonTableViewCell.reuseIdentifier: TextLinkButtonTableViewCell.loadNib()
+        ]
+        
+        for (reuseIdentifier, nib) in cells {
+            tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
+        }
+    }
+
+    /// Describes how the tableView rows should be rendered.
+    ///
+    func loadRows() {
+        rows = [.instructions, .code]
+
+        if errorMessage != nil {
+             rows.append(.errorMessage)
+         }
+
+        rows.append(.sendCode)
+    }
+
+    /// Configure cells.
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TextLabelTableViewCell where row == .instructions:
+            configureInstructionLabel(cell)
+        case let cell as TextFieldTableViewCell:
+            configureTextField(cell)
+        case let cell as TextLinkButtonTableViewCell:
+            configureTextLinkButton(cell)
+        case let cell as TextLabelTableViewCell where row == .errorMessage:
+            configureErrorLabel(cell)
+        default:
+            DDLogError("Error: Unidentified tableViewCell type found.")
+        }
+    }
+    
+    /// Configure the instruction cell.
+    ///
+    func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.twoFactorInstructions, style: .body)
+    }
+
+    /// Configure the textfield cell.
+    ///
+    func configureTextField(_ cell: TextFieldTableViewCell) {
+        cell.configureTextFieldStyle(with: .numericCode,
+                                     and: WordPressAuthenticator.shared.displayStrings.twoFactorCodePlaceholder)
+
+        // Save a reference to the first textField so it can becomeFirstResponder.
+        codeField = cell.textField
+        
+        // TODO: add cell.onChangeSelectionHandler here.
+
+        SigninEditingState.signinEditingStateActive = true
+    }
+
+    /// Configure the link cell.
+    ///
+    func configureTextLinkButton(_ cell: TextLinkButtonTableViewCell) {
+        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.textCodeButtonTitle)
+        
+        // TODO: add cell.actionHandler here.
+    }
+
+    /// Configure the error message cell.
+    ///
+    func configureErrorLabel(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: errorMessage, style: .error)
+    }
+
+    /// Configure the view for an editing state.
+    ///
+    func configureViewForEditingIfNeeded() {
+       // Check the helper to determine whether an editing state should be assumed.
+       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+       if SigninEditingState.signinEditingStateActive {
+           codeField?.becomeFirstResponder()
+       }
+    }
+
+    /// Rows listed in the order they were created.
+    ///
+    enum Row {
+        case instructions
+        case code
+        case sendCode
+        case errorMessage
+
+        var reuseIdentifier: String {
+            switch self {
+            case .instructions:
+                return TextLabelTableViewCell.reuseIdentifier
+            case .code:
+                return TextFieldTableViewCell.reuseIdentifier
+            case .sendCode:
+                return TextLinkButtonTableViewCell.reuseIdentifier
+            case .errorMessage:
+                return TextLabelTableViewCell.reuseIdentifier
+            }
+        }
+    }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -100,6 +100,9 @@ private extension TextFieldTableViewCell {
 			setSecureTextEntry(true)
 			showSecureTextEntryToggle = true
 			configureSecureTextEntryToggle()
+        case .numericCode:
+            textField.keyboardType = .numberPad
+            textField.returnKeyType = .continue
         }
     }
 
@@ -202,6 +205,7 @@ extension TextFieldTableViewCell {
         case url
         case username
         case password
+        case numericCode
     }
 
 	struct Constants {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -235,8 +235,9 @@ private extension SiteAddressViewController {
     /// Configure the textfield cell.
     ///
     func configureTextField(_ cell: TextFieldTableViewCell) {
-        let placeholderText = NSLocalizedString("example.com", comment: "Site Address placeholder")
-        cell.configureTextFieldStyle(with: .url, and: placeholderText)
+        cell.configureTextFieldStyle(with: .url,
+                                     and: WordPressAuthenticator.shared.displayStrings.siteAddressPlaceholder)
+
         // Save a reference to the first textField so it can becomeFirstResponder.
         siteURLField = cell.textField
 		cell.textField.delegate = self

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -10,9 +10,9 @@ final class SiteAddressViewController: LoginViewController {
     /// Private properties.
     ///
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
 
-    // Required property declaration for `NUXKeyboardResponder` but unused here.
+    // Required for `NUXKeyboardResponder` but unused here.
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     var verticalCenterConstraint: NSLayoutConstraint?
 
     private var rows = [Row]()
@@ -95,17 +95,6 @@ final class SiteAddressViewController: LoginViewController {
 
        configureSubmitButton(animating: loading)
        navigationItem.hidesBackButton = loading
-    }
-
-    /// Configure the view for an editing state. Should only be called from viewWillAppear
-    /// as this method skips animating any change in height.
-    ///
-    @objc func configureViewForEditingIfNeeded() {
-       // Check the helper to determine whether an editing state should be assumed.
-       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
-       if SigninEditingState.signinEditingStateActive {
-           siteURLField?.becomeFirstResponder()
-       }
     }
 
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
@@ -272,6 +261,15 @@ private extension SiteAddressViewController {
         cell.configureLabel(text: errorMessage, style: .error)
     }
 
+    /// Configure the view for an editing state.
+    ///
+    func configureViewForEditingIfNeeded() {
+       // Check the helper to determine whether an editing state should be assumed.
+       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+       if SigninEditingState.signinEditingStateActive {
+           siteURLField?.becomeFirstResponder()
+       }
+    }
 
     // MARK: - Private Constants
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 /// Part two of the self-hosted sign in flow: username + password. Used by WPiOS and NiOS.
 /// A valid site address should be acquired before presenting this view controller.
 ///
-class SiteCredentialsViewController: LoginViewController {
+final class SiteCredentialsViewController: LoginViewController {
 
 	/// Private properties.
     ///
@@ -15,10 +15,8 @@ class SiteCredentialsViewController: LoginViewController {
 	private var errorMessage: String?
 	private var shouldChangeVoiceOverFocus: Bool = false
 
-	/// Internal properties.
-	///
-	@IBOutlet var bottomContentConstraint: NSLayoutConstraint?
-    // Required property declaration for `NUXKeyboardResponder` but unused here.
+    // Required for `NUXKeyboardResponder` but unused here.
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     var verticalCenterConstraint: NSLayoutConstraint?
 
 	override var sourceTag: WordPressSupportSourceTag {
@@ -91,18 +89,6 @@ class SiteCredentialsViewController: LoginViewController {
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
-    }
-
-
-	/// Configure the view for an editing state. Should only be called from viewWillAppear
-    /// as this method skips animating any change in height.
-    ///
-    @objc func configureViewForEditingIfNeeded() {
-       // Check the helper to determine whether an editing state should be assumed.
-       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
-       if SigninEditingState.signinEditingStateActive {
-           usernameField?.becomeFirstResponder()
-       }
     }
 
 	/// Configures the appearance and state of the submit button.
@@ -357,6 +343,16 @@ private extension SiteCredentialsViewController {
 		}
 	}
 
+    /// Configure the view for an editing state.
+    ///
+    func configureViewForEditingIfNeeded() {
+       // Check the helper to determine whether an editing state should be assumed.
+       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+       if SigninEditingState.signinEditingStateActive {
+           usernameField?.becomeFirstResponder()
+       }
+    }
+    
 	// MARK: - Private Constants
 
     /// Rows listed in the order they were created.


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/336 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14534

This adds content to the new 2FA view:
- Instructions
- Code field
  - When the view first appears, the code field becomes first responder.
  - The keyboard type is numeric.
- Text code link

To note, the text link and Continue button are not yet functional.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-28 at 14 46 33](https://user-images.githubusercontent.com/1816888/88719991-65a8c600-d0e1-11ea-897d-d34db5e474dc.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-28 at 14 48 45](https://user-images.githubusercontent.com/1816888/88720082-883adf00-d0e1-11ea-9248-c41d9cb1696a.png) |
|--------|-------|