### PR TITLE
UL&S: Tracks: rename step `username_password` to `password_challenge`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0"
+  s.version       = "1.23.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -95,7 +95,7 @@ public class AuthenticatorAnalyticsTracker {
         /// This represents the user opening their mail. It’s not strictly speaking an in-app screen but for the user it is part of the flow.
         case emailOpened = "email_opened"
         
-        /// The password challenge screen after connecting a social account to a WordPress account
+        /// The screen with a username and password visible
         ///
         case userPasswordScreenShown = "password_challenge"
         

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -97,7 +97,7 @@ public class AuthenticatorAnalyticsTracker {
         
         /// The screen with a username and password visible
         ///
-        case userPasswordScreenShown = "username_password"
+        case userPasswordScreenShown = "password_challenge"
         
         /// Triggered on the epilogue screen
         ///

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -95,7 +95,7 @@ public class AuthenticatorAnalyticsTracker {
         /// This represents the user opening their mail. It’s not strictly speaking an in-app screen but for the user it is part of the flow.
         case emailOpened = "email_opened"
         
-        /// The screen with a username and password visible
+        /// The password challenge screen after connecting a social account to a WordPress account
         ///
         case userPasswordScreenShown = "password_challenge"
         


### PR DESCRIPTION
Fixes #405
Test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14749

(Branched from `main`, release tag `1.23.0`. 

This PR changes the Tracks event step name from `username_password` to `password_challenge`.
Please visit the Test PR for testing steps.