### PR TITLE
UL&S: Sign up: send magic link

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.9"
+  s.version       = "1.22.0-beta.11"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.11"
+  s.version       = "1.22.0-beta.12"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -11,22 +11,22 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticator">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="73"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa">
-                        <rect key="frame" x="16" y="11" width="40" height="40"/>
+                        <rect key="frame" x="11" y="11" width="48" height="48"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="40" id="RU3-mW-PAl"/>
+                            <constraint firstAttribute="height" constant="48" id="RU3-mW-PAl"/>
                             <constraint firstAttribute="width" secondItem="odI-Gb-fXa" secondAttribute="height" multiplier="1:1" id="TSH-sA-5Pw"/>
-                            <constraint firstAttribute="width" constant="40" id="oKU-lB-dYx"/>
+                            <constraint firstAttribute="width" constant="48" id="oKU-lB-dYx"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jle-eu-TeA" userLabel="Email Label">
-                        <rect key="frame" x="72" y="9" width="232" height="44"/>
+                        <rect key="frame" x="70" y="13" width="234" height="44"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="QBs-7U-E3W"/>
                         </constraints>
@@ -36,11 +36,11 @@
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="jle-eu-TeA" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="16" id="8Wx-qB-Fs2"/>
+                    <constraint firstItem="jle-eu-TeA" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="11" id="8Wx-qB-Fs2"/>
                     <constraint firstAttribute="trailingMargin" secondItem="jle-eu-TeA" secondAttribute="trailing" id="IUZ-dB-QnU"/>
-                    <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="kVa-7e-I73"/>
-                    <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="mKZ-7r-7KE"/>
-                    <constraint firstAttribute="bottom" secondItem="odI-Gb-fXa" secondAttribute="bottom" id="rbk-nC-l0W"/>
+                    <constraint firstItem="odI-Gb-fXa" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" constant="-2" id="YZD-yX-ic3"/>
+                    <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="hPB-Uy-lLS"/>
+                    <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="11" id="kVa-7e-I73"/>
                     <constraint firstItem="jle-eu-TeA" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="zuD-0q-QlE"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -14,7 +14,7 @@ class UnifiedSignUpViewController: LoginViewController {
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
-
+        requestAuthenticationLink()
     }
 
     // MARK: - View lifecycle

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -21,6 +21,9 @@ class UnifiedSignUpViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // TODO: Delete this line when the new sign up by email VC is ready.
+        loginFields.emailAddress = "unknownuser@example.com"
+
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -144,7 +144,7 @@ private extension UnifiedSignUpViewController {
     /// Configure the gravtar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        cell.configureImage(UIImage.gridicon(.userCircle), text: loginFields.username)
+        cell.configureImage(UIImage.gridicon(.userCircle, size: Constants.gravatarSize), text: loginFields.username)
     }
 
     /// Configure the instruction cell.
@@ -192,6 +192,10 @@ private extension UnifiedSignUpViewController {
                 return NSLocalizedString("We were unable to send you an email at this time. Please try again later.", comment: "Error message displayed when an error occurred sending the magic link email.")
             }
         }
