### PR TITLE
UL&S: Navigate to a blank UnifiedSignUpViewController

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.5"
+  s.version       = "1.22.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */; };
 		CE1B18D020EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CF20EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift */; };
 		CE1B18D220EEC44400BECC3F /* WordPressAuthenticatorStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */; };
+		CE1BBF8324D348CD001D2E3E /* UnifiedSignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */; };
+		CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */; };
 		CE30A2A722579F4100DF3CDA /* LoginUsernamePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */; };
 		CE30A2A92257C60500DF3CDA /* WordPressOrgCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */; };
 		CE30A2AD2257CECC00DF3CDA /* AuthenticatorCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */; };
@@ -292,6 +294,8 @@
 		CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDelegateProtocol.swift; sourceTree = "<group>"; };
 		CE1B18CF20EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorConfiguration.swift; sourceTree = "<group>"; };
 		CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorStyles.swift; sourceTree = "<group>"; };
+		CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSignUpViewController.swift; sourceTree = "<group>"; };
+		CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UnifiedSignUp.storyboard; sourceTree = "<group>"; };
 		CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginUsernamePasswordViewController.swift; sourceTree = "<group>"; };
 		CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentials.swift; sourceTree = "<group>"; };
 		CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatorCredentials.swift; sourceTree = "<group>"; };
@@ -698,12 +702,22 @@
 			path = Credentials;
 			sourceTree = "<group>";
 		};
