### PR TITLE
ULS Password view: Add password validation and forgot password link action.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.14"
+  s.version       = "1.22.0-beta.15"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -247,16 +247,13 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
         WordPressAuthenticator.track(.twoFactorCodeRequested)
 
-        guard let vc = Login2FAViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
+            loginFields.meta.socialService == .google else {
+            presentLogin2FA()
             return
         }
 
-        vc.loginFields = loginFields
-        vc.dismissBlock = dismissBlock
-        vc.errorToPresent = errorToPresent
-
-        navigationController?.pushViewController(vc, animated: true)
+        presentUnified2FA()
     }
 
     // Update safari stored credentials. Call after a successful sign in.

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -42,14 +42,15 @@ final class TwoFAViewController: LoginViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        
         super.viewDidAppear(animated)
-
-        configureSubmitButton(animating: false)
-        configureViewForEditingIfNeeded()
-
+        
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
-
+        
+        configureSubmitButton(animating: false)
+        configureViewForEditingIfNeeded()
+        
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(applicationBecameInactive), name: UIApplication.willResignActiveNotification, object: nil)
         nc.addObserver(self, selector: #selector(applicationBecameActive), name: UIApplication.didBecomeActiveNotification, object: nil)
@@ -165,6 +166,7 @@ private extension TwoFAViewController {
     }
 
     func loginWithNonce(info nonceInfo: SocialLogin2FANonceInfo) {
+        configureViewLoading(true)
         let code = loginFields.multifactorCode
         let (authType, nonce) = nonceInfo.authTypeAndNonce(for: code)
         loginFacade.loginToWordPressDotCom(withUser: loginFields.nonceUserID, authType: authType, twoStepCode: code, twoStepNonce: nonce)

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -96,6 +96,11 @@ final class TwoFAViewController: LoginViewController {
         )
     }
 
+    override func configureViewLoading(_ loading: Bool) {
+        super.configureViewLoading(loading)
+        codeField?.isEnabled = !loading
+    }
+    
     override func displayRemoteError(_ error: Error) {
         displayError(message: "")
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -16,7 +16,6 @@ class PasswordViewController: LoginViewController {
 
     override var loginFields: LoginFields {
         didSet {
-            // Clear the password (if any) from LoginFields.
             loginFields.password = ""
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -317,7 +317,7 @@ private extension SiteCredentialsViewController {
             }
 
             WordPressAuthenticator.openForgotPasswordURL(self.loginFields)
-            WordPressAuthenticator.track(.loginForgotPasswordClicked)
+            // TODO: add new tracks. Old track: WordPressAuthenticator.track(.loginForgotPasswordClicked)
         }
     }
 


### PR DESCRIPTION
Ref: #352 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14589

This change: 
- Copies the password validation from the old password VC (`LoginWPComViewController`) to the new one (`PasswordViewController`). 
- Enables the `Reset your password` link.
- Now shows the new 2FA view in the WP flow if it's in the unified Google flow.

| Invalid Password | Reset Password |
|--------|-------|
| ![invalid_password](https://user-images.githubusercontent.com/1816888/89467998-d67c5d80-d733-11ea-9168-8773993a5a6c.png) | ![reset_password](https://user-images.githubusercontent.com/1816888/89468018-dda36b80-d733-11ea-93cf-6dbf12001fc8.png) |