### PR TITLE
UL&S: Gravatar + Email UITableViewCell base UI and example

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.7"
+  s.version       = "1.22.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.6"
+  s.version       = "1.22.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -121,8 +121,8 @@
 		CE1B18D220EEC44400BECC3F /* WordPressAuthenticatorStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */; };
 		CE1BBF8324D348CD001D2E3E /* UnifiedSignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */; };
 		CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */; };
-		CE1BBF8824D46A19001D2E3E /* GravatarEmailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8624D46A19001D2E3E /* GravatarEmailTableViewCell.swift */; };
-		CE1BBF8924D46A19001D2E3E /* GravatarEmailTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8724D46A19001D2E3E /* GravatarEmailTableViewCell.xib */; };
+		CE1BBF8C24D48580001D2E3E /* GravatarEmailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8A24D4857F001D2E3E /* GravatarEmailTableViewCell.swift */; };
+		CE1BBF8D24D48580001D2E3E /* GravatarEmailTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8B24D48580001D2E3E /* GravatarEmailTableViewCell.xib */; };
 		CE30A2A722579F4100DF3CDA /* LoginUsernamePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */; };
 		CE30A2A92257C60500DF3CDA /* WordPressOrgCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */; };
 		CE30A2AD2257CECC00DF3CDA /* AuthenticatorCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */; };
@@ -298,8 +298,8 @@
 		CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorStyles.swift; sourceTree = "<group>"; };
 		CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSignUpViewController.swift; sourceTree = "<group>"; };
 		CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UnifiedSignUp.storyboard; sourceTree = "<group>"; };
-		CE1BBF8624D46A19001D2E3E /* GravatarEmailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GravatarEmailTableViewCell.swift; sourceTree = "<group>"; };
-		CE1BBF8724D46A19001D2E3E /* GravatarEmailTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GravatarEmailTableViewCell.xib; sourceTree = "<group>"; };
+		CE1BBF8A24D4857F001D2E3E /* GravatarEmailTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarEmailTableViewCell.swift; sourceTree = "<group>"; };
+		CE1BBF8B24D48580001D2E3E /* GravatarEmailTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GravatarEmailTableViewCell.xib; sourceTree = "<group>"; };
 		CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginUsernamePasswordViewController.swift; sourceTree = "<group>"; };
 		CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentials.swift; sourceTree = "<group>"; };
 		CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatorCredentials.swift; sourceTree = "<group>"; };
@@ -730,14 +730,14 @@
 		CEC77C70248AB0C700FB9050 /* Reusable Views */ = {
 			isa = PBXGroup;
 			children = (
+				CE1BBF8A24D4857F001D2E3E /* GravatarEmailTableViewCell.swift */,
+				CE1BBF8B24D48580001D2E3E /* GravatarEmailTableViewCell.xib */,
 				CE6BCD3624A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.swift */,
 				CE6BCD3724A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib */,
 				CE6BCD2C24A3A235001BCDC5 /* TextLabelTableViewCell.swift */,
 				CE6BCD2D24A3A235001BCDC5 /* TextLabelTableViewCell.xib */,
 				CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */,
 				CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */,
-				CE1BBF8624D46A19001D2E3E /* GravatarEmailTableViewCell.swift */,
-				CE1BBF8724D46A19001D2E3E /* GravatarEmailTableViewCell.xib */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -873,7 +873,7 @@
 				988AD8A724CB8C0400BD045E /* TwoFA.storyboard in Resources */,
 				B5609118208A555600399AE4 /* SearchTableViewCell.xib in Resources */,
 				98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */,
-				CE1BBF8924D46A19001D2E3E /* GravatarEmailTableViewCell.xib in Resources */,
+				CE1BBF8D24D48580001D2E3E /* GravatarEmailTableViewCell.xib in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
 				CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */,
 				CE6BCD3924A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib in Resources */,
@@ -1120,7 +1120,7 @@
 				B56090D0208A4F5400399AE4 /* NUXViewControllerBase.swift in Sources */,
 				3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */,
 				98D9A4B12474A526002E491C /* GoogleAuthenticator.swift in Sources */,
-				CE1BBF8824D46A19001D2E3E /* GravatarEmailTableViewCell.swift in Sources */,
+				CE1BBF8C24D48580001D2E3E /* GravatarEmailTableViewCell.swift in Sources */,
 				B56090DE208A4F9D00399AE4 /* WPWalkthroughOverlayView.m in Sources */,
 				B560910A208A54F800399AE4 /* WordPressComAccountService.swift in Sources */,
 				B56090FA208A533200399AE4 /* WordPressAuthenticator.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -121,6 +121,8 @@
 		CE1B18D220EEC44400BECC3F /* WordPressAuthenticatorStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */; };
 		CE1BBF8324D348CD001D2E3E /* UnifiedSignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */; };
 		CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */; };
