### PR TITLE
ULS: add content to Password view

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.10"
+  s.version       = "1.22.0-beta.11"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -12,6 +12,8 @@ public struct WordPressAuthenticatorDisplayStrings {
 	public let siteCredentialInstructions: String
     public let twoFactorInstructions: String
     public let magicLinkInstructions: String
+    public let googlePasswordInstructions: String
+    public let applePasswordInstructions: String
 
     /// Strings: primary call-to-action button titles.
     ///
@@ -46,6 +48,8 @@ public struct WordPressAuthenticatorDisplayStrings {
 				siteCredentialInstructions: String,
                 twoFactorInstructions: String,
                 magicLinkInstructions: String,
+                googlePasswordInstructions: String,
+                applePasswordInstructions: String,
                 continueButtonTitle: String,
                 magicLinkButtonTitle: String,
                 findSiteButtonTitle: String,
@@ -65,6 +69,8 @@ public struct WordPressAuthenticatorDisplayStrings {
 		self.siteCredentialInstructions = siteCredentialInstructions
         self.twoFactorInstructions = twoFactorInstructions
         self.magicLinkInstructions = magicLinkInstructions
+        self.googlePasswordInstructions = googlePasswordInstructions
+        self.applePasswordInstructions = applePasswordInstructions
         self.continueButtonTitle = continueButtonTitle
         self.magicLinkButtonTitle = magicLinkButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
@@ -96,6 +102,10 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                      comment: "Instruction text on the two-factor screen."),
             magicLinkInstructions: NSLocalizedString("We'll email you a magic link to create your new WordPress.com account.",
                                                      comment: "Instruction text on the Sign Up screen."),
+            googlePasswordInstructions: NSLocalizedString("To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once.",
+                                                          comment: "Instructional text shown when requesting the user's password for Google login."),
+            applePasswordInstructions: NSLocalizedString("To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.",
+                                                         comment: "Instructional text shown when requesting the user's password for Apple login."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                     comment: "The button title text when there is a next step for logging in or signing up."),
             magicLinkButtonTitle: NSLocalizedString("Send Link by Email",

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -361,7 +361,7 @@ private extension TwoFAViewController {
     /// Configure the instruction cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
-        cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.twoFactorInstructions, style: .body)
+        cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.twoFactorInstructions)
     }
 
     /// Configure the textfield cell.

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -22,7 +22,6 @@ class PasswordViewController: LoginViewController {
     
     // Required for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?
-    // TODO: implement NUXKeyboardResponder support
     
     // MARK: - View
     
@@ -38,6 +37,20 @@ class PasswordViewController: LoginViewController {
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
+                                  keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
+
+        configureViewForEditingIfNeeded()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        unregisterForKeyboardEvents()
     }
     
     // MARK: - Overrides
@@ -73,6 +86,20 @@ extension PasswordViewController: UITableViewDataSource {
         return cell
     }
     
+}
+
+// MARK: - Keyboard Notifications
+
+extension PasswordViewController: NUXKeyboardResponder {
+    
+    @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
+        keyboardWillShow(notification)
+    }
+
+    @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
+        keyboardWillHide(notification)
+    }
+
 }
 
 // MARK: - Validation and Continue
@@ -195,6 +222,15 @@ private extension PasswordViewController {
         cell.configureLabel(text: errorMessage, style: .error)
     }
     
+    /// Configure the view for an editing state.
+    ///
+    func configureViewForEditingIfNeeded() {
+       // Check the helper to determine whether an editing state should be assumed.
+       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+       if SigninEditingState.signinEditingStateActive {
+           passwordField?.becomeFirstResponder()
+       }
+    }
     
     /// Rows listed in the order they were created.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -211,9 +211,9 @@ private extension PasswordViewController {
     ///
     func configureTextLinkButton(_ cell: TextLinkButtonTableViewCell) {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle, accessibilityTrait: .link)
-        cell.actionHandler = { [weak self] in
+        // cell.actionHandler = { [weak self] in
             // TODO: handle tap
-        }
+        //}
     }
     
     /// Configure the error message cell.


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/352
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14567

This adds content to the new Password view:
- Gravatar + email. Currently contains stub info.
- Instructions for Google or Apple. Is not displayed for WP accounts.
- Password field. When the view first appears, the field becomes first responder.
- `Reset your password` link. Is not yet functional.
- The `Continue` button is now pinned to the keyboard. Is not yet functional.


<kbd>![Simulator Screen Shot - iPhone 11 Pro Max - 2020-08-03 at 16 06 53](https://user-images.githubusercontent.com/1816888/89231908-8a9aae80-d5a3-11ea-980f-6a15c8dcc763.png)</kbd>