### PR TITLE
ULS: Fix actions from Social Error

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.x"
+  s.version       = "1.23.0-beta.21"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.20"
+  s.version       = "1.23.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -94,7 +94,21 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         unregisterForKeyboardEvents()
     }
 
+    /// Displays the self-hosted login form.
+    ///
+    override func loginToSelfHostedSite() {
+        guard let vc = LoginSiteAddressViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginEmailViewController to LoginSiteAddressViewController")
+            return
+        }
 
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
     // MARK: - Setup and Configuration
 
 
@@ -515,21 +529,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         }
 
         navigationController?.pushViewController(toVC, animated: true)
-    }
-
-    /// Displays the self-hosted login form.
-    ///
-    private func loginToSelfHostedSite() {
-        guard let vc = LoginSiteAddressViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from LoginEmailViewController to LoginSiteAddressViewController")
-            return
-        }
-
-        vc.loginFields = loginFields
-        vc.dismissBlock = dismissBlock
-        vc.errorToPresent = errorToPresent
-
-        navigationController?.pushViewController(vc, animated: true)
     }
 
     @IBAction func handleTextFieldDidChange(_ sender: UITextField) {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -207,17 +207,6 @@ class LoginPrologueViewController: LoginViewController {
         presentUnifiedGoogleView()
     }
 
-    /// Determines which view to present for the site address form.
-    ///
-    private func loginToSelfHostedSite() {
-        guard configuration.enableUnifiedSiteAddress else {
-            presentSelfHostedView()
-            return
-        }
-
-        presentUnifiedSiteAddressView()
-    }
-
     private func presentSignUpEmailView() {
         guard let toVC = SignupEmailViewController.instantiate(from: .signup) else {
             DDLogError("Failed to navigate to SignupEmailViewController")
@@ -256,32 +245,6 @@ class LoginPrologueViewController: LoginViewController {
         navigationController?.pushViewController(toVC, animated: true)
     }
 
-    /// Navigates to the unified site address login flow.
-    ///
-    private func presentUnifiedSiteAddressView() {
-        guard let vc = SiteAddressViewController.instantiate(from: .siteAddress) else {
-            DDLogError("Failed to navigate from LoginPrologueViewController to SiteAddressViewController")
-            return
-        }
-
-        navigationController?.pushViewController(vc, animated: true)
-    }
-
-    /// Navigates to the old self-hosted login flow.
-    ///
-    private func presentSelfHostedView() {
-        guard let vc = LoginSiteAddressViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from LoginPrologueViewController to LoginSiteAddressViewController")
-            return
-        }
-
-        vc.loginFields = loginFields
-        vc.dismissBlock = dismissBlock
-        vc.errorToPresent = errorToPresent
-
-        navigationController?.pushViewController(vc, animated: true)
-    }
- 
     private func presentWPLogin() {
         guard let vc = LoginWPComViewController.instantiate(from: .login) else {
             DDLogError("Failed to navigate from LoginPrologueViewController to LoginWPComViewController")

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -483,22 +483,7 @@ extension LoginViewController: LoginSocialErrorViewControllerDelegate {
     private func cleanupAfterSocialErrors() {
         dismiss(animated: true) {}
     }
-
-    /// Displays the self-hosted login form.
-    ///
-    private func loginToSelfHostedSite() {
-        guard let vc = LoginSiteAddressViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from LoginViewController to LoginSiteAddressViewController")
-            return
-        }
-
-        vc.loginFields = loginFields
-        vc.dismissBlock = dismissBlock
-        vc.errorToPresent = errorToPresent
-
-        navigationController?.pushViewController(vc, animated: true)
-    }
-
+    
     func retryWithEmail() {
         loginFields.username = ""
         cleanupAfterSocialErrors()
@@ -517,4 +502,41 @@ extension LoginViewController: LoginSocialErrorViewControllerDelegate {
             navigationController?.pushViewController(controller, animated: true)
         }
     }
+    /// Displays the self-hosted login form.
+    ///
+    @objc func loginToSelfHostedSite() {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress else {
+            presentSelfHostedView()
+            return
+        }
+
+        presentUnifiedSiteAddressView()
+    }
+    
+    /// Navigates to the unified site address login flow.
+    ///
+    func presentUnifiedSiteAddressView() {
+        guard let vc = SiteAddressViewController.instantiate(from: .siteAddress) else {
+            DDLogError("Failed to navigate from LoginViewController to SiteAddressViewController")
+            return
+        }
+
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
+    /// Navigates to the old self-hosted login flow.
+    ///
+    func presentSelfHostedView() {
+        guard let vc = LoginSiteAddressViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate from LoginViewController to LoginSiteAddressViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+        vc.dismissBlock = dismissBlock
+        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
 }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -480,28 +480,31 @@ extension LoginViewController {
 // MARK: - LoginSocialError delegate methods
 
 extension LoginViewController: LoginSocialErrorViewControllerDelegate {
-    private func cleanupAfterSocialErrors() {
-        dismiss(animated: true) {}
-    }
     
     func retryWithEmail() {
         loginFields.username = ""
         cleanupAfterSocialErrors()
+        navigationController?.popToRootViewController(animated: true)
     }
-
+    
     func retryWithAddress() {
         cleanupAfterSocialErrors()
         loginToSelfHostedSite()
     }
-
+    
     func retryAsSignup() {
         cleanupAfterSocialErrors()
-
+        
         if let controller = SignupEmailViewController.instantiate(from: .signup) {
             controller.loginFields = loginFields
             navigationController?.pushViewController(controller, animated: true)
         }
     }
+    
+    private func cleanupAfterSocialErrors() {
+        dismiss(animated: true) {}
+    }
+    
     /// Displays the self-hosted login form.
     ///
     @objc func loginToSelfHostedSite() {
@@ -509,7 +512,7 @@ extension LoginViewController: LoginSocialErrorViewControllerDelegate {
             presentSelfHostedView()
             return
         }
-
+        
         presentUnifiedSiteAddressView()
     }
     

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -30,6 +30,8 @@ final class SiteAddressViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        removeGoogleWaitingView()
+        
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 


### PR DESCRIPTION
Ref: #182 
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14687

When the Social Error is presented, these actions have been fixed:
- `Try with another email` - dismisses the Waiting for Google view and returns to the prologue (effectively the same as it was before the Waiting for Google view was introduced).
- `Try with the site address` - now redirects to the unified Site Address if enabled.

To note, `LoginEmailViewController` forces showing the original Site Address flow since WP email login has not been updated yet, and we don't want to switch UIs midstream.

