### PR TITLE
ULS: Add 2FA code handling

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.2"
+  s.version       = "1.22.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.3"
+  s.version       = "1.22.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.4"
+  s.version       = "1.22.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFA.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFA.storyboard
@@ -39,6 +39,9 @@
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleContinueButtonTapped:" destination="aQT-Gx-U3x" eventType="touchUpInside" id="Yeh-8i-cow"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -73,6 +76,7 @@
                         <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
                     </view>
                     <connections>
+                        <outlet property="bottomContentConstraint" destination="Dva-c1-u2U" id="Mq1-PI-MuN"/>
                         <outlet property="submitButton" destination="ClH-Cn-49d" id="kBa-QN-0oH"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="MGk-sG-xGv"/>
                         <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -8,6 +8,7 @@ final class TwoFAViewController: LoginViewController {
     // MARK: - Properties
     
     @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     private weak var codeField: UITextField?
     
     private var rows = [Row]()
@@ -20,7 +21,6 @@ final class TwoFAViewController: LoginViewController {
     }
 
     // Required for `NUXKeyboardResponder` but unused here.
-    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     var verticalCenterConstraint: NSLayoutConstraint?
 
     // MARK: - View

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressKit
 
 /// TwoFAViewController: view to enter 2FA code.
 ///
@@ -12,12 +13,18 @@ final class TwoFAViewController: LoginViewController {
     private var rows = [Row]()
     private var errorMessage: String?
 
+    override var sourceTag: WordPressSupportSourceTag {
+        get {
+            return .login2FA
+        }
+    }
+
     // Required for `NUXKeyboardResponder` but unused here.
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     var verticalCenterConstraint: NSLayoutConstraint?
 
-    // TODO: add support tag
-
+    // MARK: - View
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -35,14 +42,21 @@ final class TwoFAViewController: LoginViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        configureSubmitButton(animating: false)
+        configureViewForEditingIfNeeded()
+
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
-        configureViewForEditingIfNeeded()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
+        
+        // Multifactor codes are time sensitive, so clear the stored code if the
+        // user dismisses the view. They'll need to reentered it upon return.
+        loginFields.multifactorCode = ""
+        codeField?.text = ""
     }
 
     // MARK: - Overrides
@@ -59,6 +73,159 @@ final class TwoFAViewController: LoginViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ??
                WordPressAuthenticator.shared.style.statusBarStyle
+    }
+
+    /// Configures the appearance and state of the submit button.
+    ///
+    override func configureSubmitButton(animating: Bool) {
+        submitButton?.showActivityIndicator(animating)
+
+        let isNumeric = loginFields.multifactorCode.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+        let isValidLength = SocialLogin2FANonceInfo.TwoFactorTypeLengths(rawValue: loginFields.multifactorCode.count) != nil
+
+        submitButton?.isEnabled = (
+            !animating &&
+            isNumeric &&
+            isValidLength
+        )
+    }
+
+    override func displayRemoteError(_ error: Error) {
+        displayError(message: "")
+
+        configureViewLoading(false)
+        let err = error as NSError
+        if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue {
+            // Invalid verification code.
+            displayError(message: LocalizedText.bad2FAMessage)
+        } else if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidTwoStepCode.rawValue {
+            // Invalid 2FA during social login
+            if let newNonce = (error as NSError).userInfo[WordPressComOAuthClient.WordPressComOAuthErrorNewNonceKey] as? String {
+                loginFields.nonceInfo?.updateNonce(with: newNonce)
+            }
+            displayError(message: LocalizedText.bad2FAMessage)
+        } else {
+            displayError(error as NSError, sourceTag: sourceTag)
+        }
+    }
+    
+    override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
+        if errorMessage != message {
+            errorMessage = message
+            tableView.reloadData()
+        }
+    }
+    
+}
+
+// MARK: - Validation and Login
+
+private extension TwoFAViewController {
+
+    // MARK: - Button Action
+    
+    @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
+        validateForm()
+    }
+    
+    // MARK: - Login
+
+    /// Validates what is entered in the various form fields and, if valid,
+    /// proceeds with the submit action.
+    ///
+    func validateForm() {
+        if let nonce = loginFields.nonceInfo {
+            loginWithNonce(info: nonce)
+            return
+        }
+        validateFormAndLogin()
+    }
+
+    func loginWithNonce(info nonceInfo: SocialLogin2FANonceInfo) {
+        let code = loginFields.multifactorCode
+        let (authType, nonce) = nonceInfo.authTypeAndNonce(for: code)
+        loginFacade.loginToWordPressDotCom(withUser: loginFields.nonceUserID, authType: authType, twoStepCode: code, twoStepNonce: nonce)
+    }
+    
+    func finishedLogin(withNonceAuthToken authToken: String) {
+        let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: true, siteURL: loginFields.siteAddress)
+        let credentials = AuthenticatorCredentials(wpcom: wpcom)
+        syncWPComAndPresentEpilogue(credentials: credentials)
+        
+        // TODO: add new Tracks.
+        // Old events:
+        // WordPressAuthenticator.track(.signedIn)
+        // WordPressAuthenticator.track(.loginSocialSuccess, properties: properties)
+    }
+    
+    // MARK: - Code Validation
+    
+    enum CodeValidation {
+        case invalid(nonNumbers: Bool)
+        case valid(String)
+    }
+
+    func isValidCode(code: String) -> CodeValidation {
+        let codeStripped = code.components(separatedBy: .whitespacesAndNewlines).joined()
+        let allowedCharacters = CharacterSet.decimalDigits
+        let resultCharacterSet = CharacterSet(charactersIn: codeStripped)
+        let isOnlyNumbers = allowedCharacters.isSuperset(of: resultCharacterSet)
+        let isShortEnough = codeStripped.count <= SocialLogin2FANonceInfo.TwoFactorTypeLengths.backup.rawValue
+
+        if isOnlyNumbers && isShortEnough {
+            return .valid(codeStripped)
+        }
+
+        if isOnlyNumbers {
+            return .invalid(nonNumbers: false)
+        }
+        
+        return .invalid(nonNumbers: true)
+    }
+    
+    // MARK: - Text Field Handling
+    
+    func handleTextFieldDidChange(_ sender: UITextField) {
+        loginFields.multifactorCode = codeField?.nonNilTrimmedText() ?? ""
+        configureSubmitButton(animating: false)
+    }
+    
+}
+
+// MARK: - UITextFieldDelegate
+
+extension TwoFAViewController: UITextFieldDelegate {
+
+    /// Only allow digits in the 2FA text field
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString: String) -> Bool {
+
+        guard let fieldText = textField.text as NSString? else {
+            return true
+        }
+        
+        let resultString = fieldText.replacingCharacters(in: range, with: replacementString)
+
+        switch isValidCode(code: resultString) {
+        case .valid(let cleanedCode):
+            displayError(message: "")
+
+            // because the string was stripped of whitespace, we can't return true and we update the textfield ourselves
+            textField.text = cleanedCode
+            handleTextFieldDidChange(textField)
+        case .invalid(nonNumbers: true):
+            displayError(message: LocalizedText.numericalCode)
+        default:
+            if let pasteString = UIPasteboard.general.string, pasteString == replacementString {
+                displayError(message: LocalizedText.invalidCode)
+            }
+        }
+
+        return false
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        validateForm()
+        return true
     }
 
 }
