### PR TITLE
Fix issues in google auth basic tracking

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.16"
+  s.version       = "1.22.0-beta.17"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AnalyticsTracker.swift
@@ -215,9 +215,13 @@ public class AnalyticsTracker {
         case createAccount = "create_account"
     }
     
-    /// Provides the sign-in tracking state machine that can be shared across different trackers if needed.
+    /// Shared Instance.
     ///
-    public class Context {
+    public static var shared = AnalyticsTracker()
+    
+    /// State for the analytics tracker.
+    ///
+    private class State {
         var lastFlow: Flow
         var lastSource: Source
         var lastStep: Step
@@ -229,7 +233,7 @@ public class AnalyticsTracker {
         }
     }
     
-    let context: Context
+    private let state = State()
     
     /// The backing analytics tracking method.  Can be overridden for testing purposes.
     ///
@@ -237,8 +241,7 @@ public class AnalyticsTracker {
     
     // MARK: - Initializers
     
-    init(context: Context, track: @escaping TrackerMethod = WPAnalytics.track) {
-        self.context = context
+    init(track: @escaping TrackerMethod = WPAnalytics.track) {
         self.track = track
     }
     
@@ -317,13 +320,13 @@ public class AnalyticsTracker {
     // MARK: - Source
     
     func set(source: Source) {
-        context.lastSource = source
+        state.lastSource = source
     }
     
     // MARK: - Properties
     
     private func properties(step: Step, flow: Flow) -> [String: String] {
-        return properties(step: step, flow: flow, source: context.lastSource)
+        return properties(step: step, flow: flow, source: state.lastSource)
     }
     
     private func properties(step: Step, flow: Flow, source: Source) -> [String: String] {
@@ -339,13 +342,13 @@ public class AnalyticsTracker {
     /// Retrieve the last step, flow and source stored in the state machine.
     ///
     private func lastProperties() -> [String: String] {
-        return properties(step: context.lastStep, flow: context.lastFlow, source: context.lastSource)
+        return properties(step: state.lastStep, flow: state.lastFlow, source: state.lastSource)
     }
     
     /// Save the step and flow in the state machine.  The source can only be changed directly using `set(source:)`.
     ///
     private func saveLastProperties(step: Step, flow: Flow) {
-        context.lastFlow = flow
-        context.lastStep = step
+        state.lastFlow = flow
+        state.lastStep = step
     }
 }

--- a/WordPressAuthenticator/Analytics/AnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AnalyticsTracker.swift
@@ -238,7 +238,7 @@ public class AnalyticsTracker {
     /// The backing analytics tracking method.  Can be overridden for testing purposes.
     ///
     let track: TrackerMethod
-    
+
     // MARK: - Initializers
     
     init(track: @escaping TrackerMethod = WPAnalytics.track) {

--- a/WordPressAuthenticator/Analytics/AnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AnalyticsTracker.swift
@@ -249,8 +249,8 @@ public class AnalyticsTracker {
     
     /// Track a step within a flow.
     ///
-    func track(step: Step, flow: Flow) {
-        track(event(step: step, flow: flow))
+    func track(step: Step) {
+        track(event(step: step))
     }
     
     /// Track a click interaction.
@@ -275,12 +275,12 @@ public class AnalyticsTracker {
     ///
     /// - Returns: an analytics event representing the step.
     ///
-    private func event(step: Step, flow: Flow) -> AnalyticsEvent {
+    private func event(step: Step) -> AnalyticsEvent {
         let event = AnalyticsEvent(
             name: EventType.step.rawValue,
-            properties: properties(step: step, flow: flow))
+            properties: properties(step: step))
         
-        saveLastProperties(step: step, flow: flow)
+        state.lastStep = step
         
         return event
     }
@@ -317,7 +317,11 @@ public class AnalyticsTracker {
             properties: properties)
     }
     
-    // MARK: - Source
+    // MARK: - Source & Flow
+    
+    func set(flow: Flow) {
+        state.lastFlow = flow
+    }
     
     func set(source: Source) {
         state.lastSource = source
@@ -325,8 +329,8 @@ public class AnalyticsTracker {
     
     // MARK: - Properties
     
-    private func properties(step: Step, flow: Flow) -> [String: String] {
-        return properties(step: step, flow: flow, source: state.lastSource)
+    private func properties(step: Step) -> [String: String] {
+        return properties(step: step, flow: state.lastFlow, source: state.lastSource)
     }
     
     private func properties(step: Step, flow: Flow, source: Source) -> [String: String] {
@@ -337,18 +341,9 @@ public class AnalyticsTracker {
         ]
     }
     
-    // MARK: - Properties: state machine
-    
     /// Retrieve the last step, flow and source stored in the state machine.
     ///
     private func lastProperties() -> [String: String] {
         return properties(step: state.lastStep, flow: state.lastFlow, source: state.lastSource)
-    }
-    
-    /// Save the step and flow in the state machine.  The source can only be changed directly using `set(source:)`.
-    ///
-    private func saveLastProperties(step: Step, flow: Flow) {
-        state.lastFlow = flow
-        state.lastStep = step
     }
 }

--- a/WordPressAuthenticator/Analytics/GoogleAuthenticatorTracker.swift
+++ b/WordPressAuthenticator/Analytics/GoogleAuthenticatorTracker.swift
@@ -8,8 +8,8 @@ class GoogleAuthenticatorTracker {
     ///
     private let analyticsTracker: AnalyticsTracker
     
-    init(context: AnalyticsTracker.Context) {
-        self.analyticsTracker = AnalyticsTracker(context: context)
+    init(analyticsTracker: AnalyticsTracker) {
+        self.analyticsTracker = analyticsTracker
     }
     
     // MARK: -  Tracking Support

--- a/WordPressAuthenticator/Analytics/GoogleAuthenticatorTracker.swift
+++ b/WordPressAuthenticator/Analytics/GoogleAuthenticatorTracker.swift
@@ -17,13 +17,21 @@ class GoogleAuthenticatorTracker {
     func trackSigninStart(authType: GoogleAuthType) {
         switch authType {
         case .login:
-            analyticsTracker.set(flow: .googleLogin)
-            analyticsTracker.track(step: .start)
+            trackLoginStart()
         case .signup:
-            analyticsTracker.set(flow: .googleSignup)
-            analyticsTracker.track(step: .start)
+            trackSignupStart()
         }
      }
+    
+    func trackLoginStart() {
+        analyticsTracker.set(flow: .googleLogin)
+        analyticsTracker.track(step: .start)
+    }
+    
+    func trackSignupStart() {
+        analyticsTracker.set(flow: .googleSignup)
+        analyticsTracker.track(step: .start)
+    }
     
     func trackSuccess() {
         analyticsTracker.track(step: .success)

--- a/WordPressAuthenticator/Analytics/GoogleAuthenticatorTracker.swift
+++ b/WordPressAuthenticator/Analytics/GoogleAuthenticatorTracker.swift
@@ -17,53 +17,47 @@ class GoogleAuthenticatorTracker {
     func trackSigninStart(authType: GoogleAuthType) {
         switch authType {
         case .login:
-            trackLogin(step: .start)
+            analyticsTracker.set(flow: .googleLogin)
+            analyticsTracker.track(step: .start)
         case .signup:
-            trackSignup(step: .start)
+            analyticsTracker.set(flow: .googleSignup)
+            analyticsTracker.track(step: .start)
         }
      }
     
-    func trackLoginSuccess() {
-        trackLogin(step: .success)
-    }
-    
-    func trackSignupSuccess() {
-        trackSignup(step: .success)
+    func trackSuccess() {
+        analyticsTracker.track(step: .success)
     }
     
     /// Tracks a failure in any step of the signin process.
     ///
     func trackSigninFailure(authType: GoogleAuthType, error: Error?) {
         let errorMessage = error?.localizedDescription ?? "Unknown error"
-        trackFailure(failure: errorMessage)
+        analyticsTracker.track(failure: errorMessage)
     }
     
 
     func trackSignupFailure(error: Error) {
         let errorMessage = error.localizedDescription
-        trackFailure(failure: errorMessage)
+        analyticsTracker.track(failure: errorMessage)
     }
     
     /// Tracks a change of flow from signup to login.
     ///
     func trackLoginInstead() {
-        trackLogin(step: .start)
-        trackLogin(step: .success)
+        analyticsTracker.set(flow: .googleLogin)
+        analyticsTracker.track(step: .start)
+        analyticsTracker.track(step: .success)
     }
     
     /// Tracks the request of a 2FA code to the user.
     ///
     func trackTwoFactorAuthenticationRequested() {
-        trackLogin(step: .twoFactorAuthentication)
+        analyticsTracker.track(step: .twoFactorAuthentication)
     }
     
     func trackPasswordRequested(authType: GoogleAuthType) {
-        switch authType {
-        case .login:
-            trackLogin(step: .userPasswordScreenShown)
-        case .signup:
-            trackSignup(step: .userPasswordScreenShown)
-        }
+        analyticsTracker.track(step: .userPasswordScreenShown)
     }
 }
 
@@ -71,15 +65,7 @@ class GoogleAuthenticatorTracker {
 
 extension GoogleAuthenticatorTracker {
 
-    private func trackLogin(step: AnalyticsTracker.Step) {
-        analyticsTracker.track(step: step, flow: .googleLogin)
-    }
-
-    private func trackSignup(step: AnalyticsTracker.Step) {
-        analyticsTracker.track(step: step, flow: .googleSignup)
-    }
-
     private func trackFailure(failure: String) {
-        analyticsTracker.track(failure: failure)
+        
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -51,7 +51,7 @@ import AuthenticationServices
     /// Authenticator's Display Texts.
     ///
     public let displayStrings: WordPressAuthenticatorDisplayStrings
-
+    
     /// Notification to be posted whenever the signing flow completes.
     ///
     @objc public static let WPSigninDidFinishNotification = "WPSigninDidFinishNotification"

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -7,6 +7,8 @@ import GoogleSignIn
 open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     @IBOutlet var instructionLabel: UILabel?
     @objc var errorToPresent: Error?
+    
+    let tracker = AnalyticsTracker.shared
 
     /// Constraints on the table view container.
     /// Used to adjust the table width in unified views.

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -275,7 +275,7 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
 
         track(.signedIn)
         track(.loginSocialSuccess)
-        tracker?.trackLoginSuccess()
+        tracker?.trackSuccess()
         
         let wpcom = WordPressComCredentials(authToken: authToken,
                                             isJetpackLogin: loginFields.meta.jetpackLogin,
@@ -387,7 +387,7 @@ private extension GoogleAuthenticator {
         track(.createdAccount)
         track(.signedIn)
         track(.signupSocialSuccess)
-        tracker?.trackSignupSuccess()
+        tracker?.trackSuccess()
 
         signupDelegate?.googleFinishedSignup(credentials: credentials, loginFields: loginFields)
         delegate?.googleFinishedSignup(credentials: credentials, loginFields: loginFields)

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -115,7 +115,7 @@ class GoogleAuthenticator: NSObject {
     
     private override init() {
         if WordPressAuthenticator.shared.configuration.enableUnifiedGoogle {
-            tracker = GoogleAuthenticatorTracker(context: AnalyticsTracker.Context())
+            tracker = GoogleAuthenticatorTracker(analyticsTracker: AnalyticsTracker.shared)
         } else {
             tracker = nil
         }

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -349,6 +349,8 @@ private extension GoogleAuthenticator {
     func createWordPressComUser(user: GIDGoogleUser, token: String, email: String) {
         SVProgressHUD.show(withStatus: LocalizedText.processing)
         let service = SignupService()
+        
+        tracker?.trackSignupStart()
 
         service.createWPComUserWithGoogle(token: token, success: { [weak self] accountCreated, wpcomUsername, wpcomToken in
 

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -177,10 +177,7 @@ private extension TwoFAViewController {
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
         syncWPComAndPresentEpilogue(credentials: credentials)
         
-        // TODO: add new Tracks.
-        // Old events:
-        // WordPressAuthenticator.track(.signedIn)
-        // WordPressAuthenticator.track(.loginSocialSuccess, properties: properties)
+        tracker.track(step: .success)
     }
     
     // MARK: - Code Validation

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -13,8 +13,6 @@ class PasswordViewController: LoginViewController {
     private weak var passwordField: UITextField?
     private var rows = [Row]()
     private var errorMessage: String?
-    
-    private let tracker = AnalyticsTracker.shared
 
     override var loginFields: LoginFields {
         didSet {

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -13,6 +13,8 @@ class PasswordViewController: LoginViewController {
     private weak var passwordField: UITextField?
     private var rows = [Row]()
     private var errorMessage: String?
+    
+    private let tracker = AnalyticsTracker.shared
 
     override var loginFields: LoginFields {
         didSet {
@@ -101,7 +103,7 @@ class PasswordViewController: LoginViewController {
             super.displayRemoteError(error)
         }
     }
-    
+
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
         if errorMessage != message {
             errorMessage = message

--- a/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
+++ b/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
@@ -55,7 +55,8 @@ class AnalyticsTrackerTests: XCTestCase {
         let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
-        tracker.track(step: step, flow: flow)
+        tracker.set(flow: flow)
+        tracker.track(step: step)
         
         waitForExpectations(timeout: 0.1)
     }
@@ -83,7 +84,8 @@ class AnalyticsTrackerTests: XCTestCase {
         let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
-        tracker.track(step: step, flow: flow)
+        tracker.set(flow: flow)
+        tracker.track(step: step)
         
         waitForExpectations(timeout: 0.1)
     }
@@ -114,7 +116,8 @@ class AnalyticsTrackerTests: XCTestCase {
         let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
-        tracker.track(step: step, flow: flow)
+        tracker.set(flow: flow)
+        tracker.track(step: step)
         tracker.track(failure: failure)
         
         waitForExpectations(timeout: 0.1)
@@ -146,7 +149,8 @@ class AnalyticsTrackerTests: XCTestCase {
         let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
-        tracker.track(step: step, flow: flow)
+        tracker.set(flow: flow)
+        tracker.track(step: step)
         tracker.track(click: click)
         
         waitForExpectations(timeout: 0.1)

--- a/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
+++ b/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
@@ -30,26 +30,6 @@ class AnalyticsTrackerTests: XCTestCase {
         return properties
     }
     
-    /// Test that the no-params constructor for the context initializes it with the properties we expect.
-    ///
-    func testContextInitializerWithDefaultParams() {
-        let context = AnalyticsTracker.Context()
-        
-        XCTAssertEqual(context.lastFlow, .wpCom)
-        XCTAssertEqual(context.lastSource, .default)
-        XCTAssertEqual(context.lastStep, .prologue)
-    }
-    
-    /// Test that initializing a context with specific params works.
-    ///
-    func testContextInitializerWithExplicitParams() {
-        let context = AnalyticsTracker.Context(lastFlow: .appleLogin, lastSource: .deeplink, lastStep: .emailOpened)
-        
-        XCTAssertEqual(context.lastFlow, .appleLogin)
-        XCTAssertEqual(context.lastSource, .deeplink)
-        XCTAssertEqual(context.lastStep, .emailOpened)
-    }
-    
     /// Test that when tracking an event through the AnalyticsTracker, the backing analytics tracker
     /// receives a matching event.
     ///
@@ -72,8 +52,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let context = AnalyticsTracker.Context()
-        let tracker = AnalyticsTracker(context: context, track: track)
+        let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
         tracker.track(step: step, flow: flow)
@@ -101,8 +80,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let context = AnalyticsTracker.Context()
-        let tracker = AnalyticsTracker(context: context, track: track)
+        let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
         tracker.track(step: step, flow: flow)
@@ -133,8 +111,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let context = AnalyticsTracker.Context()
-        let tracker = AnalyticsTracker(context: context, track: track)
+        let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
         tracker.track(step: step, flow: flow)
@@ -166,8 +143,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let context = AnalyticsTracker.Context()
-        let tracker = AnalyticsTracker(context: context, track: track)
+        let tracker = AnalyticsTracker(track: track)
         
         tracker.set(source: source)
         tracker.track(step: step, flow: flow)


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14600

This PR addresses two issues with the analytics tracking in the basic Google authentication flow.

1. It tracks the change of the login flow to a signup flow if the user is logging in with Google, and a matching WPCom account does not exist.
2. It tracks the success of the login flow when logging in through Google, when the WPcom account has a 2FA code set.

In order to make this easier, some changes were made to `AnalyticsTracker`:

1. The context is no longer what's meant to be shared.  We now have an `AnalyticsTracker` singleton to make things easier.
2. The flow is no longer set in each tracking call.  It's guarded so that it's possible for us to track a success step without having to know what flow we're in.  We're basically leveraging the advantage of having a state machine for tracking.

Testing is done through the WPiOS PR.