### PR TITLE
UL&S: PasswordViewController: send a magic link

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.k"
+  s.version       = "1.24.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0-beta.27"
+  s.version       = "1.24.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -37,6 +37,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     ///
     public let findSiteButtonTitle: String
     public let resetPasswordButtonTitle: String
+    public let getLoginLinkButtonTitle: String
     public let textCodeButtonTitle: String
 
 	/// Placeholder text for textfields.
@@ -66,6 +67,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 createAccountButtonTitle: String = defaultStrings.createAccountButtonTitle,
                 findSiteButtonTitle: String = defaultStrings.findSiteButtonTitle,
                 resetPasswordButtonTitle: String = defaultStrings.resetPasswordButtonTitle,
+                getLoginLinkButtonTitle: String = defaultStrings.getLoginLinkButtonTitle,
                 textCodeButtonTitle: String = defaultStrings.textCodeButtonTitle,
                 gettingStartedTitle: String = defaultStrings.gettingStartedTitle,
                 logInTitle: String = defaultStrings.logInTitle,
@@ -93,6 +95,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.createAccountButtonTitle = createAccountButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
+        self.getLoginLinkButtonTitle = getLoginLinkButtonTitle
         self.textCodeButtonTitle = textCodeButtonTitle
         self.gettingStartedTitle = gettingStartedTitle
         self.logInTitle = logInTitle
@@ -141,7 +144,9 @@ public extension WordPressAuthenticatorDisplayStrings {
             findSiteButtonTitle: NSLocalizedString("Find your site address",
                                                    comment: "The hint button's title text to help users find their site address."),
             resetPasswordButtonTitle: NSLocalizedString("Reset your password",
-                                                        comment: "The secondary call-to-action button title text, for when the user can't remember their password."),
+                                                        comment: "The button title for a secondary call-to-action button. When the user can't remember their password."),
+            getLoginLinkButtonTitle: NSLocalizedString("Get a login link by email",
+                                                       comment: "The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password."),
             textCodeButtonTitle: NSLocalizedString("Text me a code instead",
                                                    comment: "The button's title text to send a 2FA code via SMS text message."),
             

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -1,6 +1,11 @@
 import WordPressUI
 import WordPressShared
 