@@ -153,8 +320,7 @@ private extension TwoFAViewController {
 
         // Save a reference to the first textField so it can becomeFirstResponder.
         codeField = cell.textField
-        
-        // TODO: add cell.onChangeSelectionHandler here.
+        cell.textField.delegate = self
 
         SigninEditingState.signinEditingStateActive = true
     }
@@ -204,4 +370,11 @@ private extension TwoFAViewController {
             }
         }
     }
+
+    enum LocalizedText {
+        static let bad2FAMessage = NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!", comment: "Error message shown when an incorrect two factor code is provided.")
+        static let numericalCode = NSLocalizedString("A verification code will only contain numbers.", comment: "Shown when a user types a non-number into the two factor field.")
+        static let invalidCode = NSLocalizedString("That doesn't appear to be a valid verification code.", comment: "Shown when a user pastes a code into the two factor field that contains letters or is the wrong length")
+    }
+
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
@@ -108,6 +108,7 @@ extension GoogleAuthViewController: GoogleAuthenticatorDelegate {
             return
         }
 
+        vc.loginFields = loginFields
         navigationController?.pushViewController(vc, animated: true)
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -10,9 +10,9 @@ final class SiteAddressViewController: LoginViewController {
     /// Private properties.
     ///
     @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
 
     // Required for `NUXKeyboardResponder` but unused here.
-    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     var verticalCenterConstraint: NSLayoutConstraint?
 
     private var rows = [Row]()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -9,14 +9,15 @@ final class SiteCredentialsViewController: LoginViewController {
 	/// Private properties.
     ///
     @IBOutlet private weak var tableView: UITableView!
-	private weak var usernameField: UITextField?
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+
+    private weak var usernameField: UITextField?
 	private weak var passwordField: UITextField?
 	private var rows = [Row]()
 	private var errorMessage: String?
 	private var shouldChangeVoiceOverFocus: Bool = false
 
     // Required for `NUXKeyboardResponder` but unused here.
-    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     var verticalCenterConstraint: NSLayoutConstraint?
 
 	override var sourceTag: WordPressSupportSourceTag {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -12,10 +12,10 @@ final class SiteCredentialsViewController: LoginViewController {
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
 
     private weak var usernameField: UITextField?
-	private weak var passwordField: UITextField?
-	private var rows = [Row]()
-	private var errorMessage: String?
-	private var shouldChangeVoiceOverFocus: Bool = false
+    private weak var passwordField: UITextField?
+    private var rows = [Row]()
+    private var errorMessage: String?
+    private var shouldChangeVoiceOverFocus: Bool = false
 
     // Required for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?


### PR DESCRIPTION
Ref: #336 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14544

This essentially copies the 2FA code handling logic from the old 2FA VC (`Login2FAViewController`) into the new one (`TwoFAViewController`) to process the entered 2FA code.

An entered code is now validated for length and numeric values. When it is submitted, errors are displayed if the code is incorrect, or the account is logged in.

Also, the Continue button is now pinned to the top of the keyboard.

To  note, the `Text me a code instead` link is not yet functional. 

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-29 at 17 18 09](https://user-images.githubusercontent.com/1816888/88863281-ad058400-d1bf-11ea-80c8-431c059cc8d8.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-29 at 17 18 16](https://user-images.githubusercontent.com/1816888/88863291-b2fb6500-d1bf-11ea-9aac-a80005c9fbf8.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-29 at 17 18 20](https://user-images.githubusercontent.com/1816888/88863319-c4447180-d1bf-11ea-9cd2-c790794b413e.png) |
|--------|-------|-------|