### PR TITLE
Social account logins: Don't update username when using a password manager.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.4"
+  s.version       = "1.23.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.5"
+  s.version       = "1.23.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -458,12 +458,19 @@ import AuthenticationServices
     ///
     /// - Parameter sender: A UIView. Typically the button the user tapped on.
     ///
-    class func fetchOnePasswordCredentials(_ controller: UIViewController, sourceView: UIView, loginFields: LoginFields, success: @escaping ((_ loginFields: LoginFields) -> Void)) {
+    class func fetchOnePasswordCredentials(_ controller: UIViewController,
+                                           sourceView: UIView,
+                                           loginFields: LoginFields,
+                                           allowUsernameChange: Bool = true,
+                                           success: @escaping ((_ loginFields: LoginFields) -> Void)) {
 
         let loginURL = loginFields.meta.userIsDotCom ? OnePasswordDefaults.dotcomURL : loginFields.siteAddress
 
         OnePasswordFacade().findLogin(for: loginURL, viewController: controller, sender: sourceView, success: { (username, password, otp) in
-            loginFields.username = username
+            if allowUsernameChange {
+                loginFields.username = username
+            }
+            
             loginFields.password = password
             loginFields.multifactorCode = otp ?? String()
 

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -187,8 +187,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
             // Ref: https://git.io/JJSUM
             if loginFields.meta.socialService != nil {
                 emailLabel?.text = loginFields.username
-            }
-            else {
+            } else {
                 loginFields.username = sender.nonNilTrimmedText()
             }
         default:
@@ -211,7 +210,15 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         view.endEditing(true)
 
         WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sender, loginFields: loginFields) { [weak self] (loginFields) in
-            self?.emailLabel?.text = loginFields.username
+            
+            // The email can only be changed via a password manager.
+            // In this case, don't update username for social accounts.
+            // This prevents inadvertent account linking.
+            // Ref: https://git.io/JJSUM
+            if loginFields.meta.socialService == nil {
+                self?.emailLabel?.text = loginFields.username
+            }
+
             self?.passwordField?.text = loginFields.password
             self?.validateForm()
         }

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -209,16 +209,14 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     @objc func handleOnePasswordButtonTapped(_ sender: UIButton) {
         view.endEditing(true)
 
-        WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sender, loginFields: loginFields) { [weak self] (loginFields) in
-            
-            // The email can only be changed via a password manager.
-            // In this case, don't update username for social accounts.
-            // This prevents inadvertent account linking.
-            // Ref: https://git.io/JJSUM
-            if loginFields.meta.socialService == nil {
-                self?.emailLabel?.text = loginFields.username
-            }
+        // Don't update username for social accounts.
+        // This prevents inadvertent account linking.
+        // Ref: https://git.io/JJSUM
+        let allowUsernameChange = (loginFields.meta.socialService == nil)
 
+        WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sender, loginFields: loginFields, allowUsernameChange: allowUsernameChange) { [weak self] (loginFields) in
+            
+            self?.emailLabel?.text = loginFields.username
             self?.passwordField?.text = loginFields.password
             self?.validateForm()
         }

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -181,7 +181,16 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         case passwordField:
             loginFields.password = sender.nonNilTrimmedText()
         case emailLabel:
-            loginFields.username = sender.nonNilTrimmedText()
+            // The email can only be changed via a password manager.
+            // In this case, don't update username for social accounts.
+            // This prevents inadvertent account linking.
+            // Ref: https://git.io/JJSUM
+            if loginFields.meta.socialService != nil {
+                emailLabel?.text = loginFields.username
+            }
+            else {
+                loginFields.username = sender.nonNilTrimmedText()
+            }
         default:
             break
         }


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14620
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14626

In the current login flow (not unified), using a password manager on the Password view:
- If logging in via WordPress, selecting any account will still update the username and password. (This is existing behavior.)
- If logging in via Google or SIWA (with an account that has a WP password), only the password will be used. The username is ignored. (This is new behavior.)