### PR TITLE
ULS: Show unified 2FA view in Site Address flow.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.13"
+  s.version       = "1.23.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -248,15 +248,16 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     open func needsMultifactorCode() {
         displayError(message: "")
         configureViewLoading(false)
-
+        
         tracker.track(step: .twoFactorAuthentication, ifTrackingNotEnabled: {
             WordPressAuthenticator.track(.twoFactorCodeRequested)
         })
         
         let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedGoogle && loginFields.meta.socialService == .google
         let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
+        let unifiedSiteAddress = WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress && !loginFields.siteAddress.isEmpty
         
-        guard (unifiedGoogle || unifiedApple) else {
+        guard (unifiedGoogle || unifiedApple || unifiedSiteAddress) else {
             presentLogin2FA()
             return
         }


### PR DESCRIPTION
Ref: #336 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14664

This shows the unified 2FA view in the unified Site Address flow.

<kbd>![2fa](https://user-images.githubusercontent.com/1816888/90460018-32de6600-e0c0-11ea-9a6f-cddf8732b606.png)</kbd>