+		CE1BBF8824D46A19001D2E3E /* GravatarEmailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8624D46A19001D2E3E /* GravatarEmailTableViewCell.swift */; };
+		CE1BBF8924D46A19001D2E3E /* GravatarEmailTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8724D46A19001D2E3E /* GravatarEmailTableViewCell.xib */; };
 		CE30A2A722579F4100DF3CDA /* LoginUsernamePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */; };
 		CE30A2A92257C60500DF3CDA /* WordPressOrgCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */; };
 		CE30A2AD2257CECC00DF3CDA /* AuthenticatorCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */; };
@@ -296,6 +298,8 @@
 		CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorStyles.swift; sourceTree = "<group>"; };
 		CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSignUpViewController.swift; sourceTree = "<group>"; };
 		CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UnifiedSignUp.storyboard; sourceTree = "<group>"; };
+		CE1BBF8624D46A19001D2E3E /* GravatarEmailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GravatarEmailTableViewCell.swift; sourceTree = "<group>"; };
+		CE1BBF8724D46A19001D2E3E /* GravatarEmailTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GravatarEmailTableViewCell.xib; sourceTree = "<group>"; };
 		CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginUsernamePasswordViewController.swift; sourceTree = "<group>"; };
 		CE30A2A82257C60500DF3CDA /* WordPressOrgCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentials.swift; sourceTree = "<group>"; };
 		CE30A2AC2257CECC00DF3CDA /* AuthenticatorCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatorCredentials.swift; sourceTree = "<group>"; };
@@ -732,6 +736,8 @@
 				CE6BCD2D24A3A235001BCDC5 /* TextLabelTableViewCell.xib */,
 				CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */,
 				CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */,
+				CE1BBF8624D46A19001D2E3E /* GravatarEmailTableViewCell.swift */,
+				CE1BBF8724D46A19001D2E3E /* GravatarEmailTableViewCell.xib */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -867,6 +873,7 @@
 				988AD8A724CB8C0400BD045E /* TwoFA.storyboard in Resources */,
 				B5609118208A555600399AE4 /* SearchTableViewCell.xib in Resources */,
 				98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */,
+				CE1BBF8924D46A19001D2E3E /* GravatarEmailTableViewCell.xib in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
 				CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */,
 				CE6BCD3924A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib in Resources */,
@@ -1113,6 +1120,7 @@
 				B56090D0208A4F5400399AE4 /* NUXViewControllerBase.swift in Sources */,
 				3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */,
 				98D9A4B12474A526002E491C /* GoogleAuthenticator.swift in Sources */,
