### PR TITLE
UL&S: Add Tracks events to DotCom Signup flow

### DIFF
--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -225,6 +225,7 @@ public class AuthenticatorAnalyticsTracker {
         let configuration = AuthenticatorAnalyticsTracker.Configuration(
             appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedApple,
             googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
+            signupEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedSignup,
             siteAuthenticationEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress)
         
         return AuthenticatorAnalyticsTracker(configuration: configuration)
@@ -233,6 +234,7 @@ public class AuthenticatorAnalyticsTracker {
     struct Configuration {
         let appleEnabled: Bool
         let googleEnabled: Bool
+        let signupEnabled: Bool
         let siteAuthenticationEnabled: Bool
     }
     
@@ -278,7 +280,8 @@ public class AuthenticatorAnalyticsTracker {
     /// - Returns: `true` if the
     ///
     public func canTrackInCurrentFlow() -> Bool {
-        return isInSiteAuthenticationFlowAndCanTrack()
+        return isInSignupFlowAndCanTrack()
+            || isInSiteAuthenticationFlowAndCanTrack()
             || isInAppleFlowAndCanTrack()
             || isInGoogleFlowAndCanTrack()
     }
@@ -294,6 +297,10 @@ public class AuthenticatorAnalyticsTracker {
 
     // MARK: - Legacy vs Unified tracking: Support Methods
     
+    private func isInSignupFlowAndCanTrack() -> Bool {
+        return configuration.siteAuthenticationEnabled && state.lastFlow == .signup
+    }
+
     private func isInSiteAuthenticationFlowAndCanTrack() -> Bool {
         return configuration.siteAuthenticationEnabled && state.lastFlow == .loginWithSiteAddress
     }

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -298,7 +298,7 @@ public class AuthenticatorAnalyticsTracker {
     // MARK: - Legacy vs Unified tracking: Support Methods
     
     private func isInSignupFlowAndCanTrack() -> Bool {
-        return configuration.siteAuthenticationEnabled && state.lastFlow == .signup
+        return configuration.signupEnabled && state.lastFlow == .signup
     }
 
     private func isInSiteAuthenticationFlowAndCanTrack() -> Bool {

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
@@ -21,8 +21,7 @@ final class SignupMagicLinkViewController: LoginViewController {
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
-        // TODO: - Tracks.
-        // WordPressAuthenticator.track(.signupMagicLinkOpenEmailClientViewed)
+        tracker.track(click: .openEmailClient)
         let linkMailPresenter = LinkMailPresenter(emailAddress: loginFields.username)
         let appSelector = AppSelector(sourceView: sender)
         linkMailPresenter.presentEmailClients(on: self, appSelector: appSelector)

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -221,7 +221,7 @@ extension UnifiedSignupViewController {
 
             }, failure: { [weak self] (error: Error) in
                 DDLogError("Request for signup link email failed.")
-                // TODO: add new Tracks event. Old: .signupMagicLinkFailed
+                self?.tracker.track(failure: error.localizedDescription)
                 self?.displayError(message: ErrorMessage.magicLinkRequestFail.description())
                 self?.configureSubmitButton(animating: false)
         })

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -228,7 +228,7 @@ extension UnifiedSignupViewController {
     }
 
     func didRequestSignupLink() {
-        // TODO: add new Tracks event. Old: .signupMagicLinkRequested
+        self.tracker.track(click: .requestMagicLink)
         WordPressAuthenticator.storeLoginInfoForTokenAuth(loginFields)
 
         guard let vc = SignupMagicLinkViewController.instantiate(from: .unifiedSignUp) else {


### PR DESCRIPTION
Closes #345 
Testing PR: tk

This PR adds new Tracks events to the new DotCom Signup flow.