### PR TITLE
UL&S: Password challenge bugfix

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.0"
+  s.version       = "1.23.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -61,9 +61,9 @@ extension WPStyleGuide {
     /// - Note: this is for the old UI.
 	///
     class func configureOnePasswordButtonForStackView(_ stack: UIStackView, target: NSObject, selector: Selector) {
-        guard OnePasswordFacade.isOnePasswordEnabled else {
-            return
-        }
+//        guard OnePasswordFacade.isOnePasswordEnabled else {
+//            return
+//        }
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -61,9 +61,9 @@ extension WPStyleGuide {
     /// - Note: this is for the old UI.
 	///
     class func configureOnePasswordButtonForStackView(_ stack: UIStackView, target: NSObject, selector: Selector) {
-//        guard OnePasswordFacade.isOnePasswordEnabled else {
-//            return
-//        }
+        guard OnePasswordFacade.isOnePasswordEnabled else {
+            return
+        }
 
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(.onePasswordImage, for: .normal)

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -104,7 +104,7 @@ class PasswordViewController: LoginViewController {
             let message = NSLocalizedString("It seems like you've entered an incorrect password. Want to give it another try?", comment: "An error message shown when a wpcom user provides the wrong password.")
             displayError(message: message, moveVoiceOverFocus: true)
         } else {
-            super.displayRemoteError(error)
+            displayError(error as NSError, sourceTag: sourceTag)
         }
     }
 
@@ -125,7 +125,23 @@ class PasswordViewController: LoginViewController {
             tableView.reloadData()
         }
     }
-    
+
+    override func validateFormAndLogin() {
+        view.endEditing(true)
+        displayError(message: "", moveVoiceOverFocus: true)
+
+        // Is everything filled out?
+        if !loginFields.validateFieldsPopulatedForSignin() {
+            let errorMsg = Constants.missingInfoError
+            displayError(message: errorMsg, moveVoiceOverFocus: true)
+
+            return
+        }
+
+        configureViewLoading(true)
+
+        loginFacade.signIn(with: loginFields)
+    }
 }
 
 // MARK: - Validation and Continue
@@ -144,7 +160,6 @@ private extension PasswordViewController {
     func validateForm() {
         validateFormAndLogin()
     }
-    
 }
 
 // MARK: - UITextFieldDelegate
@@ -399,4 +414,10 @@ private extension PasswordViewController {
         }
     }
 
+    /// Constants
+    ///
+    struct Constants {
+        static let missingInfoError = NSLocalizedString("Please fill out all the fields",
+                                                        comment: "A short prompt asking the user to properly fill out all login fields.")
+    }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -14,7 +14,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     // This results in the 1Password button being disabled as well.
     // So we add the 1Password button to a stack view instead of the email field.
     // When iOS12 support is removed, the emailStackView can be removed as it only facilitates 1Password.
-    @IBOutlet private weak var emailLabel: UITextField!
+    @IBOutlet private weak var emailLabel: UITextField?
     @IBOutlet private weak var emailStackView: UIStackView?
     
     private let gridiconSize = CGSize(width: 48, height: 48)
@@ -49,14 +49,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     func updateEmailAddress(_ email: String?) {
         emailLabel?.text = email
     }
-    
-    override func prepareForReuse() {
-        emailLabel.text = nil
-        gravatarImageView?.image = nil
-        
-        // Remove 1Password icon.
-        emailStackView?.arrangedSubviews.last?.removeFromSuperview()
-    }
+
 }
 
 // MARK: - Password Manager Handling
@@ -83,7 +76,11 @@ private extension GravatarEmailTableViewCell {
     }
     
     @objc func onePasswordTapped(_ sender: UIButton) {
-        onePasswordHandler?(emailLabel)
+        guard let emailTextField = emailLabel else {
+            return
+        }
+
+        onePasswordHandler?(emailTextField)
     }
     
     // MARK: - All Password Managers
@@ -97,7 +94,11 @@ private extension GravatarEmailTableViewCell {
     /// be deleted in favor of adding the delegate method to view controllers.
     ///
     @IBAction func textFieldDidChangeSelection() {
-        onChangeSelectionHandler?(emailLabel)
+        guard let emailTextField = emailLabel else {
+            return
+        }
+
+        onChangeSelectionHandler?(emailTextField)
     }
 
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -65,7 +65,8 @@ private extension GravatarEmailTableViewCell {
         if #available(iOS 13, *) {
             // no-op, we rely on the key icon in the keyboard to initiate a password manager.
         } else {
-            guard let emailStackView = emailStackView else {
+            guard let emailStackView = emailStackView,
+                !(emailStackView.arrangedSubviews.last is UIButton) else {
                 return
             }
             


### PR DESCRIPTION
Fixes #408 
Testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14752

After an error message occurs, the email address would disappear from the display. Sometimes the gravatar would also be wiped out and a crash would happen. This affects SIWA and Google accounts that connect to an existing WP user for the first time. 

#### Setup
Have a WordPress.com account that is disconnected from Google or SIWA.

### To test
1. Check out this branch
2. Disable the check for `.isOnePasswordEnabled` by visiting `WPStyleGuide+Login` and commenting out Lines 64-65. (Or you can check out the "Workaround - show password icon in the sims" commit.
3. Build and run
4. See testing PR for further instructions