### PR TITLE
Constrain nav bar, and bar button appearance changes to auth classes.

### DIFF
--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -122,11 +122,11 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             appearance.shadowColor = hideBottomBorder ? .clear : .separator
             appearance.backgroundColor = backgroundColor
             appearance.titleTextAttributes = [.foregroundColor: titleTextColor]
-            UIBarButtonItem.appearance().tintColor = buttonTextColor
+            UIBarButtonItem.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).tintColor = buttonTextColor
             
-            UINavigationBar.appearance().standardAppearance = appearance
-            UINavigationBar.appearance().compactAppearance = appearance
-            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+            UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).standardAppearance = appearance
+            UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).compactAppearance = appearance
+            UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).scrollEdgeAppearance = appearance
         } else {
             let appearance = UINavigationBar.appearance()
             appearance.barTintColor = backgroundColor


### PR DESCRIPTION
This PR makes a small change to how the appearance of UINavigationBar and UIBarButtonItem instances is handled. 

Prior to this PR the global appearance proxy for UINavigationBar and UIBarButtonItem was being modified.  This had a consequence of the changes carrying over into other parts of the implementing app that might use different styles. 
This PR constrains the changes to UINavigationBar and UIBarButtonItem instances that appear within a LoginNavigationController instance.

To test:
- Confirm the issue by launching an app that implements the Authenticator.
- Set the authenticator's navbar background style via the WordPressAuthenticatorStyle config to something garish (mauve maybe? chartreuse? assert yourself ;) )
- Run the app and go through the auth flow to successfully log in.
- Note that the app's navbar remains the color you set. The same is true for the bar button items depending on how you've configured styles.
- Re-launch the app and confirm that the app's normal navbar style appears.
- Apply the patch and repeat the test. 
- Confirm that once the auth flow is complete the app's normal navbar style appears.

(Newspack-iOS is a nifty test platform for this one ;) )

@ScoutHarris could I trouble you with this one? 
