### PR TITLE
ULS Site Address: set accessibility identifiers used by WPiOS UI tests.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.21"
+  s.version       = "1.23.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.x"
+  s.version       = "1.23.0-beta.22"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -91,11 +91,13 @@ private extension TextFieldTableViewCell {
             textField.returnKeyType = .continue
             registerTextFieldAction()
             textField.accessibilityLabel = Constants.siteAddress
+            textField.accessibilityIdentifier = Constants.siteAddress
         case .username:
             textField.keyboardType = .default
             textField.returnKeyType = .next
             setupOnePasswordButtonIfNeeded()
             textField.accessibilityLabel = Constants.username
+            textField.accessibilityIdentifier = Constants.username
         case .password:
             textField.keyboardType = .default
             textField.returnKeyType = .continue
@@ -103,10 +105,12 @@ private extension TextFieldTableViewCell {
             showSecureTextEntryToggle = true
             configureSecureTextEntryToggle()
             textField.accessibilityLabel = Constants.password
+            textField.accessibilityIdentifier = Constants.password
         case .numericCode:
             textField.keyboardType = .numberPad
             textField.returnKeyType = .continue
             textField.accessibilityLabel = Constants.otp
+            textField.accessibilityIdentifier = Constants.otp
         }
     }
 
@@ -195,6 +199,7 @@ private extension TextFieldTableViewCell {
 
     func updateSecureTextEntryForAccessibility() {
         secureTextEntryToggle?.accessibilityLabel = Constants.showPassword
+        secureTextEntryToggle?.accessibilityIdentifier = Constants.showPassword
         secureTextEntryToggle?.accessibilityValue = textField.isSecureTextEntry ? Constants.passwordHidden : Constants.passwordShown
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -84,6 +84,9 @@ final class SiteAddressViewController: LoginViewController {
     /// Configures the appearance and state of the submit button.
     ///
     override func configureSubmitButton(animating: Bool) {
+        // This matches the string in WPiOS UI tests.
+        submitButton?.accessibilityIdentifier = "Site Address Next Button"
+        
         submitButton?.showActivityIndicator(animating)
 
         submitButton?.isEnabled = (


### PR DESCRIPTION
Ref: #283 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14696

This sets `accessibilityIdentifier`s used for WPiOS UI login tests.