### PR TITLE
Address whitespace issues

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.1"
+  s.version       = "1.22.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -9,40 +9,40 @@ final class TextFieldTableViewCell: UITableViewCell {
     ///
     @IBOutlet private weak var borderView: UIView!
     @IBOutlet private weak var borderWidth: NSLayoutConstraint!
-	private var secureTextEntryToggle: UIButton?
-	private var secureTextEntryImageVisible: UIImage?
-	private var secureTextEntryImageHidden: UIImage?
-	private var textfieldStyle: TextFieldStyle = .url
+    private var secureTextEntryToggle: UIButton?
+    private var secureTextEntryImageVisible: UIImage?
+    private var secureTextEntryImageHidden: UIImage?
+    private var textfieldStyle: TextFieldStyle = .url
 
     private var hairlineBorderWidth: CGFloat {
         return 1.0 / UIScreen.main.scale
     }
 
-	/// Register an action for the SiteAddress URL textfield.
-	/// - Note: we have to manually add an action to the textfield
-	///	        because the delegate method `textFieldDidChangeSelection(_ textField: UITextField)`
-	///         is only available to iOS 13+. When we no longer support iOS 12,
-	///			`registerTextFieldAction`, `textFieldDidChangeSelection`, and `onChangeSelectionHandler` can
-	///			be deleted in favor of adding the delegate method to SiteAddressViewController.
-	@IBAction func registerTextFieldAction() {
-		onChangeSelectionHandler?(textField)
-	}
+    /// Register an action for the SiteAddress URL textfield.
+    /// - Note: we have to manually add an action to the textfield
+    ///	        because the delegate method `textFieldDidChangeSelection(_ textField: UITextField)`
+    ///         is only available to iOS 13+. When we no longer support iOS 12,
+    ///			`registerTextFieldAction`, `textFieldDidChangeSelection`, and `onChangeSelectionHandler` can
+    ///			be deleted in favor of adding the delegate method to SiteAddressViewController.
+    @IBAction func registerTextFieldAction() {
+        onChangeSelectionHandler?(textField)
+    }
 
-	/// Internal properties.
-	///
-	@objc var onePasswordButton: UIButton!
+    /// Internal properties.
+    ///
+    @objc var onePasswordButton: UIButton!
 
     /// Public properties.
     ///
     @IBOutlet public weak var textField: UITextField! // public so it can be the first responder
-	@IBInspectable public var showSecureTextEntryToggle: Bool = false {
-		didSet {
-			configureSecureTextEntryToggle()
-		}
-	}
+    @IBInspectable public var showSecureTextEntryToggle: Bool = false {
+        didSet {
+            configureSecureTextEntryToggle()
+        }
+    }
 
