### PR TITLE
Add VoiceOver support to TwoFAViewController

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.4"
+  s.version       = "1.23.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.2"
+  s.version       = "1.23.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.3"
+  s.version       = "1.23.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -40,6 +40,7 @@ final class TwoFAViewController: LoginViewController {
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()
+        configureForAccessibility()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -51,7 +52,6 @@ final class TwoFAViewController: LoginViewController {
         
         configureSubmitButton(animating: false)
         configureViewForEditingIfNeeded()
-        configureForAccessibility()
         
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(applicationBecameInactive), name: UIApplication.willResignActiveNotification, object: nil)
@@ -99,13 +99,20 @@ final class TwoFAViewController: LoginViewController {
         )
     }
 
-    /// Sets up the order in which accessibility elements should be read aloud.
+    /// Sets up accessibility elements in the order which they should be read aloud
+    /// and quiets repetitive elements.
     ///
     private func configureForAccessibility() {
         view.accessibilityElements = [
             tableView,
             submitButton as Any
         ]
+
+        UIAccessibility.post(notification: .screenChanged, argument: codeField)
+
+        if UIAccessibility.isVoiceOverRunning {
+            codeField?.placeholder = nil
+        }
     }
 
     override func configureViewLoading(_ loading: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -120,13 +120,13 @@ final class TwoFAViewController: LoginViewController {
         let err = error as NSError
         if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue {
             // Invalid verification code.
-            displayError(message: LocalizedText.bad2FAMessage)
+            displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
         } else if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidTwoStepCode.rawValue {
             // Invalid 2FA during social login
             if let newNonce = (error as NSError).userInfo[WordPressComOAuthClient.WordPressComOAuthErrorNewNonceKey] as? String {
                 loginFields.nonceInfo?.updateNonce(with: newNonce)
             }
-            displayError(message: LocalizedText.bad2FAMessage)
+            displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
         } else {
             displayError(error as NSError, sourceTag: sourceTag)
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -100,7 +100,7 @@ final class TwoFAViewController: LoginViewController {
     }
 
     /// Sets up accessibility elements in the order which they should be read aloud
-    /// and quiets repetitive elements.
+    /// and chooses which element to focus on at the beginning.
     ///
     private func configureForAccessibility() {
         view.accessibilityElements = [
@@ -109,10 +109,6 @@ final class TwoFAViewController: LoginViewController {
         ]
 
         UIAccessibility.post(notification: .screenChanged, argument: codeField)
-
-        if UIAccessibility.isVoiceOverRunning {
-            codeField?.placeholder = nil
-        }
     }
 
     override func configureViewLoading(_ loading: Bool) {
@@ -399,6 +395,10 @@ private extension TwoFAViewController {
         cell.textField.delegate = self
 
         SigninEditingState.signinEditingStateActive = true
+        if UIAccessibility.isVoiceOverRunning {
+            // Quiet repetitive VoiceOver elements.
+            codeField?.placeholder = nil
+        }
     }
 
     /// Configure the link cell.

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -15,6 +15,7 @@ final class TwoFAViewController: LoginViewController {
     private var rows = [Row]()
     private var errorMessage: String?
     private var pasteboardBeforeBackground: String? = nil
+    private var shouldChangeVoiceOverFocus: Bool = false
 
     override var sourceTag: WordPressSupportSourceTag {
         get {
@@ -124,6 +125,8 @@ final class TwoFAViewController: LoginViewController {
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
         if errorMessage != message {
             errorMessage = message
+            shouldChangeVoiceOverFocus = moveVoiceOverFocus
+            loadRows()
             tableView.reloadData()
         }
     }
@@ -338,9 +341,9 @@ private extension TwoFAViewController {
     func loadRows() {
         rows = [.instructions, .code]
 
-        if errorMessage != nil {
-             rows.append(.errorMessage)
-         }
+        if let errorText = errorMessage, !errorText.isEmpty {
+            rows.append(.errorMessage)
+        }
 
         rows.append(.sendCode)
     }
@@ -395,6 +398,9 @@ private extension TwoFAViewController {
     ///
     func configureErrorLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: errorMessage, style: .error)
+        if shouldChangeVoiceOverFocus {
+            UIAccessibility.post(notification: .layoutChanged, argument: cell)
+        }
     }
 
     /// Configure the view for an editing state.

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -104,6 +104,7 @@ final class TwoFAViewController: LoginViewController {
     ///
     private func configureForAccessibility() {
         view.accessibilityElements = [
+            codeField as Any,
             tableView,
             submitButton as Any
         ]

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -51,6 +51,7 @@ final class TwoFAViewController: LoginViewController {
         
         configureSubmitButton(animating: false)
         configureViewForEditingIfNeeded()
+        configureForAccessibility()
         
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(applicationBecameInactive), name: UIApplication.willResignActiveNotification, object: nil)
@@ -96,6 +97,15 @@ final class TwoFAViewController: LoginViewController {
             isNumeric &&
             isValidLength
         )
+    }
+
+    /// Sets up the order in which accessibility elements should be read aloud.
+    ///
+    private func configureForAccessibility() {
+        view.accessibilityElements = [
+            tableView,
+            submitButton as Any
+        ]
     }
 
     override func configureViewLoading(_ loading: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -33,6 +33,9 @@
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="wDk-4b-EYN"/>
                 </constraints>
             </tableViewCellContentView>
+            <accessibility key="accessibilityConfiguration">
+                <accessibilityTraits key="traits" button="YES"/>
+            </accessibility>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="button" destination="ofe-LL-CbC" id="lDp-3a-YIR"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -41,6 +41,7 @@ final class SiteAddressViewController: LoginViewController {
         registerTableViewCells()
         loadRows()
         configureSubmitButton(animating: false)
+        configureForAccessibility()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -48,7 +49,6 @@ final class SiteAddressViewController: LoginViewController {
 
         siteURLField?.text = loginFields.siteAddress
         configureSubmitButton(animating: false)
-        configureForAccessibility()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -89,13 +89,20 @@ final class SiteAddressViewController: LoginViewController {
         )
     }
 
-    /// Sets up the order in which accessibility elements should be read aloud.
+    /// Sets up accessibility elements in the order which they should be read aloud
+    /// and quiets repetitive elements.
     ///
     private func configureForAccessibility() {
         view.accessibilityElements = [
             tableView,
             submitButton as Any
         ]
+
+        UIAccessibility.post(notification: .screenChanged, argument: siteURLField)
+
+        if UIAccessibility.isVoiceOverRunning {
+            siteURLField?.placeholder = nil
+        }
     }
 
     /// Sets the view's state to loading or not loading.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -101,6 +101,9 @@ final class SiteAddressViewController: LoginViewController {
         UIAccessibility.post(notification: .screenChanged, argument: siteURLField)
 
         if UIAccessibility.isVoiceOverRunning {
+            // Remove the placeholder if VoiceOver is running, because it speaks the label
+            // and the placeholder together. Since the placeholder matches the label, it's
+            // like VoiceOver is reading the same thing twice.
             siteURLField?.placeholder = nil
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -94,6 +94,7 @@ final class SiteAddressViewController: LoginViewController {
     ///
     private func configureForAccessibility() {
         view.accessibilityElements = [
+            siteURLField as Any,
             tableView,
             submitButton as Any
         ]

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -105,6 +105,22 @@ final class SiteCredentialsViewController: LoginViewController {
         )
     }
 
+    /// Sets up accessibility elements in the order which they should be read aloud
+    /// and quiets repetitive elements.
+    ///
+    private func configureForAccessibility() {
+        view.accessibilityElements = [
+            tableView,
+            submitButton as Any
+        ]
+
+        UIAccessibility.post(notification: .screenChanged, argument: usernameField)
+
+        if UIAccessibility.isVoiceOverRunning {
+            usernameField?.placeholder = nil
+        }
+    }
+
     /// Sets the view's state to loading or not loading.
     ///
     /// - Parameter loading: True if the form should be configured to a "loading" state.
@@ -338,16 +354,6 @@ private extension SiteCredentialsViewController {
         if shouldChangeVoiceOverFocus {
             UIAccessibility.post(notification: .layoutChanged, argument: cell)
         }
-    }
-
-    /// Sets up accessibility elements in the order which they should be read aloud
-    /// and quiets repetitive elements.
-    ///
-    func configureForAccessibility() {
-        view.accessibilityElements = [
-            tableView,
-            submitButton as Any
-        ]
     }
 
     /// Configure the view for an editing state.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -110,7 +110,7 @@ final class SiteCredentialsViewController: LoginViewController {
     ///
     private func configureForAccessibility() {
         view.accessibilityElements = [
-            usernameField,
+            usernameField as Any,
             tableView,
             submitButton as Any
         ]

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -106,19 +106,16 @@ final class SiteCredentialsViewController: LoginViewController {
     }
 
     /// Sets up accessibility elements in the order which they should be read aloud
-    /// and quiets repetitive elements.
+    /// and chooses which element to focus on at the beginning.
     ///
     private func configureForAccessibility() {
         view.accessibilityElements = [
+            usernameField,
             tableView,
             submitButton as Any
         ]
 
         UIAccessibility.post(notification: .screenChanged, argument: usernameField)
-
-        if UIAccessibility.isVoiceOverRunning {
-            usernameField?.placeholder = nil
-        }
     }
 
     /// Sets the view's state to loading or not loading.
@@ -289,7 +286,6 @@ private extension SiteCredentialsViewController {
         // Save a reference to the textField so it can becomeFirstResponder.
         usernameField = cell.textField
         cell.textField.delegate = self
-        SigninEditingState.signinEditingStateActive = true
         cell.onePasswordHandler = { [weak self] in
             guard let self = self else {
                 return
@@ -312,6 +308,12 @@ private extension SiteCredentialsViewController {
             self?.loginFields.username = textfield.nonNilTrimmedText()
             self?.configureSubmitButton(animating: false)
         }
+
+        SigninEditingState.signinEditingStateActive = true
+        if UIAccessibility.isVoiceOverRunning {
+            // Quiet repetitive elements in VoiceOver.
+            usernameField?.placeholder = nil
+        }
     }
 
     /// Configure the password textfield cell.
@@ -324,6 +326,11 @@ private extension SiteCredentialsViewController {
         cell.onChangeSelectionHandler = { [weak self] textfield in
             self?.loginFields.password = textfield.nonNilTrimmedText()
             self?.configureSubmitButton(animating: false)
+        }
+
+        if UIAccessibility.isVoiceOverRunning {
+            // Quiet repetitive elements in VoiceOver.
+            passwordField?.placeholder = nil
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -362,13 +362,6 @@ private extension SiteCredentialsViewController {
         // Check the helper to determine whether an editing state should be assumed.
         adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
         if SigninEditingState.signinEditingStateActive {
-            if UIAccessibility.isVoiceOverRunning {
-                // Remove the placeholder if VoiceOver is running. VoiceOver speaks the label and the
-                // placeholder together. In this case, both labels and placeholders are the same so it's
-                // like VoiceOver is reading the same thing twice.
-                usernameField?.placeholder = nil
-            }
-
             usernameField?.becomeFirstResponder()
         }
     }


### PR DESCRIPTION
Ref. #358 
Testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14613

This PR updates the TwoFAViewController with VoiceOver support. 

### To test
1. `bundle exec pod install` to ensure 1.23.0-beta.3 appears.