+
+/// This class houses the "3 button view":
+/// Continue with WordPress.com, Continue with Google, Continue with Apple
+/// and a text link - Or log in by entering your site address.
+///
 class LoginPrologueLoginMethodViewController: NUXViewController {
     /// Buttons at bottom of screen
     private var buttonViewController: NUXButtonViewController?

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -31,10 +31,6 @@ final class LoginMagicLinkViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // TODO: - Delete this line when unified login by email exists.
-        // Bypasses the login by email view.
-        loginFields.username = "pamelanguyen@example.com"
-
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -43,12 +43,6 @@ class PasswordViewController: LoginViewController {
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
 
-        // TODO: Delete this when the unified login & signup by email view is completed.
-        // It assists with bypassing screens for testing purposes.
-        if loginFields.username.isEmpty {
-            loginFields.username = "pamela.nguyen@example.com"
-        }
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -45,7 +45,7 @@ class PasswordViewController: LoginViewController {
 
         // TODO: Delete this when the unified login & signup by email view is completed.
         // It assists with bypassing screens for testing purposes.
-        if loginFields.username.isEmpty && WordPressAuthenticator.shared.configuration.enableUnifiedLoginLink {
+        if loginFields.username.isEmpty {
             loginFields.username = "pamela.nguyen@example.com"
         }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -227,6 +227,7 @@ private extension PasswordViewController {
         }
         
         rows.append(.forgotPassword)
+        rows.append(.sendMagicLink)
     }
     
     /// Configure cells.
@@ -239,8 +240,10 @@ private extension PasswordViewController {
             configureInstructionLabel(cell)
         case let cell as TextFieldTableViewCell where row == .password:
             configurePasswordTextField(cell)
-        case let cell as TextLinkButtonTableViewCell:
-            configureTextLinkButton(cell)
+        case let cell as TextLinkButtonTableViewCell where row == .forgotPassword:
+            configureForgotPasswordButton(cell)
+        case let cell as TextLinkButtonTableViewCell where row == .sendMagicLink:
+            configureSendMagicLinkButton(cell)
         case let cell as TextLabelTableViewCell where row == .errorMessage:
             configureErrorLabel(cell)
         default:
@@ -325,7 +328,7 @@ private extension PasswordViewController {
     
     /// Configure the forgot password link cell.
     ///
-    func configureTextLinkButton(_ cell: TextLinkButtonTableViewCell) {
+    func configureForgotPasswordButton(_ cell: TextLinkButtonTableViewCell) {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle,
                              accessibilityTrait: .link,
                              showBorder: true)
@@ -342,6 +345,12 @@ private extension PasswordViewController {
             WordPressAuthenticator.openForgotPasswordURL(self.loginFields)
             self.tracker.track(click: .forgottenPassword)
         }
+    }
+
+    /// Configure the "send magic link" cell.
+    ///
+    func configureSendMagicLinkButton(_ cell: TextLinkButtonTableViewCell) {
+//        cell.configureButton(text: <#T##String?#>)
     }
     
     /// Configure the error message cell.
@@ -383,6 +392,7 @@ private extension PasswordViewController {
         case instructions
         case password
         case forgotPassword
+        case sendMagicLink
         case errorMessage
         
         var reuseIdentifier: String {
@@ -393,6 +403,8 @@ private extension PasswordViewController {
                 return TextLabelTableViewCell.reuseIdentifier
             case .password:
                 return TextFieldTableViewCell.reuseIdentifier
+            case .sendMagicLink:
+                return TextLinkButtonTableViewCell.reuseIdentifier
             case .forgotPassword:
                 return TextLinkButtonTableViewCell.reuseIdentifier
             case .errorMessage:

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -165,7 +165,7 @@ private extension PasswordViewController {
 // MARK: - UITextFieldDelegate
 
 extension PasswordViewController: UITextFieldDelegate {
-        
+
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if enableSubmit(animating: false) {
             validateForm()
@@ -314,7 +314,7 @@ private extension PasswordViewController {
 
         let displayStrings = WordPressAuthenticator.shared.displayStrings
         let instructions = (service == .google) ? displayStrings.googlePasswordInstructions :
-                                                  displayStrings.applePasswordInstructions
+            displayStrings.applePasswordInstructions
 
         cell.configureLabel(text: instructions)
     }
@@ -392,11 +392,11 @@ private extension PasswordViewController {
     /// Configure the view for an editing state.
     ///
     func configureViewForEditingIfNeeded() {
-       // Check the helper to determine whether an editing state should be assumed.
-       adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
-       if SigninEditingState.signinEditingStateActive {
-           passwordField?.becomeFirstResponder()
-       }
+        // Check the helper to determine whether an editing state should be assumed.
+        adjustViewForKeyboard(SigninEditingState.signinEditingStateActive)
+        if SigninEditingState.signinEditingStateActive {
+            passwordField?.becomeFirstResponder()
+        }
     }
     
     /// Sets up accessibility elements in the order which they should be read aloud
@@ -419,13 +419,9 @@ private extension PasswordViewController {
 
         let email = loginFields.username
         guard email.isValidEmail() else {
-            // This is a bit of paranoia as in practice it should never happen.
-            // However, let's make sure we give the user some useful feedback just in case.
             DDLogError("Attempted to request authentication link, but the email address did not appear valid.")
-            let alert = UIAlertController(title: NSLocalizedString("Can Not Request Link", comment: "Title of an alert letting the user know"), message: NSLocalizedString("A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address.", comment: "An error message."), preferredStyle: .alert)
-            alert.addActionWithTitle(NSLocalizedString("Need help?", comment: "Takes the user to get help"), style: .cancel, handler: { _ in WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: self, sourceTag: .loginEmail) })
-            alert.addActionWithTitle(NSLocalizedString("OK", comment: "Dismisses the alert"), style: .default, handler: nil)
-            self.present(alert, animated: true, completion: nil)
+            let alert = buildInvalidEmailAlert()
+            present(alert, animated: true, completion: nil)
             return
         }
 
@@ -463,6 +459,27 @@ private extension PasswordViewController {
         vc.loginFields = self.loginFields
         vc.loginFields.restrictToWPCom = true
         navigationController?.pushViewController(vc, animated: true)
+    }
+
+    /// Build the alert message when the email address is invalid.
+    ///
+    func buildInvalidEmailAlert() -> UIAlertController {
+        let title = NSLocalizedString("Can Not Request Link",
+                                      comment: "Title of an alert letting the user know")
+        let message = NSLocalizedString("A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address.",
+                                        comment: "An error message.")
+        let helpActionTitle = NSLocalizedString("Need help?",
+                                                comment: "Takes the user to get help")
+        let okActionTitle = NSLocalizedString("OK",
+                                              comment: "Dismisses the alert")
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addActionWithTitle(helpActionTitle,
+                                 style: .cancel,
+                                 handler: { _ in
+                                    WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: self, sourceTag: .loginEmail)
+        })
+        alert.addActionWithTitle(okActionTitle, style: .default, handler: nil)
+        return alert
     }
     
     /// Rows listed in the order they were created.

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -326,7 +326,9 @@ private extension PasswordViewController {
     /// Configure the forgot password link cell.
     ///
     func configureTextLinkButton(_ cell: TextLinkButtonTableViewCell) {
-        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle, accessibilityTrait: .link)
+        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle,
+                             accessibilityTrait: .link,
+                             showBorder: true)
         cell.actionHandler = { [weak self] in
             guard let self = self else {
                 return

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -436,11 +436,12 @@ private extension PasswordViewController {
                 // TODO: Tracks.
                 // WordPressAuthenticator.track(.loginMagicLinkFailed)
                 // WordPressAuthenticator.track(.loginFailed, error: error)
-                guard let strongSelf = self else {
+                guard let self = self else {
                     return
                 }
-                strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
-                strongSelf.configureViewLoading(false)
+
+                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                self.configureViewLoading(false)
         })
     }
 
@@ -473,12 +474,15 @@ private extension PasswordViewController {
         let okActionTitle = NSLocalizedString("OK",
                                               comment: "Dismisses the alert")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
         alert.addActionWithTitle(helpActionTitle,
                                  style: .cancel,
                                  handler: { _ in
                                     WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: self, sourceTag: .loginEmail)
         })
+
         alert.addActionWithTitle(okActionTitle, style: .default, handler: nil)
+
         return alert
     }
     

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -8,9 +8,16 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     /// Private properties
     ///
     @IBOutlet private weak var button: UIButton!
-    @IBOutlet private weak var borderline: UIView!
+    @IBOutlet private weak var borderView: UIView!
+    @IBOutlet private weak var borderWidth: NSLayoutConstraint!
     @IBAction private func textLinkButtonTapped(_ sender: UIButton) {
         actionHandler?()
+    }
+
+    /// Calculate the border based on the display
+    ///
+    private var hairlineBorderWidth: CGFloat {
+        return 1.0 / UIScreen.main.scale
     }
     
     /// Public properties
@@ -23,6 +30,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         super.awakeFromNib()
 
         button.titleLabel?.adjustsFontForContentSizeCategory = true
+        styleBorder()
     }
     
     public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits? = .button, showBorder: Bool = false) {
@@ -34,12 +42,25 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
         button.accessibilityTraits = accessibilityTraits
 
-        borderline.isHidden = !showBorder
+        borderView.isHidden = !showBorder
     }
     
     /// Toggle button enabled / disabled
     ///
     public func toggleButton(_ isEnabled: Bool) {
         button.isEnabled = isEnabled
+    }
+}
+
+
+// MARK: - Private methods
+private extension TextLinkButtonTableViewCell {
+
+    /// Style the bottom cell border, called borderView.
+    ///
+    func styleBorder() {
+        let borderColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
+        borderView.backgroundColor = borderColor
+        borderWidth.constant = hairlineBorderWidth
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -8,6 +8,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     /// Private properties
     ///
     @IBOutlet private weak var button: UIButton!
+    @IBOutlet private weak var borderline: UIView!
     @IBAction private func textLinkButtonTapped(_ sender: UIButton) {
         actionHandler?()
     }
@@ -20,11 +21,11 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+
         button.titleLabel?.adjustsFontForContentSizeCategory = true
     }
     
-    public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits? = .button) {
+    public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits? = .button, showBorder: Bool = false) {
         button.setTitle(text, for: .normal)
         
         let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
@@ -32,6 +33,8 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
         button.accessibilityTraits = accessibilityTraits
+
+        borderline.isHidden = !showBorder
     }
     
     /// Toggle button enabled / disabled

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
@@ -11,14 +11,17 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextLinkButtonTableViewCell" id="KGk-i7-Jjw" userLabel="TextLinkButtonTableViewCell" customClass="TextLinkButtonTableViewCell" customModule="WordPressAuthenticator">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="46"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="46"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="ofe-LL-CbC">
                         <rect key="frame" x="16" y="11" width="288" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="ejX-sY-dNm"/>
+                        </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                         <state key="normal" title="Button"/>
                         <connections>
@@ -26,7 +29,7 @@
                         </connections>
                     </button>
                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xr7-80-xLk">
-                        <rect key="frame" x="16" y="43" width="304" height="1"/>
+                        <rect key="frame" x="16" y="44" width="304" height="1"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="0TA-3S-RTi"/>
@@ -35,12 +38,11 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="xr7-80-xLk" secondAttribute="trailing" id="4bK-tU-GZP"/>
+                    <constraint firstItem="xr7-80-xLk" firstAttribute="top" secondItem="ofe-LL-CbC" secondAttribute="bottom" constant="11" id="BMB-7K-7dn"/>
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="PVs-Tw-W6U"/>
                     <constraint firstItem="xr7-80-xLk" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Pub-Ud-xHo"/>
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Qkb-T4-qVM"/>
-                    <constraint firstItem="ofe-LL-CbC" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" id="Z1X-9b-Yen"/>
-                    <constraint firstItem="xr7-80-xLk" firstAttribute="top" secondItem="ofe-LL-CbC" secondAttribute="bottom" constant="10" id="byM-9G-nEq"/>
-                    <constraint firstAttribute="bottom" secondItem="xr7-80-xLk" secondAttribute="bottom" id="fbb-di-NHu"/>
+                    <constraint firstAttribute="bottom" secondItem="xr7-80-xLk" secondAttribute="bottom" constant="1" id="fbb-di-NHu"/>
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="wDk-4b-EYN"/>
                 </constraints>
             </tableViewCellContentView>
@@ -49,7 +51,8 @@
             </accessibility>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="borderline" destination="xr7-80-xLk" id="YlO-xR-wAf"/>
+                <outlet property="borderView" destination="xr7-80-xLk" id="tw4-jZ-ity"/>
+                <outlet property="borderWidth" destination="0TA-3S-RTi" id="HYi-5W-eNL"/>
                 <outlet property="button" destination="ofe-LL-CbC" id="lDp-3a-YIR"/>
             </connections>
             <point key="canvasLocation" x="132" y="147"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.xib
@@ -25,11 +25,22 @@
                             <action selector="textLinkButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="nY9-jd-WF5"/>
                         </connections>
                     </button>
+                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xr7-80-xLk">
+                        <rect key="frame" x="16" y="43" width="304" height="1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="1" id="0TA-3S-RTi"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="trailing" secondItem="xr7-80-xLk" secondAttribute="trailing" id="4bK-tU-GZP"/>
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="PVs-Tw-W6U"/>
+                    <constraint firstItem="xr7-80-xLk" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Pub-Ud-xHo"/>
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Qkb-T4-qVM"/>
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" id="Z1X-9b-Yen"/>
+                    <constraint firstItem="xr7-80-xLk" firstAttribute="top" secondItem="ofe-LL-CbC" secondAttribute="bottom" constant="10" id="byM-9G-nEq"/>
+                    <constraint firstAttribute="bottom" secondItem="xr7-80-xLk" secondAttribute="bottom" id="fbb-di-NHu"/>
                     <constraint firstItem="ofe-LL-CbC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="wDk-4b-EYN"/>
                 </constraints>
             </tableViewCellContentView>
@@ -38,6 +49,7 @@
             </accessibility>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="borderline" destination="xr7-80-xLk" id="YlO-xR-wAf"/>
                 <outlet property="button" destination="ofe-LL-CbC" id="lDp-3a-YIR"/>
             </connections>
             <point key="canvasLocation" x="132" y="147"/>


### PR DESCRIPTION
Ref. #398 
Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14746

This PR
- adds the ability to send a magic link on the password entry screen
- updates the button color in Unified to "hero blue" instead of `.brand`
- doesn't have Tracks events

### To test
See testing instructions on the testing PR https://github.com/wordpress-mobile/WordPress-iOS/pull/14746

### Screenshots

| Design | Screenshot |
| --- | --- |
| <img width="344" alt="Screen Shot 2020-08-24 at 8 12 28 AM" src="https://user-images.githubusercontent.com/1062444/91182398-bd6e2900-e6af-11ea-8447-206884d5bb01.png"> | <a href="https://user-images.githubusercontent.com/1062444/91183386-0672ad00-e6b1-11ea-82d1-13e50029122d.png"><img src="https://user-images.githubusercontent.com/1062444/91183386-0672ad00-e6b1-11ea-82d1-13e50029122d.png" width="350" /></a> |

| Password errors are in-line | Magic link errors are alerts |
| --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/91183426-15f1f600-e6b1-11ea-805d-6d8038164a7a.png"><img src="https://user-images.githubusercontent.com/1062444/91183426-15f1f600-e6b1-11ea-805d-6d8038164a7a.png" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/91183459-20ac8b00-e6b1-11ea-9667-f29e1337adbd.png"><img src="https://user-images.githubusercontent.com/1062444/91183459-20ac8b00-e6b1-11ea-9667-f29e1337adbd.png" width="350" /></a> |
