### PR TITLE
ULS: Remove the Waiting for Google view from the navigation stack.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.x"
+  s.version       = "1.23.0-beta.y"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -447,6 +447,11 @@ extension LoginViewController {
 
 extension LoginViewController {
 
+    func removeGoogleView() {
+        // Remove the Waiting for Google view so it doesn't reappear when backing through the navigation stack.
+        navigationController?.viewControllers.removeAll(where: { $0 is GoogleAuthViewController })
+    }
+    
     func signInAppleAccount() {
         guard let token = loginFields.meta.socialServiceIDToken else {
             WordPressAuthenticator.track(.loginSocialButtonFailure, properties: ["source": SocialServiceName.apple.rawValue])

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -447,7 +447,7 @@ extension LoginViewController {
 
 extension LoginViewController {
 
-    func removeGoogleView() {
+    func removeGoogleWaitingView() {
         // Remove the Waiting for Google view so it doesn't reappear when backing through the navigation stack.
         navigationController?.viewControllers.removeAll(where: { $0 is GoogleAuthViewController })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -31,6 +31,8 @@ final class TwoFAViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        removeGoogleView()
+        
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -31,7 +31,7 @@ final class TwoFAViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        removeGoogleView()
+        removeGoogleWaitingView()
         
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
@@ -20,7 +20,7 @@ class GoogleSignupConfirmationViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        removeGoogleView()
+        removeGoogleWaitingView()
         
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
@@ -20,6 +20,8 @@ class GoogleSignupConfirmationViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        removeGoogleView()
+        
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -35,6 +35,8 @@ class PasswordViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        removeGoogleView()
+        
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
         

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -35,7 +35,7 @@ class PasswordViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        removeGoogleView()
+        removeGoogleWaitingView()
         
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)


### PR DESCRIPTION
Ref: #282 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14670

This removes the Waiting for Google view from the navigation stack when these views are displayed so that it's not redisplayed when `Back` is tapped.
- `GoogleSignupConfirmationViewController`
- `PasswordViewController`
- `TwoFAViewController`

<kbd>![Simulator Screen Shot - iPhone 11 Pro Max - 2020-08-18 at 14 11 31](https://user-images.githubusercontent.com/1816888/90560752-d2513680-e15c-11ea-91ff-185500397571.png)</kbd>