### PR TITLE
ULS: Password view: display user's email and Gravatar

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.13"
+  s.version       = "1.22.0-beta.14"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -110,6 +110,7 @@ private extension PasswordViewController {
     
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         // TODO: passwordy stuff
+        // configureViewLoading(true)
     }
     
 }
@@ -171,11 +172,10 @@ private extension PasswordViewController {
         }
     }
     
-    /// Configure the gravtar + email cell.
+    /// Configure the gravatar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        // TODO: update with user info
-        cell.configureImage(UIImage.gridicon(.userCircle), text: "unknownuser@example.com")
+        cell.configure(withEmail: loginFields.username)
     }
     
     /// Configure the instruction cell.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -11,21 +11,35 @@ class GravatarEmailTableViewCell: UITableViewCell {
     @IBOutlet private weak var gravatarImageView: UIImageView?
     @IBOutlet private weak var emailLabel: UILabel?
 
+    private let gridiconSize = CGSize(width: 48, height: 48)
+    
     /// Public properties
     ///
     public static let reuseIdentifier = "GravatarEmailTableViewCell"
 
-    public func configureImage(_ image: UIImage?, text: String?) {
-        gravatarImageView?.image = image
+    public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil) {
+        
         gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
-        emailLabel?.text = text
         emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        emailLabel?.text = email
+        
+        let gridicon = UIImage.gridicon(.userCircle, size: gridiconSize)
+        
+        guard let email = email,
+            email.isValidEmail() else {
+                gravatarImageView?.image = gridicon
+                return
+        }
+
+        gravatarImageView?.downloadGravatarWithEmail(email, placeholderImage: placeholderImage ?? gridicon)
     }
 
     /// Override methods
     ///
     public override func prepareForReuse() {
         emailLabel?.text = nil
+        gravatarImageView?.image = nil
     }
+    
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPress">
                         <rect key="frame" x="11" y="11" width="48" height="48"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="48" id="RU3-mW-PAl"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -141,11 +141,10 @@ private extension UnifiedSignUpViewController {
         }
     }
 
-    /// Configure the gravtar + email cell.
+    /// Configure the gravatar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        let gridicon = UIImage.gridicon(.userCircle, size: Constants.gridiconSize)
-        cell.configureImage(gridicon, text: loginFields.username)
+        cell.configure(withEmail: loginFields.username)
     }
 
     /// Configure the instruction cell.
@@ -195,9 +194,6 @@ private extension UnifiedSignUpViewController {
         }
     }
 
-    struct Constants {
-        static let gridiconSize = CGSize(width: 48, height: 48)
-    }
 }
 
 


### PR DESCRIPTION
Ref: #352 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14573

This refactors the `GravatarEmailTableViewCell`:
- The `gravatarImageView` is now a `CircularImageView`.
- The configure method now accepts and email and a placeholder image.
- If the email is valid, the gravatar is downloaded and displayed.
- If the email is not valid, or there is no gravatar, the `userCircle` gridicon is displayed.

Specifically for the Password view:
- The user's email is now displayed.
- The user's gravatar is displayed, if they have one.

| ![gravatar](https://user-images.githubusercontent.com/1816888/89355178-0108e080-d678-11ea-9b40-30f4bc097565.png) | ![no_gravatar](https://user-images.githubusercontent.com/1816888/89355133-da4aaa00-d677-11ea-83f5-400ee30d05ba.png) |
|--------|-------|

