### PR TITLE
Disable old tracking events for Google Sign In

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.22.0-beta.17"
+  s.version       = "1.22.0-beta.18"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -194,6 +194,10 @@ private extension GoogleAuthenticator {
     }
 
     func track(_ event: WPAnalyticsStat, properties: [AnyHashable: Any] = [:]) {
+        guard authConfig.enableUnifiedGoogle else {
+            return
+        }
+        
         var trackProperties = properties
         trackProperties["source"] = "google"
         WordPressAuthenticator.track(event, properties: trackProperties)

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -194,7 +194,7 @@ private extension GoogleAuthenticator {
     }
 
     func track(_ event: WPAnalyticsStat, properties: [AnyHashable: Any] = [:]) {
-        guard authConfig.enableUnifiedGoogle else {
+        guard !authConfig.enableUnifiedGoogle else {
             return
         }
         


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14604

Disables the old tracking events in `GoogleAuthenticator` when the unified sign in is enabled for Google.

## Testing:

The testing steps are detailed in the WPiOS PR.