-	public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
-	public var onePasswordHandler: (() -> Void)?
+    public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
+    public var onePasswordHandler: (() -> Void)?
     public static let reuseIdentifier = "TextFieldTableViewCell"
 
     override func awakeFromNib() {
@@ -51,12 +51,12 @@ final class TextFieldTableViewCell: UITableViewCell {
         setCommonTextFieldStyles()
     }
 
-	/// Configures the textfield for URL, username, or entering a password.
-	/// - Parameter style: changes the textfield behavior and appearance.
-	/// - Parameter placeholder: the placeholder text, if any
-	///
+    /// Configures the textfield for URL, username, or entering a password.
+    /// - Parameter style: changes the textfield behavior and appearance.
+    /// - Parameter placeholder: the placeholder text, if any
+    ///
     public func configureTextFieldStyle(with style: TextFieldStyle = .url, and placeholder: String?) {
-		textfieldStyle = style
+        textfieldStyle = style
         applyTextFieldStyle(style)
         textField.placeholder = placeholder
     }
@@ -85,48 +85,48 @@ private extension TextFieldTableViewCell {
     /// - note: Don't assign first responder here. It's too early in the view lifecycle.
     ///
     func applyTextFieldStyle(_ style: TextFieldStyle) {
-		switch style {
+        switch style {
         case .url:
             textField.keyboardType = .URL
-			textField.returnKeyType = .continue
-			registerTextFieldAction()
-		case .username:
-			textField.keyboardType = .default
-			textField.returnKeyType = .next
-			setupOnePasswordButtonIfNeeded()
-		case .password:
-			textField.keyboardType = .default
-			textField.returnKeyType = .continue
-			setSecureTextEntry(true)
-			showSecureTextEntryToggle = true
-			configureSecureTextEntryToggle()
+            textField.returnKeyType = .continue
+            registerTextFieldAction()
+        case .username:
+            textField.keyboardType = .default
+            textField.returnKeyType = .next
+            setupOnePasswordButtonIfNeeded()
+        case .password:
+            textField.keyboardType = .default
+            textField.returnKeyType = .continue
+            setSecureTextEntry(true)
+            showSecureTextEntryToggle = true
+            configureSecureTextEntryToggle()
         }
     }
 
-	/// Call the handler when the textfield changes.
-	///
-	@objc func textFieldDidChangeSelection() {
-		onChangeSelectionHandler?(textField)
-	}
+    /// Call the handler when the textfield changes.
+    ///
+    @objc func textFieldDidChangeSelection() {
+        onChangeSelectionHandler?(textField)
+    }
 
-	/// Sets up a 1Password button if 1Password is available and user is on iOS 12.
-	///
-	@objc func setupOnePasswordButtonIfNeeded() {
-		if #available(iOS 13, *) {
-			// no-op, we rely on the key icon in the keyboard to initiate a password manager.
-		} else {
-			let tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
-			// iOS 12 and lower, display the OnePassword button.
-			WPStyleGuide.configureOnePasswordButtonForTextfield(textField,
-																tintColor: tintColor,
-																target: self,
-																selector: #selector(onePasswordTapped(_:)))
-		}
-	}
+    /// Sets up a 1Password button if 1Password is available and user is on iOS 12.
+    ///
+    @objc func setupOnePasswordButtonIfNeeded() {
+        if #available(iOS 13, *) {
+            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
+        } else {
+            let tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
+            // iOS 12 and lower, display the OnePassword button.
+            WPStyleGuide.configureOnePasswordButtonForTextfield(textField,
+                                                                tintColor: tintColor,
+                                                                target: self,
+                                                                selector: #selector(onePasswordTapped(_:)))
+        }
+    }
 
-	@objc func onePasswordTapped(_ sender: UIButton) {
-		onePasswordHandler?()
-	}
+    @objc func onePasswordTapped(_ sender: UIButton) {
+        onePasswordHandler?()
+    }
 }
 
 
@@ -135,61 +135,61 @@ private extension TextFieldTableViewCell {
 ///
 private extension TextFieldTableViewCell {
 
-	/// Build the show / hide icon in the textfield.
-	///
-	func configureSecureTextEntryToggle() {
-		guard showSecureTextEntryToggle else {
-			return
-		}
+    /// Build the show / hide icon in the textfield.
+    ///
+    func configureSecureTextEntryToggle() {
+        guard showSecureTextEntryToggle else {
+            return
+        }
 
-		secureTextEntryImageVisible = UIImage.gridicon(.visible)
-		secureTextEntryImageHidden = UIImage.gridicon(.notVisible)
+        secureTextEntryImageVisible = UIImage.gridicon(.visible)
+        secureTextEntryImageHidden = UIImage.gridicon(.notVisible)
 
-		secureTextEntryToggle = UIButton(type: .custom)
-		secureTextEntryToggle?.clipsToBounds = true
-		// The icon should match the border color.
-		let tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
-		secureTextEntryToggle?.tintColor = tintColor
+        secureTextEntryToggle = UIButton(type: .custom)
+        secureTextEntryToggle?.clipsToBounds = true
+        // The icon should match the border color.
+        let tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
+        secureTextEntryToggle?.tintColor = tintColor
 
-		secureTextEntryToggle?.addTarget(self,
-										 action: #selector(secureTextEntryToggleAction),
-										 for: .touchUpInside)
+        secureTextEntryToggle?.addTarget(self,
+                                         action: #selector(secureTextEntryToggleAction),
+                                         for: .touchUpInside)
 
-		updateSecureTextEntryToggleImage()
-		updateSecureTextEntryForAccessibility()
-		textField.rightView = secureTextEntryToggle
-		textField.rightViewMode = .always
-	}
+        updateSecureTextEntryToggleImage()
+        updateSecureTextEntryForAccessibility()
+        textField.rightView = secureTextEntryToggle
+        textField.rightViewMode = .always
+    }
 
-	func setSecureTextEntry(_ secureTextEntry: Bool) {
-		textField.font = UIFont.preferredFont(forTextStyle: .body)
+    func setSecureTextEntry(_ secureTextEntry: Bool) {
+        textField.font = UIFont.preferredFont(forTextStyle: .body)
 
-		textField.isSecureTextEntry = secureTextEntry
-		updateSecureTextEntryToggleImage()
-		updateSecureTextEntryForAccessibility()
-	}
+        textField.isSecureTextEntry = secureTextEntry
+        updateSecureTextEntryToggleImage()
+        updateSecureTextEntryForAccessibility()
+    }
 
-	@objc func secureTextEntryToggleAction(_ sender: Any) {
-		textField.isSecureTextEntry = !textField.isSecureTextEntry
+    @objc func secureTextEntryToggleAction(_ sender: Any) {
+        textField.isSecureTextEntry = !textField.isSecureTextEntry
 
-		// Save and re-apply the current selection range to save the cursor position
-		let currentTextRange = textField.selectedTextRange
-		textField.becomeFirstResponder()
-		textField.selectedTextRange = currentTextRange
-		updateSecureTextEntryToggleImage()
-		updateSecureTextEntryForAccessibility()
-	}
+        // Save and re-apply the current selection range to save the cursor position
+        let currentTextRange = textField.selectedTextRange
+        textField.becomeFirstResponder()
+        textField.selectedTextRange = currentTextRange
+        updateSecureTextEntryToggleImage()
+        updateSecureTextEntryForAccessibility()
+    }
 
-	func updateSecureTextEntryToggleImage() {
-		let image = textField.isSecureTextEntry ? secureTextEntryImageHidden : secureTextEntryImageVisible
-		secureTextEntryToggle?.setImage(image, for: .normal)
-		secureTextEntryToggle?.sizeToFit()
-	}
+    func updateSecureTextEntryToggleImage() {
+        let image = textField.isSecureTextEntry ? secureTextEntryImageHidden : secureTextEntryImageVisible
+        secureTextEntryToggle?.setImage(image, for: .normal)
+        secureTextEntryToggle?.sizeToFit()
+    }
 
-	func updateSecureTextEntryForAccessibility() {
-		secureTextEntryToggle?.accessibilityLabel = Constants.showPassword
-		secureTextEntryToggle?.accessibilityValue = textField.isSecureTextEntry ? Constants.passwordHidden : Constants.passwordShown
-	}
+    func updateSecureTextEntryForAccessibility() {
+        secureTextEntryToggle?.accessibilityLabel = Constants.showPassword
+        secureTextEntryToggle?.accessibilityValue = textField.isSecureTextEntry ? Constants.passwordHidden : Constants.passwordShown
+    }
 }
 
 
@@ -204,15 +204,15 @@ extension TextFieldTableViewCell {
         case password
     }
 
-	struct Constants {
-		/// Accessibility Hints
-		///
-		static let passwordHidden = NSLocalizedString("Hidden",
-													  comment: "Accessibility value if login page's password field is hiding the password (i.e. with asterisks).")
-		static let passwordShown = NSLocalizedString("Shown",
-													 comment: "Accessibility value if login page's password field is displaying the password.")
-		static let showPassword = NSLocalizedString("Show password",
-													comment:"Accessibility label for the 'Show password' button in the login page's password field.")
+    struct Constants {
+        /// Accessibility Hints
+        ///
+        static let passwordHidden = NSLocalizedString("Hidden",
+                                                      comment: "Accessibility value if login page's password field is hiding the password (i.e. with asterisks).")
+        static let passwordShown = NSLocalizedString("Shown",
+                                                     comment: "Accessibility value if login page's password field is displaying the password.")
+        static let showPassword = NSLocalizedString("Show password",
+                                                    comment:"Accessibility label for the 'Show password' button in the login page's password field.")
 
-	}
+    }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -4,39 +4,39 @@ import UIKit
 /// TextLinkButtonTableViewCell: a plain button made to look like a text link.
 ///
 class TextLinkButtonTableViewCell: UITableViewCell {
-
+    
     /// Private properties
     ///
     @IBOutlet private weak var button: UIButton!
     @IBAction private func textLinkButtonTapped(_ sender: UIButton) {
         actionHandler?()
     }
-
+    
     /// Public properties
     ///
     public static let reuseIdentifier = "TextLinkButtonTableViewCell"
-
+    
     public var actionHandler: (() -> Void)?
-
-	override func awakeFromNib() {
-		super.awakeFromNib()
-
-		button.titleLabel?.adjustsFontForContentSizeCategory = true
-	}
-
-	public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits? = .button) {
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+    }
+    
+    public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits? = .button) {
         button.setTitle(text, for: .normal)
-
+        
         let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
         let buttonHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
-		button.accessibilityTraits = accessibilityTraits
+        button.accessibilityTraits = accessibilityTraits
     }
-
-	/// Toggle button enabled / disabled
-	///
-	public func toggleButton(_ isEnabled: Bool) {
-		button.isEnabled = isEnabled
-	}
+    
+    /// Toggle button enabled / disabled
+    ///
+    public func toggleButton(_ isEnabled: Bool) {
+        button.isEnabled = isEnabled
+    }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -46,7 +46,7 @@ final class SiteAddressViewController: LoginViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-		siteURLField?.text = loginFields.siteAddress
+        siteURLField?.text = loginFields.siteAddress
         configureSubmitButton(animating: false)
     }
 
@@ -91,29 +91,29 @@ final class SiteAddressViewController: LoginViewController {
     /// - Parameter loading: True if the form should be configured to a "loading" state.
     ///
     override func configureViewLoading(_ loading: Bool) {
-       siteURLField?.isEnabled = !loading
+        siteURLField?.isEnabled = !loading
 
-       configureSubmitButton(animating: loading)
-       navigationItem.hidesBackButton = loading
+        configureSubmitButton(animating: loading)
+        navigationItem.hidesBackButton = loading
     }
 
     /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
     ///
     @objc func configureViewForEditingIfNeeded() {
-       // Check the helper to determine whether an editing state should be assumed.
-       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
-       if SigninEditingState.signinEditingStateActive {
-           siteURLField?.becomeFirstResponder()
-       }
+        // Check the helper to determine whether an editing state should be assumed.
+        adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+        if SigninEditingState.signinEditingStateActive {
+            siteURLField?.becomeFirstResponder()
+        }
     }
 
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
-		if errorMessage != message {
-			errorMessage = message
-			shouldChangeVoiceOverFocus = moveVoiceOverFocus
-			tableView.reloadData()
-		}
+        if errorMessage != message {
+            errorMessage = message
+            shouldChangeVoiceOverFocus = moveVoiceOverFocus
+            tableView.reloadData()
+        }
     }
 }
 
