### PR TITLE
UL&S: Use consistent naming when referring to "Signup"

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.4"
+  s.version       = "1.23.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.2"
+  s.version       = "1.23.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -121,8 +121,8 @@
 		CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */; };
 		CE1B18D020EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18CF20EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift */; };
 		CE1B18D220EEC44400BECC3F /* WordPressAuthenticatorStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */; };
-		CE1BBF8324D348CD001D2E3E /* UnifiedSignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */; };
-		CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */; };
+		CE1BBF8324D348CD001D2E3E /* UnifiedSignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8224D348CD001D2E3E /* UnifiedSignupViewController.swift */; };
+		CE1BBF8524D348EC001D2E3E /* UnifiedSignup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8424D348EC001D2E3E /* UnifiedSignup.storyboard */; };
 		CE1BBF8C24D48580001D2E3E /* GravatarEmailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BBF8A24D4857F001D2E3E /* GravatarEmailTableViewCell.swift */; };
 		CE1BBF8D24D48580001D2E3E /* GravatarEmailTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1BBF8B24D48580001D2E3E /* GravatarEmailTableViewCell.xib */; };
 		CE30A2A722579F4100DF3CDA /* LoginUsernamePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */; };
@@ -303,8 +303,8 @@
 		CE1B18CD20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDelegateProtocol.swift; sourceTree = "<group>"; };
 		CE1B18CF20EEC41600BECC3F /* WordPressAuthenticatorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorConfiguration.swift; sourceTree = "<group>"; };
 		CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorStyles.swift; sourceTree = "<group>"; };
-		CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSignUpViewController.swift; sourceTree = "<group>"; };
-		CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UnifiedSignUp.storyboard; sourceTree = "<group>"; };
+		CE1BBF8224D348CD001D2E3E /* UnifiedSignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedSignupViewController.swift; sourceTree = "<group>"; };
+		CE1BBF8424D348EC001D2E3E /* UnifiedSignup.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UnifiedSignup.storyboard; sourceTree = "<group>"; };
 		CE1BBF8A24D4857F001D2E3E /* GravatarEmailTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarEmailTableViewCell.swift; sourceTree = "<group>"; };
 		CE1BBF8B24D48580001D2E3E /* GravatarEmailTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GravatarEmailTableViewCell.xib; sourceTree = "<group>"; };
 		CE30A2A622579F4100DF3CDA /* LoginUsernamePasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginUsernamePasswordViewController.swift; sourceTree = "<group>"; };
@@ -730,8 +730,8 @@
 		CE1BBF8124D3487A001D2E3E /* Sign up */ = {
 			isa = PBXGroup;
 			children = (
-				CE1BBF8224D348CD001D2E3E /* UnifiedSignUpViewController.swift */,
-				CE1BBF8424D348EC001D2E3E /* UnifiedSignUp.storyboard */,
+				CE1BBF8224D348CD001D2E3E /* UnifiedSignupViewController.swift */,
+				CE1BBF8424D348EC001D2E3E /* UnifiedSignup.storyboard */,
 			);
 			path = "Sign up";
 			sourceTree = "<group>";
@@ -915,7 +915,7 @@
 				98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */,
 				CE1BBF8D24D48580001D2E3E /* GravatarEmailTableViewCell.xib in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
-				CE1BBF8524D348EC001D2E3E /* UnifiedSignUp.storyboard in Resources */,
+				CE1BBF8524D348EC001D2E3E /* UnifiedSignup.storyboard in Resources */,
 				CE6BCD3924A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib in Resources */,
 				CE6BCD2F24A3A235001BCDC5 /* TextLabelTableViewCell.xib in Resources */,
 				98CF18F9248725620047B66C /* GoogleSignupConfirmation.storyboard in Resources */,
@@ -1092,7 +1092,7 @@
 				CE1B18CC20EEC32400BECC3F /* WordPressComCredentials.swift in Sources */,
 				98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */,
 				B560913C208A563800399AE4 /* LoginProloguePromoViewController.swift in Sources */,
-				CE1BBF8324D348CD001D2E3E /* UnifiedSignUpViewController.swift in Sources */,
+				CE1BBF8324D348CD001D2E3E /* UnifiedSignupViewController.swift in Sources */,
 				B560910F208A54F800399AE4 /* SafariCredentialsService.swift in Sources */,
 				B5CDBED420B4714500BC1EF2 /* UIImage+Assets.swift in Sources */,
 				B5609116208A555600399AE4 /* LoginTextField.swift in Sources */,

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -5,7 +5,7 @@ import Foundation
 enum Storyboard: String {
     case login = "Login"
     case signup = "Signup"
-    case unifiedSignUp = "UnifiedSignUp"
+    case unifiedSignUp = "UnifiedSignup"
     case emailMagicLink = "EmailMagicLink"
     case siteAddress = "SiteAddress"
     case googleAuth = "GoogleAuth"

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -189,7 +189,7 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func presentUnifiedSignUpView() {
-        guard let toVC = UnifiedSignUpViewController.instantiate(from: .unifiedSignUp) else {
+        guard let toVC = UnifiedSignupViewController.instantiate(from: .unifiedSignUp) else {
             DDLogError("Failed to navigate to UnifiedSignUpViewController")
             return
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUp.storyboard
@@ -8,10 +8,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Unified Sign Up View Controller-->
+        <!--Unified Signup View Controller-->
         <scene sceneID="tlG-zZ-6we">
             <objects>
-                <viewController storyboardIdentifier="UnifiedSignUpViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="eEV-Dl-qyz" customClass="UnifiedSignUpViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="UnifiedSignUpViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="eEV-Dl-qyz" customClass="UnifiedSignupViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="48f-x8-Uiu">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignUpViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// UnifiedSignUpViewController: sign up to .com with an email address.
 ///
-class UnifiedSignUpViewController: LoginViewController {
+class UnifiedSignupViewController: LoginViewController {
 
     /// Private properties.
     ///
@@ -77,7 +77,7 @@ class UnifiedSignUpViewController: LoginViewController {
 
 
 // MARK: - UITableViewDataSource
-extension UnifiedSignUpViewController: UITableViewDataSource {
+extension UnifiedSignupViewController: UITableViewDataSource {
 
     /// Returns the number of rows in a section.
     ///
@@ -98,11 +98,11 @@ extension UnifiedSignUpViewController: UITableViewDataSource {
 
 
 // MARK: - UITableViewDelegate conformance
-extension UnifiedSignUpViewController: UITableViewDelegate { }
+extension UnifiedSignupViewController: UITableViewDelegate { }
 
 
 // MARK: - Private methods
-private extension UnifiedSignUpViewController {
+private extension UnifiedSignupViewController {
 
     /// Registers all of the available TableViewCells.
     ///
@@ -204,7 +204,7 @@ private extension UnifiedSignUpViewController {
 // Mark: - Instance Methods
 /// Implementation methods imported from SignupEmailViewController.
 ///
-extension UnifiedSignUpViewController {
+extension UnifiedSignupViewController {
     // MARK: - Send email
 
     /// Makes the call to request a magic signup link be emailed to the user.


### PR DESCRIPTION
It should not be "SignUp". No WPiOS testing PR because this change will be incorporated when the `SignupMagicLinkViewController` PR is opened.