### PR TITLE
ULS: Show unified 2FA view for Apple

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.7"
+  s.version       = "1.22.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.8"
+  s.version       = "1.22.0-beta.9"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -82,6 +82,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableUnifiedGoogle: Bool
 
+    /// Flag indicating if the unified Apple flow should display.
+    ///
+    let enableUnifiedApple: Bool
+    
     /// Flag indicating if signing up via Email should display.
     ///
     let enableUnifiedSignup: Bool
@@ -105,6 +109,7 @@ public struct WordPressAuthenticatorConfiguration {
                  displayHintButtons: Bool = true,
                  enableUnifiedSiteAddress: Bool = false,
                  enableUnifiedGoogle: Bool = false,
+                 enableUnifiedApple: Bool = false,
                  enableUnifiedSignup: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
@@ -124,6 +129,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableUnifiedSiteAddress = enableUnifiedAuth && enableUnifiedSiteAddress
         self.enableUnifiedGoogle = enableUnifiedAuth && enableUnifiedGoogle
         self.enableSignupWithGoogle = enableSignupWithGoogle
+        self.enableUnifiedApple = enableUnifiedAuth && enableUnifiedApple
         self.enableUnifiedSignup = enableUnifiedAuth && enableUnifiedSignup
     }
 }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -463,7 +463,16 @@ extension LoginViewController {
     func socialNeedsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         loginFields.nonceInfo = nonceInfo
         loginFields.nonceUserID = userID
-        
+
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedApple else {
+            presentLogin2FA()
+            return
+        }
+
+        presentUnified2FA()
+    }
+    
+    private func presentLogin2FA() {
         var properties = [AnyHashable:Any]()
         if let service = loginFields.meta.socialService?.rawValue {
             properties["source"] = service
@@ -483,6 +492,20 @@ extension LoginViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
     
+    private func presentUnified2FA() {
+        
+        // TODO: add Tracks. Old event:
+        // WordPressAuthenticator.track(.loginSocial2faNeeded, properties: properties)
+        
+        guard let vc = TwoFAViewController.instantiate(from: .twoFA) else {
+            DDLogError("Failed to navigate from LoginViewController to TwoFAViewController")
+            return
+        }
+        
+        vc.loginFields = loginFields
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
 }
 
 // MARK: - LoginSocialError delegate methods


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/336
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14556

This shows the new 2FA view when 2FA'ing Apple accounts. Specifically:
- _Does not_ have a WP password set.
- _Does_ have WP 2FA enabled.

<kbd>![2fa_view](https://user-images.githubusercontent.com/1816888/89067868-55852680-d32d-11ea-8c03-fdba76b5b259.png)</kbd>
