### PR TITLE
Implement LegacyGoogleAuthenticatorTracker.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -43,6 +43,6 @@ Pod::Spec.new do |s|
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
-  s.dependency 'WordPressKit', '~> 4.0-beta.0' # Don't change this until we hit 5.0 in WPKit
-  s.dependency 'WordPressShared', '~> 1.9-beta' # Don't change this until we hit 2.0 in WPShared
+  s.dependency 'WordPressKit', '~> 4.14-beta' # Don't change this until we hit 5.0 in WPKit
+  s.dependency 'WordPressShared', '~> 1.10-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.13"
+  s.version       = "1.22.0-beta.15"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		F120765A24D9F5CA0032577C /* GoogleAuthenticatorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */; };
 		F12F9FB424D8A68E00771BCE /* AnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
+		F1F98B3E24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F98B3D24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift */; };
 		FF629D9622393500004C4106 /* WordPressAuthenticator.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */; };
 /* End PBXBuildFile section */
 
@@ -327,6 +328,7 @@
 		F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GoogleAuthenticatorTracker.swift; path = ../../../../Desktop/GoogleAuthenticatorTracker.swift; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
+		F1F98B3D24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyGoogleAuthenticatorTracker.swift; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
 		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
@@ -787,6 +789,7 @@
 			children = (
 				F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */,
 				F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */,
+				F1F98B3D24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -1162,6 +1165,7 @@
 				B56090EF208A527000399AE4 /* WPStyleGuide+Login.swift in Sources */,
 				B56090D0208A4F5400399AE4 /* NUXViewControllerBase.swift in Sources */,
 				3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */,
+				F1F98B3E24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift in Sources */,
 				98D9A4B12474A526002E491C /* GoogleAuthenticator.swift in Sources */,
 				CE1BBF8C24D48580001D2E3E /* GravatarEmailTableViewCell.swift in Sources */,
 				B56090DE208A4F9D00399AE4 /* WPWalkthroughOverlayView.m in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		CEDE0D952420121D00CB3345 /* UIStoryboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */; };
 		CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
+		F120765A24D9F5CA0032577C /* GoogleAuthenticatorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */; };
 		F12F9FB424D8A68E00771BCE /* AnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
 		FF629D9622393500004C4106 /* WordPressAuthenticator.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */; };
@@ -323,6 +324,7 @@
 		CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
+		F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GoogleAuthenticatorTracker.swift; path = ../../../../Desktop/GoogleAuthenticatorTracker.swift; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -784,6 +786,7 @@
 			isa = PBXGroup;
 			children = (
 				F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */,
+				F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -1084,6 +1087,7 @@
 				B5609120208A555E00399AE4 /* SignupNavigationController.swift in Sources */,
 				B5609143208A563800399AE4 /* LoginSocialErrorViewController.swift in Sources */,
 				B56090F8208A533200399AE4 /* WordPressAuthenticator+Notifications.swift in Sources */,
+				F120765A24D9F5CA0032577C /* GoogleAuthenticatorTracker.swift in Sources */,
 				98ED483624802F8F00992B2D /* GoogleAuthViewController.swift in Sources */,
 				B56090EA208A51D000399AE4 /* LoginFields+Validation.swift in Sources */,
 				CE1B18CC20EEC32400BECC3F /* WordPressComCredentials.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -142,10 +142,10 @@
 		CEDE0D952420121D00CB3345 /* UIStoryboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */; };
 		CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
-		F120765A24D9F5CA0032577C /* GoogleAuthenticatorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */; };
 		F12F9FB424D8A68E00771BCE /* AnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
 		F1F98B3E24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F98B3D24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift */; };
+		F1F98B4024DB1CC50099C295 /* LegacyGoogleAuthenticatorTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F98B3F24DB1CC50099C295 /* LegacyGoogleAuthenticatorTrackerTests.swift */; };
 		FF629D9622393500004C4106 /* WordPressAuthenticator.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */; };
 /* End PBXBuildFile section */
 
