### PR TITLE
ULS Password view: add password manager support

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.4"
+  s.version       = "1.23.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -33,7 +33,7 @@ class PasswordViewController: LoginViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
         
@@ -60,7 +60,7 @@ class PasswordViewController: LoginViewController {
 
         configureViewForEditingIfNeeded()
         
-        // TODO: add new tracks. Old track: WordPressAuthenticator.track(.loginPasswordFormViewed)
+        // TODO: - Tracks. Old track: WordPressAuthenticator.track(.loginPasswordFormViewed)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -103,6 +103,7 @@ class PasswordViewController: LoginViewController {
     }
 
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
+        configureViewLoading(false)
         if errorMessage != message {
             errorMessage = message
             tableView.reloadData()
@@ -228,11 +229,27 @@ private extension PasswordViewController {
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
     }
-    
+
     /// Configure the gravatar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
         cell.configure(withEmail: loginFields.username)
+        
+        cell.onChangeSelectionHandler = { [weak self] textfield in
+            // The email can only be changed via a password manager.
+            // In this case, don't update username for social accounts.
+            // This prevents inadvertent account linking.
+            if self?.loginFields.meta.socialService != nil {
+                cell.updateEmailAddress(self?.loginFields.username)
+            } else {
+                self?.loginFields.username = textfield.nonNilTrimmedText()
+                self?.loginFields.emailAddress = textfield.nonNilTrimmedText()
+            }
+            
+            self?.configureSubmitButton(animating: false)
+        }
+
+        // TODO: - add onePasswordHandler
     }
     
     /// Configure the instruction cell.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -86,7 +86,7 @@ private extension GravatarEmailTableViewCell {
     /// because the delegate method `textFieldDidChangeSelection(_ textField: UITextField)`
     /// is only available to iOS 13+. When we no longer support iOS 12,
     /// `textFieldDidChangeSelection`, and `onChangeSelectionHandler` can