@@ -140,13 +140,13 @@ extension SiteAddressViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate conformance
 extension SiteAddressViewController: UITableViewDelegate {
-	/// After the site address textfield cell is done displaying, remove the textfield reference.
-	///
-	func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-		if rows[indexPath.row] == .siteAddress {
-			siteURLField = nil
-		}
-	}
+    /// After the site address textfield cell is done displaying, remove the textfield reference.
+    ///
+    func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if rows[indexPath.row] == .siteAddress {
+            siteURLField = nil
+        }
+    }
 }
 
 
@@ -165,16 +165,16 @@ extension SiteAddressViewController: NUXKeyboardResponder {
 // MARK: - TextField Delegate conformance
 extension SiteAddressViewController: UITextFieldDelegate {
 
-	/// Handle the keyboard `return` button action.
-	///
-	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-		if canSubmit() {
-			validateForm()
-			return true
-		}
+    /// Handle the keyboard `return` button action.
+    ///
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if canSubmit() {
+            validateForm()
+            return true
+        }
 
-		return false
-	}
+        return false
+    }
 }
 
 
@@ -201,8 +201,8 @@ private extension SiteAddressViewController {
         rows = [.instructions, .siteAddress]
 
         if errorMessage != nil {
-             rows.append(.errorMessage)
-         }
+            rows.append(.errorMessage)
+        }
 
         if WordPressAuthenticator.shared.configuration.displayHintButtons {
             rows.append(.findSiteAddress)
@@ -239,11 +239,11 @@ private extension SiteAddressViewController {
         cell.configureTextFieldStyle(with: .url, and: placeholderText)
         // Save a reference to the first textField so it can becomeFirstResponder.
         siteURLField = cell.textField
-		cell.textField.delegate = self
-		cell.onChangeSelectionHandler = { [weak self] textfield in
-			self?.loginFields.siteAddress = textfield.nonNilTrimmedText()
-			self?.configureSubmitButton(animating: false)
-		}
+        cell.textField.delegate = self
+        cell.onChangeSelectionHandler = { [weak self] textfield in
+            self?.loginFields.siteAddress = textfield.nonNilTrimmedText()
+            self?.configureSubmitButton(animating: false)
+        }
 
         SigninEditingState.signinEditingStateActive = true
     }
@@ -326,32 +326,32 @@ extension SiteAddressViewController {
             // Let's try to grab site info in preparation for the next screen.
             self?.fetchSiteInfo()
 
-        }, failure: { [weak self] (error) in
-            guard let error = error, let self = self else {
-                return
-            }
+            }, failure: { [weak self] (error) in
+                guard let error = error, let self = self else {
+                    return
+                }
 
-            DDLogError(error.localizedDescription)
-            WordPressAuthenticator.track(.loginFailedToGuessXMLRPC, error: error)
-            WordPressAuthenticator.track(.loginFailed, error: error)
-            self.configureViewLoading(false)
+                DDLogError(error.localizedDescription)
+                WordPressAuthenticator.track(.loginFailedToGuessXMLRPC, error: error)
+                WordPressAuthenticator.track(.loginFailed, error: error)
+                self.configureViewLoading(false)
 
-            let err = self.originalErrorOrError(error: error as NSError)
+                let err = self.originalErrorOrError(error: error as NSError)
 
-            if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                self.displayError(message: xmlrpcValidatorError.localizedDescription, moveVoiceOverFocus: true)
+                if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
+                    self.displayError(message: xmlrpcValidatorError.localizedDescription, moveVoiceOverFocus: true)
 
-            } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
-                (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
-                // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
-                let msg = NSLocalizedString(
-                    "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
-                    comment: "Error message shown a URL does not point to an existing site.")
-                self.displayError(message: msg, moveVoiceOverFocus: true)
+                } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
+                    (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
+                    // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
+                    let msg = NSLocalizedString(
+                        "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
+                        comment: "Error message shown a URL does not point to an existing site.")
+                    self.displayError(message: msg, moveVoiceOverFocus: true)
 
-            } else {
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
-            }
+                } else {
+                    self.displayError(error as NSError, sourceTag: self.sourceTag)
+                }
         })
     }
 
