### PR TITLE
Update login prologue options for WCiOS customizations

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.7"
+  s.version       = "1.23.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.4"
+  s.version       = "1.23.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -150,7 +150,7 @@ import AuthenticationServices
         showLogin(from: presenter, animated: animated)
     }
 
-    public class func showLogin(from presenter: UIViewController, animated: Bool, showCancel: Bool = false, restrictToWPCom: Bool = false) {
+    public class func showLogin(from presenter: UIViewController, animated: Bool, showCancel: Bool = false, restrictToWPCom: Bool = false, onLoginButtonTapped: (() -> Void)? = nil) {
         defer {
             trackOpenedLogin()
         }
@@ -160,6 +160,7 @@ import AuthenticationServices
             if let childController = controller.children.first as? LoginPrologueViewController {
                 childController.loginFields.restrictToWPCom = restrictToWPCom
                 childController.showCancel = showCancel
+                childController.onLoginButtonTapped = onLoginButtonTapped
             }
             controller.modalPresentationStyle = .fullScreen
             presenter.present(controller, animated: animated, completion: nil)

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -51,6 +51,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let showLoginOptions: Bool
 
+    /// Flag indicating if Sign Up UX is enabled for all services.
+    ///
+    let enabledSignUp: Bool
+
     /// Flag indicating if the Sign In With Apple option should be displayed.
     ///
     let enableSignInWithApple: Bool
@@ -103,6 +107,7 @@ public struct WordPressAuthenticatorConfiguration {
                  googleLoginScheme: String,
                  userAgent: String,
                  showLoginOptions: Bool = false,
+                 enabledSignUp: Bool = true,
                  enableSignInWithApple: Bool = false,
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
@@ -123,6 +128,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginScheme = googleLoginScheme
         self.userAgent = userAgent
         self.showLoginOptions = showLoginOptions
+        self.enabledSignUp = enabledSignUp
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
         self.displayHintButtons = displayHintButtons

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -107,7 +107,7 @@ public struct WordPressAuthenticatorConfiguration {
                  googleLoginScheme: String,
                  userAgent: String,
                  showLoginOptions: Bool = false,
-                 enabledSignUp: Bool = true,
+                 enableSignUp: Bool = true,
                  enableSignInWithApple: Bool = false,
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
@@ -128,7 +128,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginScheme = googleLoginScheme
         self.userAgent = userAgent
         self.showLoginOptions = showLoginOptions
-        self.enableSignUp = enabledSignUp
+        self.enableSignUp = enableSignUp
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
         self.displayHintButtons = displayHintButtons

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -53,7 +53,7 @@ public struct WordPressAuthenticatorConfiguration {
 
     /// Flag indicating if Sign Up UX is enabled for all services.
     ///
-    let enabledSignUp: Bool
+    let enableSignUp: Bool
 
     /// Flag indicating if the Sign In With Apple option should be displayed.
     ///
@@ -128,7 +128,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginScheme = googleLoginScheme
         self.userAgent = userAgent
         self.showLoginOptions = showLoginOptions
-        self.enabledSignUp = enabledSignUp
+        self.enableSignUp = enabledSignUp
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
         self.displayHintButtons = displayHintButtons

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -42,27 +42,27 @@ public struct WordPressAuthenticatorDisplayStrings {
 
     /// Designated initializer.
     ///
-    public init(emailLoginInstructions: String,
-                jetpackLoginInstructions: String,
-                siteLoginInstructions: String,
-				siteCredentialInstructions: String,
-                twoFactorInstructions: String,
-                magicLinkInstructions: String,
-                googlePasswordInstructions: String,
-                applePasswordInstructions: String,
-                continueButtonTitle: String,
-                magicLinkButtonTitle: String,
-                findSiteButtonTitle: String,
-                resetPasswordButtonTitle: String,
-                textCodeButtonTitle: String,
-                gettingStartedTitle: String,
-                logInTitle: String,
-                signUpTitle: String,
-                waitingForGoogleTitle: String,
-				usernamePlaceholder: String,
-				passwordPlaceholder: String,
-                siteAddressPlaceholder: String,
-                twoFactorCodePlaceholder: String) {
+    public init(emailLoginInstructions: String = defaultStrings.emailLoginInstructions,
+                jetpackLoginInstructions: String = defaultStrings.jetpackLoginInstructions,
+                siteLoginInstructions: String = defaultStrings.siteLoginInstructions,
+                siteCredentialInstructions: String = defaultStrings.siteCredentialInstructions,
+                twoFactorInstructions: String = defaultStrings.twoFactorInstructions,
+                magicLinkInstructions: String = defaultStrings.magicLinkInstructions,
+                googlePasswordInstructions: String = defaultStrings.googlePasswordInstructions,
+                applePasswordInstructions: String = defaultStrings.applePasswordInstructions,
+                continueButtonTitle: String = defaultStrings.continueButtonTitle,
+                magicLinkButtonTitle: String = defaultStrings.magicLinkButtonTitle,
+                findSiteButtonTitle: String = defaultStrings.findSiteButtonTitle,
+                resetPasswordButtonTitle: String = defaultStrings.resetPasswordButtonTitle,
+                textCodeButtonTitle: String = defaultStrings.textCodeButtonTitle,
+                gettingStartedTitle: String = defaultStrings.gettingStartedTitle,
+                logInTitle: String = defaultStrings.logInTitle,
+                signUpTitle: String = defaultStrings.signUpTitle,
+                waitingForGoogleTitle: String = defaultStrings.waitingForGoogleTitle,
+                usernamePlaceholder: String = defaultStrings.usernamePlaceholder,
+                passwordPlaceholder: String = defaultStrings.passwordPlaceholder,
+                siteAddressPlaceholder: String = defaultStrings.siteAddressPlaceholder,
+                twoFactorCodePlaceholder: String = defaultStrings.twoFactorCodePlaceholder) {
         self.emailLoginInstructions = emailLoginInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -86,6 +86,7 @@ public struct WordPressAuthenticatorStyle {
     public let prologueTitleColor: UIColor
 
     /// Style: prologue top container child view controller
+    /// When nil, `LoginProloguePageViewController` is displayed in the top container
     ///
     public let prologueTopContainerChildViewController: UIViewController?
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -88,7 +88,7 @@ public struct WordPressAuthenticatorStyle {
     /// Style: prologue top container child view controller
     /// When nil, `LoginProloguePageViewController` is displayed in the top container
     ///
-    public let prologueTopContainerChildViewController: UIViewController?
+    public let prologueTopContainerChildViewController: () -> UIViewController?
 
     /// Style: status bar style
     ///
@@ -124,7 +124,7 @@ public struct WordPressAuthenticatorStyle {
                 navButtonTextColor: UIColor = .white,
                 prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(),
                 prologueTitleColor: UIColor = .white,
-                prologueTopContainerChildViewController: UIViewController? = nil,
+                prologueTopContainerChildViewController: @autoclosure @escaping () -> UIViewController? = nil,
                 statusBarStyle: UIStatusBarStyle = .lightContent) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -62,6 +62,8 @@ public struct WordPressAuthenticatorStyle {
     // If not specified, falls back to viewControllerBackgroundColor.
     public let buttonViewBackgroundColor: UIColor
 
+    public let buttonViewTopShadowImage: UIImage?
+
     /// Style: nav bar
     ///
     public let navBarImage: UIImage
@@ -79,6 +81,10 @@ public struct WordPressAuthenticatorStyle {
     /// Style: prologue background colors
     ///
     public let prologueTitleColor: UIColor
+
+    /// Style: prologue top container child view controller
+    ///
+    public let prologueTopContainerChildViewController: UIViewController?
 
     /// Style: status bar style
     ///
@@ -107,12 +113,14 @@ public struct WordPressAuthenticatorStyle {
                 viewControllerBackgroundColor: UIColor,
                 textFieldBackgroundColor: UIColor,
                 buttonViewBackgroundColor: UIColor? = nil,
+                buttonViewTopShadowImage: UIImage? = UIImage(named: "darkgrey-shadow"),
                 navBarImage: UIImage,
                 navBarBadgeColor: UIColor,
                 navBarBackgroundColor: UIColor,
                 navButtonTextColor: UIColor = .white,
                 prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(),
                 prologueTitleColor: UIColor = .white,
+                prologueTopContainerChildViewController: UIViewController? = nil,
                 statusBarStyle: UIStatusBarStyle = .lightContent) {
         self.primaryNormalBackgroundColor = primaryNormalBackgroundColor
         self.primaryNormalBorderColor = primaryNormalBorderColor
@@ -135,12 +143,14 @@ public struct WordPressAuthenticatorStyle {
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
         self.textFieldBackgroundColor = textFieldBackgroundColor
         self.buttonViewBackgroundColor = buttonViewBackgroundColor ?? viewControllerBackgroundColor
+        self.buttonViewTopShadowImage = buttonViewTopShadowImage
         self.navBarImage = navBarImage
         self.navBarBadgeColor = navBarBadgeColor
         self.navBarBackgroundColor = navBarBackgroundColor
         self.navButtonTextColor = navButtonTextColor
         self.prologueBackgroundColor = prologueBackgroundColor
         self.prologueTitleColor = prologueTitleColor
+        self.prologueTopContainerChildViewController = prologueTopContainerChildViewController
         self.statusBarStyle = statusBarStyle
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -62,6 +62,9 @@ public struct WordPressAuthenticatorStyle {
     // If not specified, falls back to viewControllerBackgroundColor.
     public let buttonViewBackgroundColor: UIColor
 
+    /// Style: shadow image view on top of the button view like a divider.
+    /// If not specified, falls back to image "darkgrey-shadow".
+    ///
     public let buttonViewTopShadowImage: UIImage?
 
     /// Style: nav bar

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -32,7 +32,7 @@ open class NUXButtonViewController: UIViewController {
 
     // MARK: - Properties
 
-    @IBOutlet var shadowView: UIView?
+    @IBOutlet private var shadowView: UIImageView?
     @IBOutlet var stackView: UIStackView?
     @IBOutlet var bottomButton: NUXButton?
     @IBOutlet var topButton: NUXButton?
@@ -46,11 +46,15 @@ open class NUXButtonViewController: UIViewController {
     private var bottomButtonConfig: NUXButtonConfig?
     private var tertiaryButtonConfig: NUXButtonConfig?
 
+    private let style = WordPressAuthenticator.shared.style
+
     // MARK: - View
 
     override open func viewDidLoad() {
         super.viewDidLoad()
         view.translatesAutoresizingMaskIntoConstraints = false
+
+        shadowView?.image = style.buttonViewTopShadowImage
     }
 
     override open func viewWillAppear(_ animated: Bool) {

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -107,6 +107,9 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>
+                    <connections>
+                        <outlet property="topContainerView" destination="6cw-FO-hjb" id="rCh-90-6d1"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieq-Ar-5OF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -22,7 +22,7 @@ class LoginPrologueViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if let topContainerChildViewController = style.prologueTopContainerChildViewController {
+        if let topContainerChildViewController = style.prologueTopContainerChildViewController() {
             topContainerView.subviews.forEach { $0.removeFromSuperview() }
             addChild(topContainerChildViewController)
             topContainerView.addSubview(topContainerChildViewController.view)

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -8,14 +8,33 @@ class LoginPrologueViewController: LoginViewController {
 
     private var buttonViewController: NUXButtonViewController?
     var showCancel = false
+    var onLoginButtonTapped: (() -> Void)?
+
     private let configuration = WordPressAuthenticator.shared.configuration
+    private let style = WordPressAuthenticator.shared.style
+
+    @IBOutlet private weak var topContainerView: UIView!
 
     // MARK: - Lifecycle Methods
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if let topContainerChildViewController = style.prologueTopContainerChildViewController {
+            topContainerView.subviews.forEach { $0.removeFromSuperview() }
+            addChild(topContainerChildViewController)
+            topContainerView.addSubview(topContainerChildViewController.view)
+            topContainerChildViewController.didMove(toParent: self)
+
+            topContainerChildViewController.view.translatesAutoresizingMaskIntoConstraints = false
+            topContainerView.pinSubviewToAllEdges(topContainerChildViewController.view)
+        }
+    }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureButtonVC()
-        self.navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -52,6 +71,7 @@ class LoginPrologueViewController: LoginViewController {
         let createTitle = NSLocalizedString("Sign up for WordPress.com", comment: "Button title. Tapping begins the process of creating a WordPress.com account.")
 
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
+            self?.onLoginButtonTapped?()
             self?.loginTapped()
         }
 
@@ -66,13 +86,13 @@ class LoginPrologueViewController: LoginViewController {
                 self?.dismiss(animated: true, completion: nil)
             }
         }
-        buttonViewController.backgroundColor = WordPressAuthenticator.shared.style.buttonViewBackgroundColor
+        buttonViewController.backgroundColor = style.buttonViewBackgroundColor
     }
 
     // MARK: - Actions
 
     private func loginTapped() {
-        if WordPressAuthenticator.shared.configuration.showLoginOptions {
+        if configuration.showLoginOptions {
             guard let vc = LoginPrologueLoginMethodViewController.instantiate(from: .login) else {
                 DDLogError("Failed to navigate to LoginPrologueLoginMethodViewController from LoginPrologueViewController")
                 return

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -183,7 +183,7 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func googleTapped() {
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
+        guard configuration.enableUnifiedGoogle else {
             GoogleAuthenticator.sharedInstance.loginDelegate = self
             GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
             return
@@ -195,7 +195,7 @@ class LoginPrologueViewController: LoginViewController {
     /// Determines which view to present for the site address form.
     ///
     private func loginToSelfHostedSite() {
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress else {
+        guard configuration.enableUnifiedSiteAddress else {
             presentSelfHostedView()
             return
         }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -153,21 +153,29 @@ class LoginPrologueViewController: LoginViewController {
         vc.modalPresentationStyle = .custom
 
         vc.emailTapped = { [weak self] in
-            guard WordPressAuthenticator.shared.configuration.enableUnifiedSignup else {
-                self?.presentSignUpEmailView()
+            guard let self = self else {
                 return
             }
 
-            self?.presentUnifiedSignUpView()
+            guard self.configuration.enableUnifiedSignup else {
+                self.presentSignUpEmailView()
+                return
+            }
+
+            self.presentUnifiedSignUpView()
         }
 
         vc.googleTapped = { [weak self] in
-            guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
-                self?.presentGoogleSignupView()
+            guard let self = self else {
                 return
             }
 
-            self?.presentUnifiedGoogleView()
+            guard self.configuration.enableUnifiedGoogle else {
+                self.presentGoogleSignupView()
+                return
+            }
+
+            self.presentUnifiedGoogleView()
         }
 
         vc.appleTapped = { [weak self] in

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -75,7 +75,7 @@ class LoginPrologueViewController: LoginViewController {
             self?.loginTapped()
         }
 
-        if configuration.enabledSignUp {
+        if configuration.enableSignUp {
             buttonViewController.setupBottomButton(title: createTitle, isPrimary: true, accessibilityIdentifier: "Prologue Signup Button") { [weak self] in
                 self?.signupTapped()
             }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -8,6 +8,8 @@ class LoginPrologueViewController: LoginViewController {
 
     private var buttonViewController: NUXButtonViewController?
     var showCancel = false
+
+    // Called when login button is tapped
     var onLoginButtonTapped: (() -> Void)?
 
     private let configuration = WordPressAuthenticator.shared.configuration

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -8,6 +8,7 @@ class LoginPrologueViewController: LoginViewController {
 
     private var buttonViewController: NUXButtonViewController?
     var showCancel = false
+    private let configuration = WordPressAuthenticator.shared.configuration
 
     // MARK: - Lifecycle Methods
 
@@ -53,8 +54,11 @@ class LoginPrologueViewController: LoginViewController {
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
             self?.loginTapped()
         }
-        buttonViewController.setupBottomButton(title: createTitle, isPrimary: true, accessibilityIdentifier: "Prologue Signup Button") { [weak self] in
-            self?.signupTapped()
+
+        if configuration.enabledSignUp {
+            buttonViewController.setupBottomButton(title: createTitle, isPrimary: true, accessibilityIdentifier: "Prologue Signup Button") { [weak self] in
+                self?.signupTapped()
+            }
         }
         if showCancel {
             let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")


### PR DESCRIPTION
Prerequisite for https://github.com/woocommerce/woocommerce-ios/issues/2643

In order for WCiOS to adopt SIWA that comes with the authenticator, we're updating WCiOS to also use the login prologue (the first screen in the `Login.storyboard` with CTAs to log in / sign up). Since WCiOS currently has its own view design, I added a few options to enable the login prologue screen to look as close as the current one.

No user-facing changes are expected in WPiOS from this PR, as all the new options are default to the existing values.

## Changes

- In `WordPressAuthenticator.showLogin`, added a callback when the user taps on the login button
  - In WCiOS, we have custom logging on this action and would like to keep it for existing funnels. It also doesn't look like any event is logged on Tracks upon login button tap.
- Added `enableSignUp: Bool` to `WordPressAuthenticatorConfiguration`, and used this flag to determine whether the Sign Up CTA is shown on the login prologue screen
- Updated `WordPressAuthenticatorDisplayStrings`'s init to default to `defaultStrings`
- Added 2 options to `WordPressAuthenticatorStyle`:
  - `buttonViewTopShadowImage: UIImage?`: this is the shadow image above the button container at the bottom of the prologue screen, default to the existing image. Since WCiOS prologue doesn't have a shadow image, it will be set to `nil`.
    - This value is set in `NUXButtonViewController`'s `viewDidLoad` setup
  - `prologueTopContainerChildViewController: UIViewController?`: because WCiOS has a different design above the button container, this optional child view controller allows the caller to display a custom view at the top container.
    - A new outlet `topContainerView: UIView` is added to `LoginPrologueViewController`. If `prologueTopContainerChildViewController` is non-nil, it's configured to display in the `topContainerView` in `LoginPrologueViewController`'s `viewDidLoad`.
- In `LoginPrologueViewController`, replaced a few `WordPressAuthenticator.shared.configuration` and `WordPressAuthenticator.shared.style` with private properties

## Testing

- [x] WPiOS - [branch `authenticator-testing/wcios-siwa`](https://github.com/wordpress-mobile/WordPress-iOS/compare/authenticator-testing/wcios-siwa?expand=1): at least one reviewer is required. Please make sure the login prologue screen is as before.
- [ ] WCiOS - [draft PR](https://github.com/woocommerce/woocommerce-ios/pull/2644): at least one reviewer is required. Please refer to the testing steps in the PR.