+		CE1BBF8124D3487A001D2E3E /* Sign up */ = {
+			isa = PBXGroup;
+			children = (
+				CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */,
+				CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */,
+			);
+			path = "Sign up";
+			sourceTree = "<group>";
+		};
 		CEC77C6424854EE400FB9050 /* View Related */ = {
 			isa = PBXGroup;
 			children = (
 				988AD89F24CB820200BD045E /* 2FA */,
 				98CF18F5248725130047B66C /* Google */,
 				CEC77C70248AB0C700FB9050 /* Reusable Views */,
+				CE1BBF8124D3487A001D2E3E /* Sign up */,
 				CEFE241E24B666AA00B46DC5 /* Site Address */,
 			);
 			path = "View Related";
@@ -854,6 +868,7 @@
 				B5609118208A555600399AE4 /* SearchTableViewCell.xib in Resources */,
 				98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
+				CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */,
 				CE6BCD3924A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib in Resources */,
 				CE6BCD2F24A3A235001BCDC5 /* TextLabelTableViewCell.xib in Resources */,
 				98CF18F9248725620047B66C /* GoogleSignupConfirmation.storyboard in Resources */,
@@ -1029,6 +1044,7 @@
 				CE1B18CC20EEC32400BECC3F /* WordPressComCredentials.swift in Sources */,
 				98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */,
 				B560913C208A563800399AE4 /* LoginProloguePromoViewController.swift in Sources */,
+				CE1BBF8324D348CD001D2E3E /* UnifiedSignUpViewController.swift in Sources */,
 				B560910F208A54F800399AE4 /* SafariCredentialsService.swift in Sources */,
 				B5CDBED420B4714500BC1EF2 /* UIImage+Assets.swift in Sources */,
 				B5609116208A555600399AE4 /* LoginTextField.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -82,7 +82,7 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableUnifiedGoogle: Bool
 
-    /// Flag indicating if signing up via Email shouls display.
+    /// Flag indicating if signing up via Email should display.
     ///
     let enableUnifiedSignup: Bool
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -82,6 +82,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableUnifiedGoogle: Bool
 
+    /// Flag indicating if signing up via Email shouls display.
+    ///
+    let enableUnifiedSignup: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -100,7 +104,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableUnifiedAuth: Bool = false,
                  displayHintButtons: Bool = true,
                  enableUnifiedSiteAddress: Bool = false,
-                 enableUnifiedGoogle: Bool = false) {
+                 enableUnifiedGoogle: Bool = false,
+                 enableUnifiedSignup: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -119,5 +124,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableUnifiedSiteAddress = enableUnifiedAuth && enableUnifiedSiteAddress
         self.enableUnifiedGoogle = enableUnifiedAuth && enableUnifiedGoogle
         self.enableSignupWithGoogle = enableSignupWithGoogle
+        self.enableUnifiedSignup = enableUnifiedAuth && enableUnifiedSignup
     }
 }

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -5,6 +5,7 @@ import Foundation
 enum Storyboard: String {
     case login = "Login"
     case signup = "Signup"
+    case unifiedSignUp = "UnifiedSignUp"
     case emailMagicLink = "EmailMagicLink"
     case siteAddress = "SiteAddress"
     case googleAuth = "GoogleAuth"

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -129,12 +129,12 @@ class LoginPrologueViewController: LoginViewController {
         vc.modalPresentationStyle = .custom
 
         vc.emailTapped = { [weak self] in
-            guard let toVC = SignupEmailViewController.instantiate(from: .signup) else {
-                DDLogError("Failed to navigate to SignupEmailViewController")
+            guard WordPressAuthenticator.shared.configuration.enableUnifiedSignup else {
+                self?.presentSignUpEmailView()
                 return
             }
 
-            self?.navigationController?.pushViewController(toVC, animated: true)
+            self?.presentUnifiedSignUpView()
         }
 
         vc.googleTapped = { [weak self] in
@@ -177,6 +177,24 @@ class LoginPrologueViewController: LoginViewController {
         }
 
         presentUnifiedSiteAddressView()
+    }
+
+    private func presentSignUpEmailView() {
+        guard let toVC = SignupEmailViewController.instantiate(from: .signup) else {
+            DDLogError("Failed to navigate to SignupEmailViewController")
+            return
+        }
+
+        navigationController?.pushViewController(toVC, animated: true)
+    }
+
+    private func presentUnifiedSignUpView() {
+        guard let toVC = UnifiedSignUpViewController.instantiate(from: .unifiedSignUp) else {
+            DDLogError("Failed to navigate to UnifiedSignUpViewController")
+            return
+        }
+
+        navigationController?.pushViewController(toVC, animated: true)
     }
 
     // Shows the VC that handles both Google login & signup.

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
@@ -22,10 +22,6 @@
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uMq-La-HEm">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="547"/>
                                         <sections/>
-                                        <connections>
-                                            <outlet property="dataSource" destination="eEV-Dl-qyz" id="3Wh-Xj-3zz"/>
-                                            <outlet property="delegate" destination="eEV-Dl-qyz" id="IPK-RE-Bmh"/>
-                                        </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UFq-9y-0cn" userLabel="Button background view">
                                         <rect key="frame" x="0.0" y="547" width="375" height="76"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Zt7-Aw-WhB">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Unified Sign Up View Controller-->
+        <scene sceneID="tlG-zZ-6we">
+            <objects>
+                <viewController storyboardIdentifier="UnifiedSignUpViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="eEV-Dl-qyz" customClass="UnifiedSignUpViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="48f-x8-Uiu">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vrC-wY-7gH" userLabel="Containing View">
+                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <subviews>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uMq-La-HEm">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="547"/>
+                                        <sections/>
+                                        <connections>
+                                            <outlet property="dataSource" destination="eEV-Dl-qyz" id="3Wh-Xj-3zz"/>
+                                            <outlet property="delegate" destination="eEV-Dl-qyz" id="IPK-RE-Bmh"/>
+                                        </connections>
+                                    </tableView>
+                                    <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UFq-9y-0cn" userLabel="Button background view">
+                                        <rect key="frame" x="0.0" y="547" width="375" height="76"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4e9-BU-PNb" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="bK8-Nz-TAg"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleContinueButtonTapped:" destination="eEV-Dl-qyz" eventType="touchUpInside" id="B6r-DP-dMc"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstItem="4e9-BU-PNb" firstAttribute="top" secondItem="UFq-9y-0cn" secondAttribute="topMargin" constant="8" id="HBB-yb-lJS"/>
+                                            <constraint firstAttribute="bottomMargin" secondItem="4e9-BU-PNb" secondAttribute="bottom" constant="8" id="cns-b6-V0y"/>
+                                        </constraints>
+                                        <viewLayoutGuide key="safeArea" id="ggX-Oc-Xox"/>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="UFq-9y-0cn" firstAttribute="bottom" secondItem="vrC-wY-7gH" secondAttribute="bottomMargin" constant="8" id="9wB-kg-uNd"/>
+                                    <constraint firstItem="4e9-BU-PNb" firstAttribute="leading" secondItem="uMq-La-HEm" secondAttribute="leading" constant="16" id="BVd-do-zae"/>
+                                    <constraint firstItem="UFq-9y-0cn" firstAttribute="leading" secondItem="vrC-wY-7gH" secondAttribute="leading" id="Jcq-T2-uPZ"/>
+                                    <constraint firstItem="uMq-La-HEm" firstAttribute="trailing" secondItem="4e9-BU-PNb" secondAttribute="trailing" constant="16" id="Zyc-DP-C03"/>
+                                    <constraint firstItem="UFq-9y-0cn" firstAttribute="trailing" secondItem="vrC-wY-7gH" secondAttribute="trailing" id="ceu-5F-NZe"/>
+                                    <constraint firstItem="UFq-9y-0cn" firstAttribute="top" secondItem="uMq-La-HEm" secondAttribute="bottom" id="rqC-0L-jbi"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="7D5-97-8zD" firstAttribute="trailing" secondItem="uMq-La-HEm" secondAttribute="trailing" id="6hE-qE-zLF"/>
+                            <constraint firstItem="7D5-97-8zD" firstAttribute="bottom" secondItem="vrC-wY-7gH" secondAttribute="bottom" id="A5i-l6-R2a"/>
+                            <constraint firstItem="vrC-wY-7gH" firstAttribute="top" secondItem="7D5-97-8zD" secondAttribute="top" id="R2Z-E0-wqG"/>
+                            <constraint firstItem="vrC-wY-7gH" firstAttribute="trailing" secondItem="48f-x8-Uiu" secondAttribute="trailing" id="R6b-Gs-GDz"/>
+                            <constraint firstItem="vrC-wY-7gH" firstAttribute="leading" secondItem="48f-x8-Uiu" secondAttribute="leading" id="aM7-4X-zWN"/>
+                            <constraint firstItem="uMq-La-HEm" firstAttribute="top" secondItem="7D5-97-8zD" secondAttribute="top" id="azl-B9-x80"/>
+                            <constraint firstItem="uMq-La-HEm" firstAttribute="leading" secondItem="7D5-97-8zD" secondAttribute="leading" id="xs1-4O-GeZ"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="7D5-97-8zD"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="5lc-hf-cia"/>
+                    <connections>
+                        <outlet property="bottomContentConstraint" destination="A5i-l6-R2a" id="elI-gU-ibK"/>
+                        <outlet property="submitButton" destination="4e9-BU-PNb" id="GSH-Hx-8G0"/>
+                        <outlet property="tableView" destination="uMq-La-HEm" id="uaR-Kf-8hW"/>
+                        <outlet property="tableViewLeadingConstraint" destination="xs1-4O-GeZ" id="hDa-A6-doE"/>
+                        <outlet property="tableViewTrailingConstraint" destination="6hE-qE-zLF" id="mUc-ix-0ws"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xaV-I9-fiG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="904.79999999999995" y="-33.733133433283363"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="v2f-0A-tzF">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Zt7-Aw-WhB" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="hLe-Wz-3Ka">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="eEV-Dl-qyz" kind="relationship" relationship="rootViewController" id="Wfu-pW-lIq"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Tw2-A9-Og2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-34.399999999999999" y="-33.733133433283363"/>
+        </scene>
+    </scenes>
+</document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -14,9 +14,10 @@ class UnifiedSignUpViewController: LoginViewController {
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
-        
+
     }
 
+    // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -26,5 +27,22 @@ class UnifiedSignUpViewController: LoginViewController {
         // Store default margin, and size table for the view.
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
+    }
+
+    // MARK: - Overrides
+
+    /// Style individual ViewController backgrounds, for now.
+    ///
+    override func styleBackground() {
+        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
+            super.styleBackground()
+            return
+        }
+
+        view.backgroundColor = unifiedBackgroundColor
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -27,6 +27,8 @@ class UnifiedSignUpViewController: LoginViewController {
         // Store default margin, and size table for the view.
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
+
+        localizePrimaryButton()
     }
 
     // MARK: - Overrides

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+/// UnifiedSignUpViewController: sign up to .com with an email address.
+///
+class UnifiedSignUpViewController: LoginViewController {
+
+    /// Private properties.
+    ///
+    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+
+    // Required for `NUXKeyboardResponder` but unused here.
+    var verticalCenterConstraint: NSLayoutConstraint?
+
+    // MARK: - Actions
+    @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
+        
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
+        styleNavigationBar(forUnified: true)
+
+        // Store default margin, and size table for the view.
+        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
+        setTableViewMargins(forWidth: view.frame.width)
+    }
+}


### PR DESCRIPTION
Ref. #345 
Closes #346 

Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14551

This PR navigates the user to a new, blank Sign Up screen if the `.unifiedSignup` flag is enabled. 

**iPhone 11 Pro**
| Light Mode | Dark Mode |
| --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/88963889-23f95600-d26e-11ea-940e-acec5d68aaeb.png"><img src="https://user-images.githubusercontent.com/1062444/88963889-23f95600-d26e-11ea-940e-acec5d68aaeb.png" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/88963929-2fe51800-d26e-11ea-878b-f8807980cfce.png"><img src="https://user-images.githubusercontent.com/1062444/88963929-2fe51800-d26e-11ea-878b-f8807980cfce.png" width="350" /></a> |
