### PR TITLE
ULS Password view: Add VoiceOver support

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.xxx"
+  s.version       = "1.23.0-beta.yyy"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -71,6 +71,10 @@ extension WPStyleGuide {
         onePasswordButton.sizeToFit()
         onePasswordButton.setContentHuggingPriority(.required, for: .horizontal)
         onePasswordButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        
+        onePasswordButton.accessibilityTraits = .button
+        onePasswordButton.accessibilityLabel = NSLocalizedString("One Password button", comment: "Accessibility label for 1 password button")
+        onePasswordButton.accessibilityHint = NSLocalizedString("Opens One Password manager", comment: "Accessibility hint for 1 password button")
 
         stack.addArrangedSubview(onePasswordButton)
 

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -99,19 +99,6 @@ final class TwoFAViewController: LoginViewController {
         )
     }
 
-    /// Sets up accessibility elements in the order which they should be read aloud
-    /// and chooses which element to focus on at the beginning.
-    ///
-    private func configureForAccessibility() {
-        view.accessibilityElements = [
-            codeField as Any,
-            tableView,
-            submitButton as Any
-        ]
-
-        UIAccessibility.post(notification: .screenChanged, argument: codeField)
-    }
-
     override func configureViewLoading(_ loading: Bool) {
         super.configureViewLoading(loading)
         codeField?.isEnabled = !loading
@@ -431,6 +418,19 @@ private extension TwoFAViewController {
        }
     }
 
+    /// Sets up accessibility elements in the order which they should be read aloud
+    /// and chooses which element to focus on at the beginning.
+    ///
+    func configureForAccessibility() {
+        view.accessibilityElements = [
+            codeField as Any,
+            tableView,
+            submitButton as Any
+        ]
+
+        UIAccessibility.post(notification: .screenChanged, argument: codeField)
+    }
+    
     /// Rows listed in the order they were created.
     ///
     enum Row {

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -13,6 +13,7 @@ class PasswordViewController: LoginViewController {
     private weak var passwordField: UITextField?
     private var rows = [Row]()
     private var errorMessage: String?
+    private var shouldChangeVoiceOverFocus: Bool = false
 
     override var loginFields: LoginFields {
         didSet {
@@ -43,6 +44,7 @@ class PasswordViewController: LoginViewController {
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()
+        configureForAccessibility()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -96,7 +98,7 @@ class PasswordViewController: LoginViewController {
         let errorDomain = (error as NSError).domain
         if errorDomain == WordPressComOAuthClient.WordPressComOAuthErrorDomain, errorCode == WordPressComOAuthError.invalidRequest.rawValue {
             let message = NSLocalizedString("It seems like you've entered an incorrect password. Want to give it another try?", comment: "An error message shown when a wpcom user provides the wrong password.")
-            displayError(message: message)
+            displayError(message: message, moveVoiceOverFocus: true)
         } else {
             super.displayRemoteError(error)
         }
@@ -106,6 +108,8 @@ class PasswordViewController: LoginViewController {
         configureViewLoading(false)
         if errorMessage != message {
             errorMessage = message
+            shouldChangeVoiceOverFocus = moveVoiceOverFocus
+            loadRows()
             tableView.reloadData()
         }
     }
@@ -204,7 +208,7 @@ private extension PasswordViewController {
         
         rows.append(.password)
         
-        if errorMessage != nil {
+        if let errorText = errorMessage, !errorText.isEmpty {
             rows.append(.errorMessage)
         }
         
@@ -290,7 +294,7 @@ private extension PasswordViewController {
                                      and: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder)
         // Save a reference to the first textField so it can becomeFirstResponder.
         passwordField = cell.textField
-         cell.textField.delegate = self
+        cell.textField.delegate = self
         
         cell.onChangeSelectionHandler = { [weak self] textfield in
             self?.loginFields.password = textfield.nonNilTrimmedText()
@@ -298,6 +302,11 @@ private extension PasswordViewController {
         }
         
         SigninEditingState.signinEditingStateActive = true
+        
+        if UIAccessibility.isVoiceOverRunning {
+            // Quiet repetitive VoiceOver elements.
+            passwordField?.placeholder = nil
+        }
     }
     
     /// Configure the forgot password link cell.
@@ -324,6 +333,9 @@ private extension PasswordViewController {
     ///
     func configureErrorLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: errorMessage, style: .error)
+        if shouldChangeVoiceOverFocus {
+            UIAccessibility.post(notification: .layoutChanged, argument: cell)
+        }
     }
     
     /// Configure the view for an editing state.
@@ -334,6 +346,19 @@ private extension PasswordViewController {
        if SigninEditingState.signinEditingStateActive {
            passwordField?.becomeFirstResponder()
        }
+    }
+    
+    /// Sets up accessibility elements in the order which they should be read aloud
+    /// and chooses which element to focus on at the beginning.
+    ///
+    func configureForAccessibility() {
+        view.accessibilityElements = [
+            passwordField as Any,
+            tableView,
+            submitButton as Any
+        ]
+
+        UIAccessibility.post(notification: .screenChanged, argument: passwordField)
     }
     
     /// Rows listed in the order they were created.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -30,6 +30,9 @@
                         <subviews>
                             <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
                                 <rect key="frame" x="0.0" y="0.0" width="239" height="44"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" staticText="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="axC-0i-jGu"/>
                                 </constraints>


### PR DESCRIPTION
Ref: #352 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14652

This adds VoiceOver support to the unified Password view.