@@ -325,10 +325,10 @@
 		CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
-		F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GoogleAuthenticatorTracker.swift; path = ../../../../Desktop/GoogleAuthenticatorTracker.swift; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		F1F98B3D24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyGoogleAuthenticatorTracker.swift; sourceTree = "<group>"; };
+		F1F98B3F24DB1CC50099C295 /* LegacyGoogleAuthenticatorTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyGoogleAuthenticatorTrackerTests.swift; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
 		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
@@ -780,6 +780,7 @@
 			isa = PBXGroup;
 			children = (
 				F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */,
+				F1F98B3F24DB1CC50099C295 /* LegacyGoogleAuthenticatorTrackerTests.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -788,7 +789,6 @@
 			isa = PBXGroup;
 			children = (
 				F12F9FB324D8A68E00771BCE /* AnalyticsTracker.swift */,
-				F120765924D9F5CA0032577C /* GoogleAuthenticatorTracker.swift */,
 				F1F98B3D24DAFAA00099C295 /* LegacyGoogleAuthenticatorTracker.swift */,
 			);
 			path = Analytics;
@@ -1090,7 +1090,6 @@
 				B5609120208A555E00399AE4 /* SignupNavigationController.swift in Sources */,
 				B5609143208A563800399AE4 /* LoginSocialErrorViewController.swift in Sources */,
 				B56090F8208A533200399AE4 /* WordPressAuthenticator+Notifications.swift in Sources */,
-				F120765A24D9F5CA0032577C /* GoogleAuthenticatorTracker.swift in Sources */,
 				98ED483624802F8F00992B2D /* GoogleAuthViewController.swift in Sources */,
 				B56090EA208A51D000399AE4 /* LoginFields+Validation.swift in Sources */,
 				CE1B18CC20EEC32400BECC3F /* WordPressComCredentials.swift in Sources */,
@@ -1178,6 +1177,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1F98B4024DB1CC50099C295 /* LegacyGoogleAuthenticatorTrackerTests.swift in Sources */,
 				B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */,
 				3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */,
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,

--- a/WordPressAuthenticator/Analytics/LegacyGoogleAuthenticatorTracker.swift
+++ b/WordPressAuthenticator/Analytics/LegacyGoogleAuthenticatorTracker.swift
@@ -1,60 +1,91 @@
 import Foundation
 