+    }
+
+    struct Constants {
+        static let gravatarSize = CGSize(width: 48, height: 48)
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -177,19 +177,13 @@ private extension UnifiedSignUpViewController {
     }
 
     enum ErrorMessage: String {
-        case invalidEmail = "invalid_email"
         case availabilityCheckFail = "availability_check_fail"
-        case emailUnavailable = "email_unavailable"
         case magicLinkRequestFail = "magic_link_request_fail"
 
         func description() -> String {
             switch self {
-            case .invalidEmail:
-                return NSLocalizedString("Please enter a valid email address.", comment: "Error message displayed when the user attempts use an invalid email address.")
             case .availabilityCheckFail:
                 return NSLocalizedString("Unable to verify the email address. Please try again later.", comment: "Error message displayed when an error occurred checking for email availability.")
-            case .emailUnavailable:
-                return NSLocalizedString("Sorry, that email address is already being used!", comment: "Error message displayed when the entered email is not available.")
             case .magicLinkRequestFail:
                 return NSLocalizedString("We were unable to send you an email at this time. Please try again later.", comment: "Error message displayed when an error occurred sending the magic link email.")
             }

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -22,7 +22,7 @@ class UnifiedSignUpViewController: LoginViewController {
         super.viewDidLoad()
 
         // TODO: Delete this line when the new sign up by email VC is ready.
-        loginFields.emailAddress = "unknownuser@example.com"
+        loginFields.username = "unknownuser@example.com"
 
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)
@@ -142,7 +142,7 @@ private extension UnifiedSignUpViewController {
     /// Configure the gravtar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        cell.configureImage(UIImage.gridicon(.userCircle), text: loginFields.emailAddress)
+        cell.configureImage(UIImage.gridicon(.userCircle), text: loginFields.username)
     }
 
     /// Configure the instruction cell.
@@ -207,7 +207,7 @@ extension UnifiedSignUpViewController {
         configureSubmitButton(animating: true)
 
         let service = WordPressComAccountService()
-        service.requestSignupLink(for: loginFields.emailAddress,
+        service.requestSignupLink(for: loginFields.username,
                                   success: { [weak self] in
                                     self?.didRequestSignupLink()
                                     self?.configureSubmitButton(animating: false)

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -21,8 +21,10 @@ class UnifiedSignUpViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // TODO: Delete this line when the new sign up by email VC is ready.
+        // TODO: Delete these 2 lines when the new sign up by email VC is ready.
+        // Currently this helps us bypass the SignupEmailViewController.
         loginFields.username = "unknownuser@example.com"
+        loginFields.meta.emailMagicLinkSource = .signup
 
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -214,14 +214,14 @@ extension UnifiedSignUpViewController {
 
             }, failure: { [weak self] (error: Error) in
                 DDLogError("Request for signup link email failed.")
-                WordPressAuthenticator.track(.signupMagicLinkFailed)
+                // TODO: add new Tracks event. Old: .signupMagicLinkFailed
                 self?.displayError(message: ErrorMessage.magicLinkRequestFail.description())
                 self?.configureSubmitButton(animating: false)
         })
     }
 
     func didRequestSignupLink() {
-        WordPressAuthenticator.track(.signupMagicLinkRequested)
+        // TODO: add new Tracks event. Old: .signupMagicLinkRequested
         WordPressAuthenticator.storeLoginInfoForTokenAuth(loginFields)
 
         guard let vc = NUXLinkMailViewController.instantiate(from: .emailMagicLink) else {

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -139,8 +139,7 @@ private extension UnifiedSignUpViewController {
     /// Configure the gravtar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        // TODO: This will be loginFields.emailAddress once the new sign up by email VC is ready.
-        cell.configureImage(UIImage.gridicon(.userCircle), text: "unknownuser@example.com")
+        cell.configureImage(UIImage.gridicon(.userCircle), text: loginFields.emailAddress)
     }
 
     /// Configure the instruction cell.
@@ -205,7 +204,7 @@ extension UnifiedSignUpViewController {
         configureSubmitButton(animating: true)
 
         let service = WordPressComAccountService()
-        service.requestSignupLink(for: loginFields.username,
+        service.requestSignupLink(for: loginFields.emailAddress,
                                   success: { [weak self] in
                                     self?.didRequestSignupLink()
                                     self?.configureSubmitButton(animating: false)

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -139,6 +139,7 @@ private extension UnifiedSignUpViewController {
     /// Configure the gravtar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
+        // TODO: This will be loginFields.emailAddress once the new sign up by email VC is ready.
         cell.configureImage(UIImage.gridicon(.userCircle), text: "unknownuser@example.com")
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -144,7 +144,8 @@ private extension UnifiedSignUpViewController {
     /// Configure the gravtar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        cell.configureImage(UIImage.gridicon(.userCircle, size: Constants.gravatarSize), text: loginFields.username)
+        let gridicon = UIImage.gridicon(.userCircle, size: Constants.gridiconSize)
+        cell.configureImage(gridicon, text: loginFields.username)
     }
 
     /// Configure the instruction cell.
@@ -195,7 +196,7 @@ private extension UnifiedSignUpViewController {
     }
 
     struct Constants {
-        static let gravatarSize = CGSize(width: 48, height: 48)
+        static let gridiconSize = CGSize(width: 48, height: 48)
     }
 }
 


### PR DESCRIPTION
Ref. #345 
Closes #354

Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14562

This PR ports the "send magic link" functionality found in SignupEmailViewController to UnifiedSignUpViewController. It's currently bypassing email entry and email validation found in SignupEmailViewController, so if you submit an invalid email address, it will crash (on purpose).

| Send magic link | Magic link sent |
| --- | --- | 
| <a href="https://user-images.githubusercontent.com/1062444/89213653-089e8b80-d58b-11ea-8a18-2cc5af924340.png"><img src="https://user-images.githubusercontent.com/1062444/89213653-089e8b80-d58b-11ea-8a18-2cc5af924340.png" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/89213682-1227f380-d58b-11ea-9579-59fb40f05e45.png"><img src="https://user-images.githubusercontent.com/1062444/89213682-1227f380-d58b-11ea-9579-59fb40f05e45.png" width="350" /></a> |
 