### PR TITLE
ULS: Show new Password and 2FA views in SIWA path

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.5"
+  s.version       = "1.23.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -242,7 +242,30 @@ class LoginPrologueViewController: LoginViewController {
 
         navigationController?.pushViewController(vc, animated: true)
     }
+ 
+    private func presentWPLogin() {
+        guard let vc = LoginWPComViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginPrologueViewController to LoginWPComViewController")
+            return
+        }
+        
+        vc.loginFields = self.loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+        
+        navigationController?.pushViewController(vc, animated: true)
+    }
     
+    private func presentUnifiedPassword() {
+        guard let vc = PasswordViewController.instantiate(from: .password) else {
+            DDLogError("Failed to navigate from LoginPrologueViewController to PasswordViewController")
+            return
+        }
+        
+        vc.loginFields = loginFields
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
 }
 
 // MARK: - LoginFacadeDelegate
@@ -264,16 +287,13 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
 
     func showWPComLogin(loginFields: LoginFields) {
         self.loginFields = loginFields
-        guard let vc = LoginWPComViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from Prologue > Sign in with Apple to LoginWPComViewController")
+
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedApple else {
+            presentWPLogin()
             return
         }
 
-        vc.loginFields = self.loginFields
-        vc.dismissBlock = dismissBlock
-        vc.errorToPresent = errorToPresent
-
-        navigationController?.pushViewController(vc, animated: true)
+        presentUnifiedPassword()
     }
 
     func showApple2FA(loginFields: LoginFields) {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -246,15 +246,17 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     open func needsMultifactorCode() {
         displayError(message: "")
         configureViewLoading(false)
-
+        
         WordPressAuthenticator.track(.twoFactorCodeRequested)
-
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
-            loginFields.meta.socialService == .google else {
+        
+        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedGoogle && loginFields.meta.socialService == .google
+        let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
+        
+        guard (unifiedGoogle || unifiedApple) else {
             presentLogin2FA()
             return
         }
-
+        
         presentUnified2FA()
     }
 


### PR DESCRIPTION
Ref: #352 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14647

For SIWA accounts that have a WP password set, this updates the flow to show the new Password and 2FA views.

| Password | 2FA |
|--------|-------|
| ![password](https://user-images.githubusercontent.com/1816888/90188513-d0602f80-dd78-11ea-943f-c11a21d11e29.png) | ![2fa](https://user-images.githubusercontent.com/1816888/90188520-d48c4d00-dd78-11ea-8047-d96272cbe92e.png) |
