### PR TITLE
ULS Password: add 1Password button action

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.xxx"
+  s.version       = "1.23.0-beta.11"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.10"
+  s.version       = "1.23.0-beta.xxx"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -248,8 +248,24 @@ private extension PasswordViewController {
             
             self?.configureSubmitButton(animating: false)
         }
-
-        // TODO: - add onePasswordHandler
+        
+        cell.onePasswordHandler = { [weak self] sourceView in
+            guard let self = self else {
+                return
+            }
+            
+            self.view.endEditing(true)
+            
+            // Don't update username for social accounts.
+            // This prevents inadvertent account linking.
+            let allowUsernameChange = (self.loginFields.meta.socialService == nil)
+            
+            WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sourceView, loginFields: self.loginFields, allowUsernameChange: allowUsernameChange) { [weak self] (loginFields) in
+                cell.updateEmailAddress(loginFields.username)
+                self?.passwordField?.text = loginFields.password
+                self?.validateForm()
+            }
+        }
     }
     
     /// Configure the instruction cell.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -50,6 +50,13 @@ class GravatarEmailTableViewCell: UITableViewCell {
         emailLabel?.text = email
     }
     
+    override func prepareForReuse() {
+        emailLabel.text = nil
+        gravatarImageView?.image = nil
+        
+        // Remove 1Password icon.
+        emailStackView?.arrangedSubviews.last?.removeFromSuperview()
+    }
 }
 
 // MARK: - Password Manager Handling

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -68,12 +68,10 @@ private extension GravatarEmailTableViewCell {
     /// Sets up a 1Password button if 1Password is available and user is on iOS 12.
     ///
     func setupOnePasswordButtonIfNeeded() {
-
-        // TODO: re-enable version check before merging.
         
-//        if #available(iOS 13, *) {
-//            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
-//        } else {
+        if #available(iOS 13, *) {
+            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
+        } else {
             guard let emailStackView = emailStackView else {
                 return
             }
@@ -81,7 +79,7 @@ private extension GravatarEmailTableViewCell {
             WPStyleGuide.configureOnePasswordButtonForStackView(emailStackView,
                                                                 target: self,
                                                                 selector: #selector(onePasswordTapped(_:)))
-//        }
+        }
     }
     
     @objc func onePasswordTapped(_ sender: UIButton) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -68,9 +68,12 @@ private extension GravatarEmailTableViewCell {
     /// Sets up a 1Password button if 1Password is available and user is on iOS 12.
     ///
     func setupOnePasswordButtonIfNeeded() {
-        if #available(iOS 13, *) {
-            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
-        } else {
+
+        // TODO: re-enable version check before merging.
+        
+//        if #available(iOS 13, *) {
+//            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
+//        } else {
             guard let emailStackView = emailStackView else {
                 return
             }
@@ -78,7 +81,7 @@ private extension GravatarEmailTableViewCell {
             WPStyleGuide.configureOnePasswordButtonForStackView(emailStackView,
                                                                 target: self,
                                                                 selector: #selector(onePasswordTapped(_:)))
-        }
+//        }
     }
     
     @objc func onePasswordTapped(_ sender: UIButton) {


### PR DESCRIPTION
Ref: #352 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14651

When tapping the 1Password on the email address field, 1Password is now launched.

**NOTE**: To facilitate testing, I've commented out the iOS version check. Before this is merged, I will re-enable it so the button only appears for iOS12.

<kbd>![1password_button](https://user-images.githubusercontent.com/1816888/90294405-8bed9600-de43-11ea-9747-57f0d636f1bc.jpg)</kbd>