-extension GoogleAuthenticatorTracker {
-    class LegacyGoogleAuthenticatorTracker {
+class LegacyGoogleAuthenticatorTracker {
+    
+    /// The method used for analytics tracking.  Useful for overriding in automated tests.
+    ///
+    typealias BackingTrackerMethod = (_ event: WPAnalyticsStat, _ properties: [String: String]) -> ()
+    
+    /// The method used for analytics tracking.  Useful for overriding in automated tests.
+    ///
+    private let backingTrackerMethod: BackingTrackerMethod
+    
+    // MARK: - Initializers
+    
+    init(track: @escaping BackingTrackerMethod = WPAnalytics.track) {
+        self.backingTrackerMethod = track
+    }
+    
+    // MARK: - Tracking Support
+    
+    /// Tracks events.  Overrides the `source` param so that it's set to `"google"`.
+    ///
+    func track(_ event: WPAnalyticsStat, properties: [String: String] = [:]) {
+        var trackProperties = properties
+        trackProperties["source"] = "google"
+        backingTrackerMethod(event, trackProperties)
+    }
+    
+    // MARK: - Tracking Specific Events
+    
+    func trackLoginButtonTapped() {
+        track(.loginSocialButtonClick)
+    }
+    
+    func trackCreateAccountInitiated() {
+        track(.createAccountInitiated)
+    }
+    
+    func trackSigninSuccess() {
+        track(.signedIn)
+        track(.loginSocialSuccess)
+    }
+    
+    func trackLoginButtonFailure(error: Error?) {
+        let errorMessage = error?.localizedDescription ?? "Unknown error"
+        let properties = ["error": errorMessage]
         
-        // MARK: - Tracking Support
+        track(.loginSocialButtonFailure, properties: properties)
+    }
+    
+    func trackSignupButtonFailure(error: Error?) {
+        let errorMessage = error?.localizedDescription ?? "Unknown error"
+        let properties = ["error": errorMessage]
         
-        /// Some of the methods we're tracking use `WPAnalyticsStat`.  This method offers legacy support so that we don't need to migrate
-        /// all of those methods to `AnalyticsEvent`.
-        ///
-        func track(_ event: WPAnalyticsStat, properties: [AnyHashable: Any] = [:]) {
-            var trackProperties = properties
-            trackProperties["source"] = "google"
-            WordPressAuthenticator.track(event, properties: trackProperties)
-        }
+        track(.signupSocialButtonFailure, properties: properties)
+    }
+    
+    func trackSignupFailure(error: Error) {
+        let errorMessage = error.localizedDescription
         
-        // MARK: - Tracking Specific Events
-        
-        func trackSignInStart(authType: GoogleAuthType) {
-            switch authType {
-            case .login:
-                track(.loginSocialButtonClick)
-            case .signup:
-                track(.createAccountInitiated)
-            }
-        }
-        
-        func trackSignInSuccess() {
-            track(.signedIn)
-            track(.loginSocialSuccess)
-        }
-        
-        func trackSignInFailure(authType: GoogleAuthType, errorMessage: String) {
-            let properties = ["error": errorMessage]
-
-            switch authType {
-            case .login:
-                track(.loginSocialButtonFailure, properties: properties)
-            case .signup:
-                track(.signupSocialButtonFailure, properties: properties)
-            }
-        }
-        
-        func trackSignUpFailure(errorMessage: String) {
-            track(.signupSocialFailure, properties: ["error": errorMessage])
-        }
-        
-        func trackLoginInstead() {
-            track(.signupSocialToLogin)
-            track(.signedIn)
-            track(.loginSocialSuccess)
-        }
-        
-        /// Tracks the request of a 2FA code to the user.
-        ///
-        func trackTwoFactorAuhenticationRequested() {
-            track(.loginSocial2faNeeded)
-        }
+        track(.signupSocialFailure, properties: ["error": errorMessage])
+    }
+    
+    func trackLoginInstead() {
+        track(.signedIn)
+        track(.signupSocialToLogin)
+        track(.loginSocialSuccess)
+    }
+    
+    /// Tracks the request of a 2FA code to the user.
+    ///
+    func trackTwoFactorAuhenticationRequested() {
+        track(.loginSocial2faNeeded)
+    }
+    
+    func trackWPPasswordNeeded() {
+        track(.loginSocialAccountsNeedConnecting)
+    }
+    
+    func trackSocialErrorUnknownUser() {
+        track(.loginSocialErrorUnknownUser)
+    }
+    
+    func trackAccountCreated() {
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
+        track(.createdAccount)
+        track(.signedIn)
+        track(.signupSocialSuccess)
     }
 }

--- a/WordPressAuthenticator/Analytics/LegacyGoogleAuthenticatorTracker.swift
+++ b/WordPressAuthenticator/Analytics/LegacyGoogleAuthenticatorTracker.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+extension GoogleAuthenticatorTracker {
+    class LegacyGoogleAuthenticatorTracker {
+        
+        // MARK: - Tracking Support
+        
+        /// Some of the methods we're tracking use `WPAnalyticsStat`.  This method offers legacy support so that we don't need to migrate
+        /// all of those methods to `AnalyticsEvent`.
+        ///
+        func track(_ event: WPAnalyticsStat, properties: [AnyHashable: Any] = [:]) {
+            var trackProperties = properties
+            trackProperties["source"] = "google"
+            WordPressAuthenticator.track(event, properties: trackProperties)
+        }
+        
+        // MARK: - Tracking Specific Events
+        
+        func trackSignInStart(authType: GoogleAuthType) {
+            switch authType {
+            case .login:
+                track(.loginSocialButtonClick)
+            case .signup:
+                track(.createAccountInitiated)
+            }
+        }
+        
+        func trackSignInSuccess() {
+            track(.signedIn)
+            track(.loginSocialSuccess)
+        }
+        
+        func trackSignInFailure(authType: GoogleAuthType, errorMessage: String) {
+            let properties = ["error": errorMessage]
+
+            switch authType {
+            case .login:
+                track(.loginSocialButtonFailure, properties: properties)
+            case .signup:
+                track(.signupSocialButtonFailure, properties: properties)
+            }
+        }
+        
+        func trackSignUpFailure(errorMessage: String) {
+            track(.signupSocialFailure, properties: ["error": errorMessage])
+        }
+        
+        func trackLoginInstead() {
+            track(.signupSocialToLogin)
+            track(.signedIn)
+            track(.loginSocialSuccess)
+        }
+        
+        /// Tracks the request of a 2FA code to the user.
+        ///
+        func trackTwoFactorAuhenticationRequested() {
+            track(.loginSocial2faNeeded)
+        }
+    }
+}

--- a/WordPressAuthenticatorTests/Analytics/LegacyGoogleAuthenticatorTrackerTests.swift
+++ b/WordPressAuthenticatorTests/Analytics/LegacyGoogleAuthenticatorTrackerTests.swift
@@ -1,0 +1,292 @@
+import XCTest
+@testable import WordPressAuthenticator
+
+class LegacyGoogleAuthenticatorTrackerTests: XCTestCase {
+    func testTrackLoginSocialButtonTapped() {
+        let expectedEventsTracked = expectation(description: "The expected events were tracked")
+        let expectedEvent: WPAnalyticsStat = .loginSocialButtonClick
+        let expectedProperties = [
+            "source": "google"
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventsTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackLoginButtonTapped()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackCreateAccountInitiated() {
+        let expectedEventsTracked = expectation(description: "The expected events were tracked")
+        let expectedEvent: WPAnalyticsStat = .createAccountInitiated
+        let expectedProperties = [
+            "source": "google"
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventsTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackCreateAccountInitiated()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackSigninSuccess() {
+        let expectedEventsTracked = [
+            expectation(description: "signedIn tracked"),
+            expectation(description: "loginSocialSuccess tracked"),
+        ]
+        let expectedEvents: [WPAnalyticsStat: XCTestExpectation] = [
+            .signedIn: expectedEventsTracked[0],
+            .loginSocialSuccess: expectedEventsTracked[1],
+        ]
+        let expectedProperties = [
+            "source": "google"
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            if expectedEvents.keys.contains(event) {
+                expectedEvents[event]?.fulfill()
+            }
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackSigninSuccess()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackLoginSocialButtonFailure() {
+        let expectedEventTracked = expectation(description: "The expected event was tracked")
+        let expectedEvent: WPAnalyticsStat = .loginSocialButtonFailure
+        let expectedErrorDescription = "test description"
+        let expectedError = NSError(
+            domain: "test domain",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey : expectedErrorDescription])
+        let expectedProperties = [
+            "source": "google",
+            "error": expectedErrorDescription,
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackLoginButtonFailure(error: expectedError)
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackSignupSocialButtonFailure() {
+        let expectedEventTracked = expectation(description: "The expected event was tracked")
+        let expectedEvent: WPAnalyticsStat = .signupSocialButtonFailure
+        let expectedErrorDescription = "test description"
+        let expectedError = NSError(
+            domain: "test domain",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey : expectedErrorDescription])
+        let expectedProperties = [
+            "source": "google",
+            "error": expectedErrorDescription,
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackSignupButtonFailure(error: expectedError)
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackSignupFailure() {
+        let expectedEventTracked = expectation(description: "The expected event was tracked")
+        let expectedEvent: WPAnalyticsStat = .signupSocialFailure
+        let expectedErrorDescription = "test description"
+        let expectedError = NSError(
+            domain: "test domain",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey : expectedErrorDescription])
+        let expectedProperties = [
+            "source": "google",
+            "error": expectedErrorDescription,
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackSignupFailure(error: expectedError)
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackLoginInstead() {
+        let expectedEventsTracked = [
+            expectation(description: "signedIn tracked"),
+            expectation(description: "signupSocialToLogin tracked"),
+            expectation(description: "loginSocialSuccess tracked"),
+        ]
+        let expectedEvents: [WPAnalyticsStat: XCTestExpectation] = [
+            .signedIn: expectedEventsTracked[0],
+            .signupSocialToLogin: expectedEventsTracked[1],
+            .loginSocialSuccess: expectedEventsTracked[2]
+        ]
+        let expectedProperties = [
+            "source": "google"
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            if expectedEvents.keys.contains(event) {
+                expectedEvents[event]?.fulfill()
+            }
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackLoginInstead()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackTwoFactorAuhenticationRequested() {
+        let expectedEventTracked = expectation(description: "The expected event was tracked")
+        let expectedEvent: WPAnalyticsStat = .loginSocial2faNeeded
+        let expectedProperties = [
+            "source": "google",
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackTwoFactorAuhenticationRequested()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackWPPasswordNeeded() {
+        let expectedEventTracked = expectation(description: "The expected event was tracked")
+        let expectedEvent: WPAnalyticsStat = .loginSocialAccountsNeedConnecting
+        let expectedProperties = [
+            "source": "google",
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackWPPasswordNeeded()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testTrackSocialErrorUnknownUser() {
+        let expectedEventTracked = expectation(description: "The expected event was tracked")
+        let expectedEvent: WPAnalyticsStat = .loginSocialErrorUnknownUser
+        let expectedProperties = [
+            "source": "google",
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard event == expectedEvent && properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            expectedEventTracked.fulfill()
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackSocialErrorUnknownUser()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testTrackAccountCreated() {
+        let expectedEventsTracked = [
+            expectation(description: "createdAccount tracked"),
+            expectation(description: "signedIn tracked"),
+            expectation(description: "signupSocialSuccess tracked"),
+        ]
+        let expectedEvents: [WPAnalyticsStat: XCTestExpectation] = [
+            .createdAccount: expectedEventsTracked[0],
+            .signedIn: expectedEventsTracked[1],
+            .signupSocialSuccess: expectedEventsTracked[2]
+        ]
+        let expectedProperties = [
+            "source": "google"
+        ]
+        
+        let trackingMethod: LegacyGoogleAuthenticatorTracker.BackingTrackerMethod = { (event, properties) in
+            guard properties == expectedProperties else {
+                XCTFail()
+                return
+            }
+            
+            if expectedEvents.keys.contains(event) {
+                expectedEvents[event]?.fulfill()
+            }
+        }
+        let tracker = LegacyGoogleAuthenticatorTracker(track: trackingMethod)
+        
+        tracker.trackAccountCreated()
+        
+        waitForExpectations(timeout: 0.1)
+    }
+}


### PR DESCRIPTION
Implements `LegacyGoogleAuthenticatorTracker` to group up the legacy tracking logic and to add unit tests to it before bringing in other changes.

There's more code coming up but this is in a PR of it's own since it's sensible code.

## Testing:

Make sure that the tracked events that were replaced in `GoogleAuthenticator.swift` with methods, are still tracking the same events inside those methods.

You can use branch `try/test-legacy-google-tracker` to test these changes in WPiOS and see that the events are coming up in the console.

Let me know if you want a precise list of test cases - I've tested several cases manually without seeing any issues and the code movement is fairly small.



