### PR TITLE
UL&S: Update the password "eye" icon tint color for the old UI

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.1"
+  s.version       = "1.22.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
+++ b/WordPressAuthenticator/NUX/WPWalkthroughTextField.m
@@ -121,8 +121,7 @@ NSInteger const LeftImageSpacing = 8;
     self.secureTextEntryToggle = [UIButton buttonWithType:UIButtonTypeCustom];
     self.secureTextEntryToggle.clipsToBounds = true;
 
-    // colors here are overridden in LoginTextField
-    self.secureTextEntryToggle.tintColor = (self.secureTextEntryImageColor != nil) ? self.secureTextEntryImageColor : [WPStyleGuide greyLighten10];
+    // Tint color changes set in LoginTextField.
 
     [self.secureTextEntryToggle addTarget:self action:@selector(secureTextEntryToggleAction:) forControlEvents:UIControlEventTouchUpInside];
 
@@ -280,6 +279,7 @@ NSInteger const LeftImageSpacing = 8;
     UIImage *image = self.isSecureTextEntry ? self.secureTextEntryImageHidden : self.secureTextEntryImageVisible;
     [self.secureTextEntryToggle setImage:image forState:UIControlStateNormal];
     [self.secureTextEntryToggle sizeToFit];
+    self.secureTextEntryToggle.tintColor = self.secureTextEntryImageColor;
 }
 
 - (void)updateSecureTextEntryForAccessibility

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -3,6 +3,18 @@ import WordPressShared
 
 open class LoginTextField: WPWalkthroughTextField {
 
+    /// Make a Swift-only property communicate a color to the
+    /// Objective-C only class, WPWalkthroughTextField.
+    ///
+    open override var secureTextEntryImageColor: UIColor! {
+        set {
+            // no-op. Usually set in Interface Builder.
+        }
+        get {
+            return WordPressAuthenticator.shared.style.secondaryNormalBorderColor
+        }
+    }
+
     open override func awakeFromNib() {
         super.awakeFromNib()
         backgroundColor = WordPressAuthenticator.shared.style.textFieldBackgroundColor

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -6,7 +6,6 @@ open class LoginTextField: WPWalkthroughTextField {
     open override func awakeFromNib() {
         super.awakeFromNib()
         backgroundColor = WordPressAuthenticator.shared.style.textFieldBackgroundColor
-        secureTextEntryImageColor = WordPressAuthenticator.shared.style.placeholderColor
     }
 
     override open func draw(_ rect: CGRect) {


### PR DESCRIPTION
Fixes #342 

Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14543

This PR changes the password "eye" icon tint color to match the OnePassword "lock" icon tint color.

As you can see in the code, I had to take a "creative" approach to get this to work. Here are the things that don't work:

- You can’t just set a color in Interface Builder, because it is a custom color (not the correct shade of gray compared to the standard set) and the custom colors weren't previously built into IB (which would handle light & dark modes).
- You can’t just use the `WordPressAuthenticator.shared.style` singleton directly in `WPWalkthroughTextField.m` because `WPWalkthroughTextField` is written in Obj-C. The `WordPressAuthenticator.shared.style` properties live inside a struct. Structs are only supported by Swift.
- You can’t just quick-and-dirty the imageView as seen in the example with the lock icon on the leftView, because the right view holds a button.
- You can’t just set the secureTextEntryImageColor property programmatically in the `LoginTextField` class `awakeFromNib` function. I have no idea why. 

####  iPhone 5s, iOS 12
| Before | After |
| --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/88292918-e3269d80-ccbf-11ea-8a40-af041f8b12d0.png"><img src="https://user-images.githubusercontent.com/1062444/88292918-e3269d80-ccbf-11ea-8a40-af041f8b12d0.png" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/88854009-4334ac80-d1b6-11ea-8865-ed936f388172.png"><img src="https://user-images.githubusercontent.com/1062444/88854009-4334ac80-d1b6-11ea-8865-ed936f388172.png" width="350" /></a> |