-    /// be deleted in favor of adding the delegate method to SiteAddressViewController.
+    /// be deleted in favor of adding the delegate method to view controllers.
     ///
     @IBAction func textFieldDidChangeSelection() {
         onChangeSelectionHandler?(emailLabel)

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -2,27 +2,38 @@ import UIKit
 
 
 /// GravatarEmailTableViewCell: Gravatar image + Email address in a UITableViewCell.
-/// - Note: Why not use a default-style UITableViewCell? Because it still uses springs and struts!
 ///
 class GravatarEmailTableViewCell: UITableViewCell {
 
     /// Private properties
     ///
     @IBOutlet private weak var gravatarImageView: UIImageView?
-    @IBOutlet private weak var emailLabel: UILabel?
 
+    // The email field is a UITextField so we can listen for changes when using a password manager.
+    // It is disabled so the user cannot edit it.
+    // This results in the 1Password button being disabled as well.
+    // So we add the 1Password button to a stack view instead of the email field.
+    // When iOS12 support is removed, the emailStackView can be removed as it only facilitates 1Password.
+    @IBOutlet private weak var emailLabel: UITextField!
+    @IBOutlet private weak var emailStackView: UIStackView?
+    
     private let gridiconSize = CGSize(width: 48, height: 48)
     
     /// Public properties
     ///
     public static let reuseIdentifier = "GravatarEmailTableViewCell"
-
+    public var onePasswordHandler: ((_ sourceView: UITextField) -> Void)?
+    public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
+    
+    /// Public Methods
+    ///
     public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil) {
-        
         gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         emailLabel?.text = email
+
+        setupOnePasswordButtonIfNeeded()
         
         let gridicon = UIImage.gridicon(.userCircle, size: gridiconSize)
         
@@ -35,11 +46,50 @@ class GravatarEmailTableViewCell: UITableViewCell {
         gravatarImageView?.downloadGravatarWithEmail(email, placeholderImage: placeholderImage ?? gridicon)
     }
 
-    /// Override methods
-    ///
-    public override func prepareForReuse() {
-        emailLabel?.text = nil
-        gravatarImageView?.image = nil
+    func updateEmailAddress(_ email: String?) {
+        emailLabel?.text = email
     }
     
+}
+
+// MARK: - Password Manager Handling
+
+private extension GravatarEmailTableViewCell {
+    
+    // MARK: - 1Password
+
+    /// Sets up a 1Password button if 1Password is available and user is on iOS 12.
+    ///
+    func setupOnePasswordButtonIfNeeded() {
+        if #available(iOS 13, *) {
+            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
+        } else {
+            guard let emailStackView = emailStackView else {
+                return
+            }
+            
+            WPStyleGuide.configureOnePasswordButtonForStackView(emailStackView,
+                                                                target: self,
+                                                                selector: #selector(onePasswordTapped(_:)))
+        }
+    }
+    
+    @objc func onePasswordTapped(_ sender: UIButton) {
+        onePasswordHandler?(emailLabel)
+    }
+    
+    // MARK: - All Password Managers
+    
+    /// Call the handler when the text field changes.
+    ///
+    /// - Note: we have to manually add an action to the textfield
+    /// because the delegate method `textFieldDidChangeSelection(_ textField: UITextField)`
+    /// is only available to iOS 13+. When we no longer support iOS 12,
+    /// `textFieldDidChangeSelection`, and `onChangeSelectionHandler` can
+    /// be deleted in favor of adding the delegate method to SiteAddressViewController.
+    ///
+    @IBAction func textFieldDidChangeSelection() {
+        onChangeSelectionHandler?(emailLabel)
+    }
+
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -25,28 +25,36 @@
                             <constraint firstAttribute="width" constant="48" id="oKU-lB-dYx"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jle-eu-TeA" userLabel="Email Label">
-                        <rect key="frame" x="70" y="13" width="234" height="44"/>
-                        <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="QBs-7U-E3W"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rp0-GT-dO4" userLabel="Email Stack View">
+                        <rect key="frame" x="70" y="13" width="239" height="44"/>
+                        <subviews>
+                            <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
+                                <rect key="frame" x="0.0" y="0.0" width="239" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="axC-0i-jGu"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <textInputTraits key="textInputTraits" textContentType="username"/>
+                                <connections>
+                                    <action selector="textFieldDidChangeSelection" destination="KGk-i7-Jjw" eventType="editingChanged" id="CBE-yc-dqf"/>
+                                </connections>
+                            </textField>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="jle-eu-TeA" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="11" id="8Wx-qB-Fs2"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="jle-eu-TeA" secondAttribute="trailing" id="IUZ-dB-QnU"/>
+                    <constraint firstItem="Rp0-GT-dO4" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="OXm-Es-lay"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" constant="-2" id="YZD-yX-ic3"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="hPB-Uy-lLS"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="11" id="kVa-7e-I73"/>
-                    <constraint firstItem="jle-eu-TeA" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="zuD-0q-QlE"/>
+                    <constraint firstItem="Rp0-GT-dO4" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="11" id="txL-rW-VDL"/>
+                    <constraint firstAttribute="trailing" secondItem="Rp0-GT-dO4" secondAttribute="trailing" constant="11" id="zFn-2O-cyr"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="emailLabel" destination="jle-eu-TeA" id="qlq-dw-hT2"/>
+                <outlet property="emailLabel" destination="3kD-7a-MeN" id="8Ck-Rg-3Cw"/>
+                <outlet property="emailStackView" destination="Rp0-GT-dO4" id="E8B-ds-K8H"/>
                 <outlet property="gravatarImageView" destination="odI-Gb-fXa" id="eHP-78-0Fg"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>


### PR DESCRIPTION
Ref: #352 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14637

This adds password manager support to the unified Password view.
- For iOS13+ it is fully functional.
- For iOS12, the 1Password icon appears on the email field, but is not functional yet. (Pending https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/372.)