@@ -407,17 +407,17 @@ extension SiteAddressViewController {
     /// Here we will continue with the self-hosted flow.
     ///
     @objc func showSelfHostedUsernamePassword() {
-		configureViewLoading(false)
-		guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
-			DDLogError("Failed to navigate from SiteAddressViewController to SiteCredentialsViewController")
-			return
-		}
+        configureViewLoading(false)
+        guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
+            DDLogError("Failed to navigate from SiteAddressViewController to SiteCredentialsViewController")
+            return
+        }
 
-       vc.loginFields = loginFields
-       vc.dismissBlock = dismissBlock
-       vc.errorToPresent = errorToPresent
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
 
-       navigationController?.pushViewController(vc, animated: true)
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     /// Break away from the self-hosted flow.
@@ -428,7 +428,7 @@ extension SiteAddressViewController {
 
         guard let vc = LoginUsernamePasswordViewController.instantiate(from: .login) else {
             DDLogError("Failed to navigate from LoginSiteAddressViewController to LoginUsernamePasswordViewController")
-                return
+            return
         }
 
         vc.loginFields = loginFields
@@ -437,7 +437,7 @@ extension SiteAddressViewController {
 
         navigationController?.pushViewController(vc, animated: true)
     }
-
+    
     /// Whether the form can be submitted.
     ///
     @objc func canSubmit() -> Bool {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -91,7 +91,7 @@ final class SiteCredentialsViewController: LoginViewController {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
 
-	/// Configures the appearance and state of the submit button.
+    /// Configures the appearance and state of the submit button.
     ///
     override func configureSubmitButton(animating: Bool) {
         submitButton?.showActivityIndicator(animating)
@@ -346,14 +346,14 @@ private extension SiteCredentialsViewController {
     /// Configure the view for an editing state.
     ///
     func configureViewForEditingIfNeeded() {
-       // Check the helper to determine whether an editing state should be assumed.
-       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
-       if SigninEditingState.signinEditingStateActive {
-           usernameField?.becomeFirstResponder()
-       }
+        // Check the helper to determine whether an editing state should be assumed.
+        adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+        if SigninEditingState.signinEditingStateActive {
+            usernameField?.becomeFirstResponder()
+        }
     }
     
-	// MARK: - Private Constants
+    // MARK: - Private Constants
 
     /// Rows listed in the order they were created.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -6,28 +6,28 @@ import UIKit
 ///
 class SiteCredentialsViewController: LoginViewController {
 
-	/// Private properties.
+    /// Private properties.
     ///
     @IBOutlet private weak var tableView: UITableView!
-	private weak var usernameField: UITextField?
-	private weak var passwordField: UITextField?
-	private var rows = [Row]()
-	private var errorMessage: String?
-	private var shouldChangeVoiceOverFocus: Bool = false
+    private weak var usernameField: UITextField?
+    private weak var passwordField: UITextField?
+    private var rows = [Row]()
+    private var errorMessage: String?
+    private var shouldChangeVoiceOverFocus: Bool = false
 
-	/// Internal properties.
-	///
-	@IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+    /// Internal properties.
+    ///
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     // Required property declaration for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?
 
-	override var sourceTag: WordPressSupportSourceTag {
+    override var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginUsernamePassword
         }
     }
 
-	override var loginFields: LoginFields {
+    override var loginFields: LoginFields {
         didSet {
             // Clear the password (if any) from LoginFields
             loginFields.password = ""
@@ -36,14 +36,14 @@ class SiteCredentialsViewController: LoginViewController {
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
-		validateForm()
+        validateForm()
     }
 
-	// MARK: - View lifecycle
+    // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
-		loginFields.meta.userIsDotCom = false
+        loginFields.meta.userIsDotCom = false
 
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
@@ -52,22 +52,22 @@ class SiteCredentialsViewController: LoginViewController {
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
 
-		localizePrimaryButton()
-		registerTableViewCells()
-		loadRows()
-		configureForAccessibility()
+        localizePrimaryButton()
+        registerTableViewCells()
+        loadRows()
+        configureForAccessibility()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-		configureSubmitButton(animating: false)
+        configureSubmitButton(animating: false)
 
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
         configureViewForEditingIfNeeded()
 
-		// Tracks go here. Old event: WordPressAuthenticator.track(.loginUsernamePasswordFormViewed)
+        // Tracks go here. Old event: WordPressAuthenticator.track(.loginUsernamePasswordFormViewed)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -76,7 +76,7 @@ class SiteCredentialsViewController: LoginViewController {
     }
 
 
-	// MARK: - Overrides
+    // MARK: - Overrides
 
     /// Style individual ViewController backgrounds, for now.
     ///
@@ -94,18 +94,18 @@ class SiteCredentialsViewController: LoginViewController {
     }
 
 
-	/// Configure the view for an editing state. Should only be called from viewWillAppear
+    /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
     ///
     @objc func configureViewForEditingIfNeeded() {
-       // Check the helper to determine whether an editing state should be assumed.
-       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
-       if SigninEditingState.signinEditingStateActive {
-           usernameField?.becomeFirstResponder()
-       }
+        // Check the helper to determine whether an editing state should be assumed.
+        adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+        if SigninEditingState.signinEditingStateActive {
+            usernameField?.becomeFirstResponder()
+        }
     }
 
-	/// Configures the appearance and state of the submit button.
+    /// Configures the appearance and state of the submit button.
     ///
     override func configureSubmitButton(animating: Bool) {
         submitButton?.showActivityIndicator(animating)
@@ -117,7 +117,7 @@ class SiteCredentialsViewController: LoginViewController {
         )
     }
 
-	/// Sets the view's state to loading or not loading.
+    /// Sets the view's state to loading or not loading.
     ///
     /// - Parameter loading: True if the form should be configured to a "loading" state.
     ///
@@ -129,23 +129,23 @@ class SiteCredentialsViewController: LoginViewController {
         navigationItem.hidesBackButton = loading
     }
 
-	/// Set error messages and reload the table to display them.
-	///
-	override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
-		if errorMessage != message {
-			errorMessage = message
-			shouldChangeVoiceOverFocus = moveVoiceOverFocus
-			tableView.reloadData()
-		}
+    /// Set error messages and reload the table to display them.
+    ///
+    override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
+        if errorMessage != message {
+            errorMessage = message
+            shouldChangeVoiceOverFocus = moveVoiceOverFocus
+            tableView.reloadData()
+        }
     }
 
-	/// No-op. Required by the SigninWPComSyncHandler protocol but the self-hosted
+    /// No-op. Required by the SigninWPComSyncHandler protocol but the self-hosted
     /// controller's implementation does not use safari saved credentials.
     ///
     override func updateSafariCredentialsIfNeeded() {}
 
-	/// No-op. Required by LoginFacade.
-	func displayLoginMessage(_ message: String) {}
+    /// No-op. Required by LoginFacade.
+    func displayLoginMessage(_ message: String) {}
 }
 
 
@@ -171,15 +171,15 @@ extension SiteCredentialsViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate conformance
 extension SiteCredentialsViewController: UITableViewDelegate {
-	/// After a textfield cell is done displaying, remove the textfield reference.
-	///
-	func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-		if rows[indexPath.row] == .username {
-			usernameField = nil
-		} else if rows[indexPath.row] == .password {
-			passwordField = nil
-		}
-	}
+    /// After a textfield cell is done displaying, remove the textfield reference.
+    ///
+    func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if rows[indexPath.row] == .username {
+            usernameField = nil
+        } else if rows[indexPath.row] == .password {
+            passwordField = nil
+        }
+    }
 }
 
 
@@ -198,9 +198,9 @@ extension SiteCredentialsViewController: NUXKeyboardResponder {
 // MARK: - TextField Delegate conformance
 extension SiteCredentialsViewController: UITextFieldDelegate {
 
-	/// Handle the keyboard `return` button action.
-	///
-	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    /// Handle the keyboard `return` button action.
+    ///
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if textField == usernameField {
             passwordField?.becomeFirstResponder()
         } else if textField == passwordField {
@@ -214,13 +214,13 @@ extension SiteCredentialsViewController: UITextFieldDelegate {
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
 
-	/// Registers all of the available TableViewCells.
+    /// Registers all of the available TableViewCells.
     ///
     func registerTableViewCells() {
         let cells = [
             TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
-			TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib(),
-			TextLinkButtonTableViewCell.reuseIdentifier: TextLinkButtonTableViewCell.loadNib()
+            TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib(),
+            TextLinkButtonTableViewCell.reuseIdentifier: TextLinkButtonTableViewCell.loadNib()
         ]
 
         for (reuseIdentifier, nib) in cells {
@@ -228,111 +228,111 @@ private extension SiteCredentialsViewController {
         }
     }
 
-	/// Describes how the tableView rows should be rendered.
+    /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-		rows = [.instructions, .username, .password]
+        rows = [.instructions, .username, .password]
 
-		if errorMessage != nil {
-             rows.append(.errorMessage)
-         }
+        if errorMessage != nil {
+            rows.append(.errorMessage)
+        }
 
         if WordPressAuthenticator.shared.configuration.displayHintButtons {
             rows.append(.forgotPassword)
         }
     }
 
-	/// Configure cells.
+    /// Configure cells.
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
         case let cell as TextLabelTableViewCell where row == .instructions:
             configureInstructionLabel(cell)
-		case let cell as TextFieldTableViewCell where row == .username:
-			configureUsernameTextField(cell)
-		case let cell as TextFieldTableViewCell where row == .password:
-			configurePasswordTextField(cell)
-		case let cell as TextLinkButtonTableViewCell:
-			configureForgotPassword(cell)
-		case let cell as TextLabelTableViewCell where row == .errorMessage:
-			configureErrorLabel(cell)
+        case let cell as TextFieldTableViewCell where row == .username:
+            configureUsernameTextField(cell)
+        case let cell as TextFieldTableViewCell where row == .password:
+            configurePasswordTextField(cell)
+        case let cell as TextLinkButtonTableViewCell:
+            configureForgotPassword(cell)
+        case let cell as TextLabelTableViewCell where row == .errorMessage:
+            configureErrorLabel(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
     }
 
-	/// Configure the instruction cell.
+    /// Configure the instruction cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
-		let displayURL = sanitizedSiteAddress(siteAddress: loginFields.siteAddress)
-		let text = String.localizedStringWithFormat(WordPressAuthenticator.shared.displayStrings.siteCredentialInstructions, displayURL)
+        let displayURL = sanitizedSiteAddress(siteAddress: loginFields.siteAddress)
+        let text = String.localizedStringWithFormat(WordPressAuthenticator.shared.displayStrings.siteCredentialInstructions, displayURL)
         cell.configureLabel(text: text, style: .body)
     }
 
-	/// Configure the username textfield cell.
-	///
-	func configureUsernameTextField(_ cell: TextFieldTableViewCell) {
-		cell.configureTextFieldStyle(with: .username,
-									 and: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder)
-		// Save a reference to the textField so it can becomeFirstResponder.
+    /// Configure the username textfield cell.
+    ///
+    func configureUsernameTextField(_ cell: TextFieldTableViewCell) {
+        cell.configureTextFieldStyle(with: .username,
+                                     and: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder)
+        // Save a reference to the textField so it can becomeFirstResponder.
         usernameField = cell.textField
-		cell.textField.delegate = self
+        cell.textField.delegate = self
         SigninEditingState.signinEditingStateActive = true
-		cell.onePasswordHandler = { [weak self] in
-			guard let self = self else {
-				return
-			}
+        cell.onePasswordHandler = { [weak self] in
+            guard let self = self else {
+                return
+            }
 
-			guard let sourceView = self.usernameField else {
-				return
-			}
+            guard let sourceView = self.usernameField else {
+                return
+            }
 
-			self.view.endEditing(true)
+            self.view.endEditing(true)
 
-			WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sourceView, loginFields: self.loginFields) { [unowned self] loginFields in
-				self.usernameField?.text = loginFields.username
-				self.passwordField?.text = loginFields.password
-				self.validateForm()
-			}
-		}
+            WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sourceView, loginFields: self.loginFields) { [unowned self] loginFields in
+                self.usernameField?.text = loginFields.username
+                self.passwordField?.text = loginFields.password
+                self.validateForm()
+            }
+        }
 
-		cell.onChangeSelectionHandler = { [weak self] textfield in
-			self?.loginFields.username = textfield.nonNilTrimmedText()
-			self?.configureSubmitButton(animating: false)
-		}
-	}
+        cell.onChangeSelectionHandler = { [weak self] textfield in
+            self?.loginFields.username = textfield.nonNilTrimmedText()
+            self?.configureSubmitButton(animating: false)
+        }
+    }
 
-	/// Configure the password textfield cell.
-	///
-	func configurePasswordTextField(_ cell: TextFieldTableViewCell) {
-		cell.configureTextFieldStyle(with: .password,
-									 and: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder)
-		passwordField = cell.textField
-		cell.textField.delegate = self
-		cell.onChangeSelectionHandler = { [weak self] textfield in
-			self?.loginFields.password = textfield.nonNilTrimmedText()
-			self?.configureSubmitButton(animating: false)
-		}
-	}
+    /// Configure the password textfield cell.
+    ///
+    func configurePasswordTextField(_ cell: TextFieldTableViewCell) {
+        cell.configureTextFieldStyle(with: .password,
+                                     and: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder)
+        passwordField = cell.textField
+        cell.textField.delegate = self
+        cell.onChangeSelectionHandler = { [weak self] textfield in
+            self?.loginFields.password = textfield.nonNilTrimmedText()
+            self?.configureSubmitButton(animating: false)
+        }
+    }
 
-	/// Configure the forgot password cell.
-	///
-	func configureForgotPassword(_ cell: TextLinkButtonTableViewCell) {
-		cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle, accessibilityTrait: .link)
-		cell.actionHandler = { [weak self] in
-			guard let self = self else {
-				return
-			}
+    /// Configure the forgot password cell.
+    ///
+    func configureForgotPassword(_ cell: TextLinkButtonTableViewCell) {
+        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle, accessibilityTrait: .link)
+        cell.actionHandler = { [weak self] in
+            guard let self = self else {
+                return
+            }
 
-			// If information is currently processing, ignore button tap.
-			guard self.enableSubmit(animating: false) else {
-				return
-			}
+            // If information is currently processing, ignore button tap.
+            guard self.enableSubmit(animating: false) else {
+                return
+            }
 
-			WordPressAuthenticator.openForgotPasswordURL(self.loginFields)
-			WordPressAuthenticator.track(.loginForgotPasswordClicked)
-		}
-	}
+            WordPressAuthenticator.openForgotPasswordURL(self.loginFields)
+            WordPressAuthenticator.track(.loginForgotPasswordClicked)
+        }
+    }
 
     /// Configure the error message cell.
     ///
@@ -340,47 +340,47 @@ private extension SiteCredentialsViewController {
         cell.configureLabel(text: errorMessage, style: .error)
     }
 
-	/// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
-	///
-	func configureForAccessibility() {
-		usernameField?.accessibilityLabel =
-			NSLocalizedString("Username", comment: "Accessibility label for the username text field in the self-hosted login page.")
-		passwordField?.accessibilityLabel =
-			NSLocalizedString("Password", comment: "Accessibility label for the password text field in the self-hosted login page.")
+    /// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
+    ///
+    func configureForAccessibility() {
+        usernameField?.accessibilityLabel =
+            NSLocalizedString("Username", comment: "Accessibility label for the username text field in the self-hosted login page.")
+        passwordField?.accessibilityLabel =
+            NSLocalizedString("Password", comment: "Accessibility label for the password text field in the self-hosted login page.")
 
-		if UIAccessibility.isVoiceOverRunning {
-			// Remove the placeholder if VoiceOver is running. VoiceOver speaks the label and the
-			// placeholder together. In this case, both labels and placeholders are the same so it's
-			// like VoiceOver is reading the same thing twice.
-			usernameField?.placeholder = nil
-			passwordField?.placeholder = nil
-		}
-	}
+        if UIAccessibility.isVoiceOverRunning {
+            // Remove the placeholder if VoiceOver is running. VoiceOver speaks the label and the
+            // placeholder together. In this case, both labels and placeholders are the same so it's
+            // like VoiceOver is reading the same thing twice.
+            usernameField?.placeholder = nil
+            passwordField?.placeholder = nil
+        }
+    }
 
-	// MARK: - Private Constants
+    // MARK: - Private Constants
 
     /// Rows listed in the order they were created.
     ///
     enum Row {
         case instructions
-		case username
-		case password
-		case forgotPassword
-		case errorMessage
+        case username
+        case password
+        case forgotPassword
+        case errorMessage
 
         var reuseIdentifier: String {
             switch self {
             case .instructions:
                 return TextLabelTableViewCell.reuseIdentifier
-			case .username:
-				return TextFieldTableViewCell.reuseIdentifier
-			case .password:
-				return TextFieldTableViewCell.reuseIdentifier
-			case .forgotPassword:
-				return TextLinkButtonTableViewCell.reuseIdentifier
-			case .errorMessage:
-				return TextLabelTableViewCell.reuseIdentifier
-			}
+            case .username:
+                return TextFieldTableViewCell.reuseIdentifier
+            case .password:
+                return TextFieldTableViewCell.reuseIdentifier
+            case .forgotPassword:
+                return TextLinkButtonTableViewCell.reuseIdentifier
+            case .errorMessage:
+                return TextLabelTableViewCell.reuseIdentifier
+            }
         }
     }
 }
@@ -390,7 +390,7 @@ private extension SiteCredentialsViewController {
 /// Implementation methods copied from LoginSelfHostedViewController.
 ///
 extension SiteCredentialsViewController {
-	/// Sanitize and format the site address we show to users.
+    /// Sanitize and format the site address we show to users.
     ///
     @objc func sanitizedSiteAddress(siteAddress: String) -> String {
         let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: siteAddress) as NSString
@@ -400,14 +400,14 @@ extension SiteCredentialsViewController {
         return siteAddress
     }
 
-	/// Validates what is entered in the various form fields and, if valid,
-	/// proceeds with the submit action.
-	///
-	@objc func validateForm() {
-		validateFormAndLogin()
-	}
+    /// Validates what is entered in the various form fields and, if valid,
+    /// proceeds with the submit action.
+    ///
+    @objc func validateForm() {
+        validateFormAndLogin()
+    }
 
-	func finishedLogin(withUsername username: String, password: String, xmlrpc: String, options: [AnyHashable: Any]) {
+    func finishedLogin(withUsername username: String, password: String, xmlrpc: String, options: [AnyHashable: Any]) {
         guard let delegate = WordPressAuthenticator.shared.delegate else {
             fatalError("Error: Where did the delegate go?")
         }


### PR DESCRIPTION
After comparing Xcode's editing features with @ScoutHarris, I discovered Authenticator uses spaces instead of tabs. To keep the new classes consistent with the old ones, I reformatted the classes to use spaces. There are no code changes in this PR.

This is a non-essential PR so I did not create a new pod version in WPiOS.