+				CE1BBF8824D46A19001D2E3E /* GravatarEmailTableViewCell.swift in Sources */,
 				B56090DE208A4F9D00399AE4 /* WPWalkthroughOverlayView.m in Sources */,
 				B560910A208A54F800399AE4 /* WordPressComAccountService.swift in Sources */,
 				B56090FA208A533200399AE4 /* WordPressAuthenticator.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -16,6 +16,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     /// Strings: primary call-to-action button titles.
     ///
     public let continueButtonTitle: String
+    public let magicLinkButtonTitle: String
     
     /// Large titles displayed in unified auth flows.
     ///
@@ -46,6 +47,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 twoFactorInstructions: String,
                 magicLinkInstructions: String,
                 continueButtonTitle: String,
+                magicLinkButtonTitle: String,
                 findSiteButtonTitle: String,
                 resetPasswordButtonTitle: String,
                 textCodeButtonTitle: String,
@@ -64,6 +66,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.twoFactorInstructions = twoFactorInstructions
         self.magicLinkInstructions = magicLinkInstructions
         self.continueButtonTitle = continueButtonTitle
+        self.magicLinkButtonTitle = magicLinkButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
         self.textCodeButtonTitle = textCodeButtonTitle
@@ -91,9 +94,12 @@ public extension WordPressAuthenticatorDisplayStrings {
 														  comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
             twoFactorInstructions: NSLocalizedString("Please enter the verification code from your authenticator app, or tap the link below to receive a code via SMS.",
                                                      comment: "Instruction text on the two-factor screen."),
-            magicLinkInstructions: NSLocalizedString("We'll email you a magic link to create your new WordPress.com account.", comment: ""),
+            magicLinkInstructions: NSLocalizedString("We'll email you a magic link to create your new WordPress.com account.",
+                                                     comment: "Instruction text on the Sign Up screen."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                     comment: "The button title text when there is a next step for logging in or signing up."),
+            magicLinkButtonTitle: NSLocalizedString("Send Link by Email",
+                                                    comment: "The button title text for sending a magic link."),
             findSiteButtonTitle: NSLocalizedString("Find your site address",
                                                    comment: "The hint button's title text to help users find their site address."),
             resetPasswordButtonTitle: NSLocalizedString("Reset your password",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -11,6 +11,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let siteLoginInstructions: String
 	public let siteCredentialInstructions: String
     public let twoFactorInstructions: String
+    public let magicLinkInstructions: String
 
     /// Strings: primary call-to-action button titles.
     ///
@@ -43,6 +44,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 siteLoginInstructions: String,
 				siteCredentialInstructions: String,
                 twoFactorInstructions: String,
+                magicLinkInstructions: String,
                 continueButtonTitle: String,
                 findSiteButtonTitle: String,
                 resetPasswordButtonTitle: String,
@@ -60,6 +62,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.siteLoginInstructions = siteLoginInstructions
 		self.siteCredentialInstructions = siteCredentialInstructions
         self.twoFactorInstructions = twoFactorInstructions
+        self.magicLinkInstructions = magicLinkInstructions
         self.continueButtonTitle = continueButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
@@ -88,6 +91,7 @@ public extension WordPressAuthenticatorDisplayStrings {
 														  comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
             twoFactorInstructions: NSLocalizedString("Please enter the verification code from your authenticator app, or tap the link below to receive a code via SMS.",
                                                      comment: "Instruction text on the two-factor screen."),
+            magicLinkInstructions: NSLocalizedString("We'll email you a magic link to create your new WordPress.com account.", comment: ""),
             continueButtonTitle: NSLocalizedString("Continue",
                                                     comment: "The button title text when there is a next step for logging in or signing up."),
             findSiteButtonTitle: NSLocalizedString("Find your site address",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -163,6 +163,10 @@ public struct WordPressAuthenticatorUnifiedStyle {
     ///
     public let textColor: UIColor
 
+    /// Style: Auth subtle text color
+    ///
+    public let textSubtleColor: UIColor
+
     /// Style: Auth plain text button normal state color
     ///
     public let textButtonColor: UIColor
@@ -190,6 +194,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
     public init(borderColor: UIColor,
                 errorColor: UIColor,
                 textColor: UIColor,
+                textSubtleColor: UIColor,
                 textButtonColor: UIColor,
                 textButtonHighlightColor: UIColor,
                 viewControllerBackgroundColor: UIColor,
@@ -200,6 +205,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
         self.borderColor = borderColor
         self.errorColor = errorColor
         self.textColor = textColor
+        self.textSubtleColor = textSubtleColor
         self.textButtonColor = textButtonColor
         self.textButtonHighlightColor = textButtonHighlightColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -15,16 +15,11 @@ class GravatarEmailTableViewCell: UITableViewCell {
     ///
     public static let reuseIdentifier = "GravatarEmailTableViewCell"
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-
-        emailLabel.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
-        emailLabel.font = UIFont.preferredFont(forTextStyle: .body)
-    }
-
     public func configureImage(_ image: UIImage?, text: String?) {
         gravatarImageView?.image = image
         emailLabel.text = text
+        emailLabel.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        emailLabel.font = UIFont.preferredFont(forTextStyle: .body)
     }
 
     /// Override methods

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -17,9 +17,9 @@ class GravatarEmailTableViewCell: UITableViewCell {
 
     public func configureImage(_ image: UIImage?, text: String?) {
         gravatarImageView?.image = image
-        gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         emailLabel?.text = text
-        emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+
+/// GravatarEmailTableViewCell: Gravatar image + Email address in a UITableViewCell.
+/// - Note: Why not use a default-style UITableViewCell? Because it still uses springs and struts!
+///
+class GravatarEmailTableViewCell: UITableViewCell {
+
+    /// Private properties
+    ///
+    @IBOutlet private weak var gravatarImageView: UIImageView?
+    @IBOutlet private weak var label: UILabel!
+
+    /// Public properties
+    ///
+    public static let reuseIdentifier = "GravatarEmailTableViewCell"
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        label.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+    }
+
+    public func configureImage(_ image: UIImage?, text: String?) {
+        gravatarImageView?.image = image
+        label.text = text
+    }
+
+    /// Override methods
+    ///
+    public override func prepareForReuse() {
+        label.text = nil
+    }
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -9,7 +9,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     /// Private properties
     ///
     @IBOutlet private weak var gravatarImageView: UIImageView?
-    @IBOutlet private weak var emailLabel: UILabel!
+    @IBOutlet private weak var emailLabel: UILabel?
 
     /// Public properties
     ///
@@ -17,14 +17,15 @@ class GravatarEmailTableViewCell: UITableViewCell {
 
     public func configureImage(_ image: UIImage?, text: String?) {
         gravatarImageView?.image = image
-        emailLabel.text = text
-        emailLabel.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
-        emailLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        emailLabel?.text = text
+        emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
     }
 
     /// Override methods
     ///
     public override func prepareForReuse() {
-        emailLabel.text = nil
+        emailLabel?.text = nil
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -9,7 +9,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     /// Private properties
     ///
     @IBOutlet private weak var gravatarImageView: UIImageView?
-    @IBOutlet private weak var label: UILabel!
+    @IBOutlet private weak var emailLabel: UILabel!
 
     /// Public properties
     ///
@@ -18,18 +18,18 @@ class GravatarEmailTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        label.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
-        label.font = UIFont.preferredFont(forTextStyle: .body)
+        emailLabel.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        emailLabel.font = UIFont.preferredFont(forTextStyle: .body)
     }
 
     public func configureImage(_ image: UIImage?, text: String?) {
         gravatarImageView?.image = image
-        label.text = text
+        emailLabel.text = text
     }
 
     /// Override methods
     ///
     public override func prepareForReuse() {
-        label.text = nil
+        emailLabel.text = nil
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticatorResources">
             <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
@@ -43,8 +43,8 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="emailLabel" destination="jle-eu-TeA" id="Xcz-5J-X5z"/>
                 <outlet property="gravatarImageView" destination="odI-Gb-fXa" id="eHP-78-0Fg"/>
-                <outlet property="label" destination="jle-eu-TeA" id="3VS-8N-gve"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>
         </tableViewCell>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -13,7 +13,7 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticator">
             <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
@@ -40,6 +40,7 @@
                     <constraint firstAttribute="trailingMargin" secondItem="jle-eu-TeA" secondAttribute="trailing" id="IUZ-dB-QnU"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="kVa-7e-I73"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="mKZ-7r-7KE"/>
+                    <constraint firstAttribute="bottom" secondItem="odI-Gb-fXa" secondAttribute="bottom" id="rbk-nC-l0W"/>
                     <constraint firstItem="jle-eu-TeA" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="zuD-0q-QlE"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -26,19 +26,21 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jle-eu-TeA" userLabel="Email Label">
-                        <rect key="frame" x="72" y="11" width="232" height="51"/>
+                        <rect key="frame" x="72" y="9" width="232" height="44"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="QBs-7U-E3W"/>
+                        </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="topMargin" secondItem="jle-eu-TeA" secondAttribute="top" id="6XX-Lt-OIj"/>
                     <constraint firstItem="jle-eu-TeA" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="16" id="8Wx-qB-Fs2"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="jle-eu-TeA" secondAttribute="bottom" id="H6p-O8-1R7"/>
                     <constraint firstAttribute="trailingMargin" secondItem="jle-eu-TeA" secondAttribute="trailing" id="IUZ-dB-QnU"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="kVa-7e-I73"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="mKZ-7r-7KE"/>
+                    <constraint firstItem="jle-eu-TeA" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="zuD-0q-QlE"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa">
+                        <rect key="frame" x="16" y="11" width="40" height="40"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="40" id="RU3-mW-PAl"/>
+                            <constraint firstAttribute="width" secondItem="odI-Gb-fXa" secondAttribute="height" multiplier="1:1" id="TSH-sA-5Pw"/>
+                            <constraint firstAttribute="width" constant="40" id="oKU-lB-dYx"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jle-eu-TeA">
+                        <rect key="frame" x="72" y="11" width="232" height="51"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="topMargin" secondItem="jle-eu-TeA" secondAttribute="top" id="6XX-Lt-OIj"/>
+                    <constraint firstItem="jle-eu-TeA" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="16" id="8Wx-qB-Fs2"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="jle-eu-TeA" secondAttribute="bottom" id="H6p-O8-1R7"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="jle-eu-TeA" secondAttribute="trailing" id="IUZ-dB-QnU"/>
+                    <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="kVa-7e-I73"/>
+                    <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="mKZ-7r-7KE"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="gravatarImageView" destination="odI-Gb-fXa" id="eHP-78-0Fg"/>
+                <outlet property="label" destination="jle-eu-TeA" id="3VS-8N-gve"/>
+            </connections>
+            <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticatorResources">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticator">
             <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
@@ -25,7 +25,7 @@
                             <constraint firstAttribute="width" constant="40" id="oKU-lB-dYx"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jle-eu-TeA">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jle-eu-TeA" userLabel="Email Label">
                         <rect key="frame" x="72" y="11" width="232" height="51"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
@@ -43,7 +43,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="emailLabel" destination="jle-eu-TeA" id="Xcz-5J-X5z"/>
+                <outlet property="emailLabel" destination="jle-eu-TeA" id="qlq-dw-hT2"/>
                 <outlet property="gravatarImageView" destination="odI-Gb-fXa" id="eHP-78-0Fg"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
@@ -22,6 +22,10 @@
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uMq-La-HEm">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="547"/>
                                         <sections/>
+                                        <connections>
+                                            <outlet property="dataSource" destination="eEV-Dl-qyz" id="Kql-sH-scf"/>
+                                            <outlet property="delegate" destination="eEV-Dl-qyz" id="gJT-2W-j3C"/>
+                                        </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UFq-9y-0cn" userLabel="Button background view">
                                         <rect key="frame" x="0.0" y="547" width="375" height="76"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
@@ -77,7 +77,6 @@
                     </view>
                     <navigationItem key="navigationItem" id="5lc-hf-cia"/>
                     <connections>
-                        <outlet property="bottomContentConstraint" destination="A5i-l6-R2a" id="elI-gU-ibK"/>
                         <outlet property="submitButton" destination="4e9-BU-PNb" id="GSH-Hx-8G0"/>
                         <outlet property="tableView" destination="uMq-La-HEm" id="uaR-Kf-8hW"/>
                         <outlet property="tableViewLeadingConstraint" destination="xs1-4O-GeZ" id="hDa-A6-doE"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -91,6 +91,7 @@ private extension UnifiedSignUpViewController {
     ///
     func registerTableViewCells() {
         let cells = [
+            GravatarEmailTableViewCell.reuseIdentifier: GravatarEmailTableViewCell.loadNib(),
             TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib()
         ]
 
@@ -102,7 +103,7 @@ private extension UnifiedSignUpViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.instructions]
+        rows = [.gravatarEmail, .instructions]
 
         if errorMessage != nil {
             rows.append(.errorMessage)
@@ -113,6 +114,8 @@ private extension UnifiedSignUpViewController {
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
+        case let cell as GravatarEmailTableViewCell:
+            configureGravatarEmail(cell)
         case let cell as TextLabelTableViewCell where row == .instructions:
             configureInstructionLabel(cell)
         case let cell as TextLabelTableViewCell where row == .errorMessage:
@@ -120,6 +123,12 @@ private extension UnifiedSignUpViewController {
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
+    }
+
+    /// Configure the gravtar + email cell.
+    ///
+    func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
+        cell.configureImage(UIImage.gridicon(.user), text: "unknownuser@example.com")
     }
 
     /// Configure the instruction cell.
@@ -139,11 +148,14 @@ private extension UnifiedSignUpViewController {
     /// Rows listed in the order they were created.
     ///
     enum Row {
+        case gravatarEmail
         case instructions
         case errorMessage
 
         var reuseIdentifier: String {
             switch self {
+            case .gravatarEmail:
+                return GravatarEmailTableViewCell.reuseIdentifier
             case .instructions:
                 return TextLabelTableViewCell.reuseIdentifier
             case .errorMessage:

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -49,6 +49,13 @@ class UnifiedSignUpViewController: LoginViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
+
+    /// Override the title on 'submit' button
+    ///
+    override func localizePrimaryButton() {
+        submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.magicLinkButtonTitle, for: .normal)
+        submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.magicLinkButtonTitle, for: .highlighted)
+    }
 }
 
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -7,10 +7,6 @@ class UnifiedSignUpViewController: LoginViewController {
     /// Private properties.
     ///
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
-
-    // Required for `NUXKeyboardResponder` but unused here.
-    var verticalCenterConstraint: NSLayoutConstraint?
 
     private var rows = [Row]()
     private var errorMessage: String?

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -128,7 +128,7 @@ private extension UnifiedSignUpViewController {
     /// Configure the gravtar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        cell.configureImage(UIImage.gridicon(.user), text: "unknownuser@example.com")
+        cell.configureImage(UIImage.gridicon(.userCircle), text: "unknownuser@example.com")
     }
 
     /// Configure the instruction cell.

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -46,6 +46,8 @@ class UnifiedSignUpViewController: LoginViewController {
         view.backgroundColor = unifiedBackgroundColor
     }
 
+    /// Style individual ViewController status bars.
+    ///
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
@@ -55,6 +57,11 @@ class UnifiedSignUpViewController: LoginViewController {
     override func localizePrimaryButton() {
         submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.magicLinkButtonTitle, for: .normal)
         submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.magicLinkButtonTitle, for: .highlighted)
+    }
+
+    /// Reload the tableview and show errors, if any.
+    ///
+    override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -62,6 +62,11 @@ class UnifiedSignUpViewController: LoginViewController {
     /// Reload the tableview and show errors, if any.
     ///
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
+        if errorMessage != message {
+            errorMessage = message
+            shouldChangeVoiceOverFocus = moveVoiceOverFocus
+            tableView.reloadData()
+        }
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -53,8 +53,81 @@ class UnifiedSignUpViewController: LoginViewController {
     }
 }
 
+
+// MARK: - UITableViewDataSource
+extension UnifiedSignUpViewController: UITableViewDataSource {
+
+    /// Returns the number of rows in a section.
+    ///
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return rows.count
+    }
+
+    /// Configure cells delegate method.
+    ///
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+
+// MARK: - UITableViewDelegate conformance
+extension UnifiedSignUpViewController: UITableViewDelegate { }
+
+
 // MARK: - Private methods
 private extension UnifiedSignUpViewController {
+
+    /// Registers all of the available TableViewCells.
+    ///
+    func registerTableViewCells() {
+        let cells = [
+            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib()
+        ]
+
+        for (reuseIdentifier, nib) in cells {
+            tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
+        }
+    }
+
+    /// Describes how the tableView rows should be rendered.
+    ///
+    func loadRows() {
+        rows = [.instructions]
+
+        if errorMessage != nil {
+            rows.append(.errorMessage)
+        }
+    }
+
+    /// Configure cells.
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TextLabelTableViewCell where row == .instructions:
+            configureInstructionLabel(cell)
+        case let cell as TextLabelTableViewCell where row == .errorMessage:
+            configureErrorLabel(cell)
+        default:
+            DDLogError("Error: Unidentified tableViewCell type found.")
+        }
+    }
+
+    /// Configure the instruction cell.
+    ///
+    func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.magicLinkInstructions, style: .body)
+    }
+
+    /// Configure the error message cell.
+    ///
+    func configureErrorLabel(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: errorMessage, style: .error)
+    }
 
     // MARK: - Private Constants
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -56,7 +56,6 @@ class UnifiedSignUpViewController: LoginViewController {
     ///
     override func localizePrimaryButton() {
         submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.magicLinkButtonTitle, for: .normal)
-        submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.magicLinkButtonTitle, for: .highlighted)
     }
 
     /// Reload the tableview and show errors, if any.

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -33,6 +33,8 @@ class UnifiedSignUpViewController: LoginViewController {
         setTableViewMargins(forWidth: view.frame.width)
 
         localizePrimaryButton()
+        registerTableViewCells()
+        loadRows()
     }
 
     // MARK: - Overrides

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -13,6 +13,8 @@ class UnifiedSignUpViewController: LoginViewController {
     var verticalCenterConstraint: NSLayoutConstraint?
 
     private var rows = [Row]()
+    private var errorMessage: String?
+    private var shouldChangeVoiceOverFocus: Bool = false
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -12,6 +12,8 @@ class UnifiedSignUpViewController: LoginViewController {
     // Required for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?
 
+    private var rows = [Row]()
+
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
 
@@ -46,5 +48,27 @@ class UnifiedSignUpViewController: LoginViewController {
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
+    }
+}
+
+// MARK: - Private methods
+private extension UnifiedSignUpViewController {
+
+    // MARK: - Private Constants
+
+    /// Rows listed in the order they were created.
+    ///
+    enum Row {
+        case instructions
+        case errorMessage
+
+        var reuseIdentifier: String {
+            switch self {
+            case .instructions:
+                return TextLabelTableViewCell.reuseIdentifier
+            case .errorMessage:
+                return TextLabelTableViewCell.reuseIdentifier
+            }
+        }
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -272,7 +272,6 @@ private extension SiteAddressViewController {
         cell.configureLabel(text: errorMessage, style: .error)
     }
 
-
     // MARK: - Private Constants
 
     /// Rows listed in the order they were created.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -72,6 +72,8 @@ final class SiteAddressViewController: LoginViewController {
         view.backgroundColor = unifiedBackgroundColor
     }
 
+    /// Style individual ViewController status bars.
+    ///
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
@@ -108,6 +110,8 @@ final class SiteAddressViewController: LoginViewController {
         }
     }
 
+    /// Reload the tableview and show errors, if any.
+    ///
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
         if errorMessage != message {
             errorMessage = message


### PR DESCRIPTION
Closes #349 
Ref. #345 

Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14555

This PR adds the GravatarEmailTableViewCell base UI. The work in the UnifiedSignUpViewController displays an example gravatar email cell. Note that "Send Link by Email" button isn't implemented, nor is this view properly connected to the "sign up with email" view controller yet.

**Design**
<img width="344" alt="Screen Shot 2020-07-31 at 1 21 35 PM" src="https://user-images.githubusercontent.com/1062444/89065133-d4c82980-d330-11ea-8bf9-3cebb5e8ff7d.png">

**iPhone 11 Pro Max**
| Light mode | Dark mode |
| --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/89065079-b8c48800-d330-11ea-932b-9b9e2816e560.png"><img src="https://user-images.githubusercontent.com/1062444/89065079-b8c48800-d330-11ea-932b-9b9e2816e560.png" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/89065279-fb866000-d330-11ea-9e55-e85d113220eb.png"><img src="https://user-images.githubusercontent.com/1062444/89065279-fb866000-d330-11ea-9e55-e85d113220eb.png" width="350" /></a> |
