### PR TITLE
UL&S iCloud Keychain: Basic implementation

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.3"
+  s.version       = "1.24.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -146,7 +146,9 @@
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
 		F12F9FB424D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
+		F180B82424F59263000A01F5 /* StoredCredentialsPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */; };
 		F1AF1BEF24E4A80F00BA453E /* LoginFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AF1BEE24E4A80F00BA453E /* LoginFacade.swift */; };
+		F1DE08CC24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */; };
 		FF629D9622393500004C4106 /* WordPressAuthenticator.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */; };
 /* End PBXBuildFile section */
 
@@ -330,7 +332,9 @@
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
+		F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsPicker.swift; sourceTree = "<group>"; };
 		F1AF1BEE24E4A80F00BA453E /* LoginFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFacade.swift; sourceTree = "<group>"; };
+		F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsAuthenticator.swift; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
 		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -425,6 +429,8 @@
 			isa = PBXGroup;
 			children = (
 				98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */,
+				F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */,
+				F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */,
 				CEC77C6424854EE400FB9050 /* View Related */,
 			);
 			path = "Unified Auth";
@@ -1104,6 +1110,7 @@
 				B56090F8208A533200399AE4 /* WordPressAuthenticator+Notifications.swift in Sources */,
 				98ED483624802F8F00992B2D /* GoogleAuthViewController.swift in Sources */,
 				B56090EA208A51D000399AE4 /* LoginFields+Validation.swift in Sources */,
+				F1DE08CC24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift in Sources */,
 				CE1B18CC20EEC32400BECC3F /* WordPressComCredentials.swift in Sources */,
 				98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */,
 				B560913C208A563800399AE4 /* LoginProloguePromoViewController.swift in Sources */,
@@ -1147,6 +1154,7 @@
 				CE16177521B6D82200B82A47 /* WordPressAuthenticatorDisplayStrings.swift in Sources */,
 				CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */,
 				B5609110208A54F800399AE4 /* OnePasswordFacade.swift in Sources */,
+				F180B82424F59263000A01F5 /* StoredCredentialsPicker.swift in Sources */,
 				B5609109208A54F800399AE4 /* SignupService.swift in Sources */,
 				B560913D208A563800399AE4 /* LoginProloguePageViewController.swift in Sources */,
 				B5609117208A555600399AE4 /* SearchTableViewCell.swift in Sources */,

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -232,6 +232,7 @@ public class AuthenticatorAnalyticsTracker {
     struct Configuration {
         let appleEnabled: Bool
         let googleEnabled: Bool
+        let iCloudKeychainEnabled: Bool
         let siteAddressEnabled: Bool
         let wpComEnabled: Bool
     }
@@ -240,12 +241,13 @@ public class AuthenticatorAnalyticsTracker {
         // When unit testing, WordPressAuthenticator is not always initialized.
         // The following code ensures we have configuration defaults even if that's the case.
         guard WordPressAuthenticator.isInitialized() else {
-            return Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+            return Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         }
         
         return Configuration(
             appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedApple,
             googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
+            iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
             siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress,
             wpComEnabled: false)
     }
@@ -289,13 +291,14 @@ public class AuthenticatorAnalyticsTracker {
     ///
     /// It's the responsibility of the class calling the tracking methods to check this before attempting to actually do the tracking.
     ///
-    /// - Returns: `true` if the
+    /// - Returns: `true` if we can track using the state machine.
     ///
     public func canTrackInCurrentFlow() -> Bool {
         return isInSiteAuthenticationFlowAndCanTrack()
             || isInAppleFlowAndCanTrack()
             || isInGoogleFlowAndCanTrack()
             || isInWPComFlowAndCanTrack()
+            || isInKeychainFlowAndCanTrack()
     }
     
     /// This is a convenience method, that's useful for cases where we simply want to check if the legacy tracking should be
@@ -323,6 +326,10 @@ public class AuthenticatorAnalyticsTracker {
     
     private func isInWPComFlowAndCanTrack() -> Bool {
         return configuration.wpComEnabled && state.lastFlow == .wpCom
+    }
+    
+    private func isInKeychainFlowAndCanTrack() -> Bool {
+        return configuration.iCloudKeychainEnabled && state.lastFlow == .loginWithiCloudKeychain
     }
     
     // MARK: - Tracking

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -97,6 +97,10 @@ public struct WordPressAuthenticatorConfiguration {
     /// Flag indicating if Login by Magic Link should display.
     ///
     let enableUnifiedLoginLink: Bool
+    
+    /// Flag indicating if keychain login is enabled
+    ///
+    let enableUnifiedKeychainLogin: Bool
 
     /// Designated Initializer
     ///
@@ -120,7 +124,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableUnifiedGoogle: Bool = false,
                  enableUnifiedApple: Bool = false,
                  enableUnifiedSignup: Bool = false,
-                 enableUnifiedLoginLink: Bool = false) {
+                 enableUnifiedLoginLink: Bool = false,
+                 enableUnifiedKeychainLogin: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -143,5 +148,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableUnifiedApple = enableUnifiedAuth && enableUnifiedApple
         self.enableUnifiedSignup = enableUnifiedAuth && enableUnifiedSignup
         self.enableUnifiedLoginLink = enableUnifiedAuth && enableUnifiedLoginLink
+        self.enableUnifiedKeychainLogin = enableUnifiedAuth && enableUnifiedKeychainLogin
     }
 }

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -48,6 +48,15 @@ public class LoginFields: NSObject {
         storedCredentials?.storedUserameHash = usernameHash
         storedCredentials?.storedPasswordHash = passwordHash
     }
+    
+    class func makeForWPCom(username: String, password: String) -> LoginFields {
+        let loginFields = LoginFields()
+        
+        loginFields.username = username
+        loginFields.password = password
+        
+        return loginFields
+    }
 }
 
 /// A helper class for storing safari saved password information.

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -15,6 +15,8 @@ class LoginPrologueViewController: LoginViewController {
     private let configuration = WordPressAuthenticator.shared.configuration
     private let style = WordPressAuthenticator.shared.style
 
+    private let storedCredentialsAuthenticator = StoredCredentialsAuthenticator()
+    
     @IBOutlet private weak var topContainerView: UIView!
 
     // MARK: - Lifecycle Methods
@@ -43,6 +45,8 @@ class LoginPrologueViewController: LoginViewController {
         super.viewDidAppear(animated)
         
         WordPressAuthenticator.track(.loginPrologueViewed)
+        
+        storedCredentialsAuthenticator.showPicker(in: view.window)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -15,7 +15,8 @@ class LoginPrologueViewController: LoginViewController {
     private let configuration = WordPressAuthenticator.shared.configuration
     private let style = WordPressAuthenticator.shared.style
 
-    private let storedCredentialsAuthenticator = StoredCredentialsAuthenticator()
+    @available(iOS 13, *)
+    private lazy var storedCredentialsAuthenticator = StoredCredentialsAuthenticator()
     
     @IBOutlet private weak var topContainerView: UIView!
 
@@ -46,7 +47,10 @@ class LoginPrologueViewController: LoginViewController {
         
         WordPressAuthenticator.track(.loginPrologueViewed)
         
-        storedCredentialsAuthenticator.showPicker(in: view.window)
+        if #available(iOS 13, *),
+            let window = view.window {
+                storedCredentialsAuthenticator.showPicker(in: window)
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -47,10 +47,7 @@ class LoginPrologueViewController: LoginViewController {
         
         WordPressAuthenticator.track(.loginPrologueViewed)
         
-        if #available(iOS 13, *),
-            let window = view.window {
-                storedCredentialsAuthenticator.showPicker(in: window)
-        }
+        showiCloudKeychainLoginFlow()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -61,6 +58,18 @@ class LoginPrologueViewController: LoginViewController {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UIDevice.isPad() ? .all : .portrait
+    }
+    
+    // MARK: - iCloud Keychain Login
+    
+    /// Starts the iCloud Keychain login flow if the conditions are given.
+    ///
+    private func showiCloudKeychainLoginFlow() {
+        if #available(iOS 13, *),
+            WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
+            let window = view.window {
+                storedCredentialsAuthenticator.showPicker(in: window)
+        }
     }
 
     // MARK: - Segue

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -61,7 +61,7 @@ class StoredCredentialsAuthenticator: NSObject {
             // No-op for now, but we can decide to implement AppleID login through this authenticator
             // by implementing the logic here.
             break
-        case let credential as ASPasswordCredential:
+        case _ as ASPasswordCredential:
             // TODO: No-op for now.  The code below will be enabled in my next PR.
             //
             //let loginFields = LoginFields.makeForWPCom(username: credential.user, password: credential.password)
@@ -87,13 +87,7 @@ class StoredCredentialsAuthenticator: NSObject {
             // The user cancelling the flow is not really an error, so we're not reporting or tracking
             // this as an error.  We're only tracking this as a regular UI dismissal.
             tracker.track(click: .dismiss)
-        case .failed:
-            fallthrough
-        case .invalidResponse:
-            fallthrough
-        case .notHandled:
-            fallthrough
-        case .unknown:
+        case .failed, .invalidResponse, .notHandled, .unknown:
             tracker.track(failure: authError.localizedDescription)
             DDLogError("ASAuthorizationError: \(authError.localizedDescription)")
         }

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -100,10 +100,8 @@ class StoredCredentialsAuthenticator: NSObject {
 @available(iOS 13, *)
 extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
     func needsMultifactorCode() {
-        print(">>>>>>>>>>>>>>>>> Needs multifactor code!")
     }
     
     func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
-        print(">>>>>>>>>>>>>>>>> Success!!!!")
     }
 }

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -62,8 +62,11 @@ class StoredCredentialsAuthenticator: NSObject {
             // by implementing the logic here.
             break
         case let credential as ASPasswordCredential:
-            let loginFields = LoginFields.makeForWPCom(username: credential.user, password: credential.password)
-            loginFacade.signIn(with: loginFields)
+            // TODO: No-op for now.  The code below will be enabled in my next PR.
+            //
+            //let loginFields = LoginFields.makeForWPCom(username: credential.user, password: credential.password)
+            //loginFacade.signIn(with: loginFields)
+            break
         default:
             // There aren't any other known methods for us to handle here, but we still need to complete the switch
             // statement.

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -1,8 +1,10 @@
 import Foundation
 import AuthenticationServices
 
-/// This class  implements the logic to present a UI so that our users can quickly log in with credentials stored
-/// in their iCloud Keychain, or with their Apple ID if the user has previously used SIWA with the App.
+/// The authorization flow handled by this class starts by showing Apple's `ASAuthorizationController`
+/// through our class `StoredCredentialsPicker`.  This controller lets the user pick the credentials they
+/// want to login with.  This class handles both showing that controller and executing the remaining flow to
+/// complete the login process.
 ///
 @available(iOS 13, *)
 class StoredCredentialsAuthenticator: NSObject {

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -30,6 +30,9 @@ class StoredCredentialsAuthenticator: NSObject {
     // Showing the UI
     
     func showPicker(in window: UIWindow) {
+        tracker.set(flow: .loginWithiCloudKeychain)
+        tracker.track(step: .start)
+        
         picker.show(in: window) { [weak self] result in
             guard let self = self else {
                 return
@@ -59,9 +62,6 @@ class StoredCredentialsAuthenticator: NSObject {
             // by implementing the logic here.
             break
         case let credential as ASPasswordCredential:
-            tracker.set(flow: .loginWithiCloudKeychain)
-            tracker.track(step: .start)
-            
             let loginFields = LoginFields.makeForWPCom(username: credential.user, password: credential.password)
             loginFacade.signIn(with: loginFields)
         default:

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -1,0 +1,107 @@
+import Foundation
+import AuthenticationServices
+
+/// This class  implements the logic to present a UI so that our users can quickly log in with credentials stored
+/// in their iCloud Keychain, or with their Apple ID if the user has previously used SIWA with the App.
+///
+@available(iOS 13, *)
+class StoredCredentialsAuthenticator: NSObject {
+    
+    private var authConfig: WordPressAuthenticatorConfiguration {
+        WordPressAuthenticator.shared.configuration
+    }
+    
+    private lazy var loginFacade: LoginFacade = {
+        let facade = LoginFacade(dotcomClientID: authConfig.wpcomClientId,
+                                 dotcomSecret: authConfig.wpcomSecret,
+                                 userAgent: authConfig.userAgent)
+        facade.delegate = self
+        return facade
+    }()
+    
+    private var tracker: AuthenticatorAnalyticsTracker {
+        AuthenticatorAnalyticsTracker.shared
+    }
+    
+    private let picker = StoredCredentialsPicker()
+
+    // Showing the UI
+    
+    func showPicker(in window: UIWindow) {
+        picker.show(in: window) { [weak self] result in
+            guard let self = self else {
+                return
+            }
+            
+            switch result {
+            case .success(let authorization):
+                self.pickerSuccess(authorization)
+            case .failure(let error):
+                self.pickerFailure(error)
+            }
+        }
+    }
+    
+    // MARK: - Picker Interactions
+    
+    /// The selection of credentials and subsequent authorization by the OS succeeded.  This method processes the credentials
+    /// and proceeds with the login operation.
+    ///
+    /// - Parameters:
+    ///         - authorization: The authorization by the OS, containing the credentials picked by the user.
+    ///
+    private func pickerSuccess(_ authorization: ASAuthorization) {
+        switch authorization.credential {
+        case _ as ASAuthorizationAppleIDCredential:
+            // No-op for now, but we can decide to implement AppleID login through this authenticator
+            // by implementing the logic here.
+            break
+        case let credential as ASPasswordCredential:
+            tracker.set(flow: .loginWithiCloudKeychain)
+            tracker.track(step: .start)
+            
+            let loginFields = LoginFields.makeForWPCom(username: credential.user, password: credential.password)
+            loginFacade.signIn(with: loginFields)
+        default:
+            // There aren't any other known methods for us to handle here, but we still need to complete the switch
+            // statement.
+            break
+        }
+    }
+    
+    /// The selection of credentials or the subsequent authorization by the OS failed.  This method processes the failure.
+    ///
+    /// - Parameters:
+    ///         - error: The error detailing what failed.
+    ///
+    private func pickerFailure(_ error: Error) {
+        let authError = ASAuthorizationError(_nsError: error as NSError)
+
+        switch authError.code {
+        case .canceled:
+            // The user cancelling the flow is not really an error, so we're not reporting or tracking
+            // this as an error.  We're only tracking this as a regular UI dismissal.
+            tracker.track(click: .dismiss)
+        case .failed:
+            fallthrough
+        case .invalidResponse:
+            fallthrough
+        case .notHandled:
+            fallthrough
+        case .unknown:
+            tracker.track(failure: authError.localizedDescription)
+            DDLogError("ASAuthorizationError: \(authError.localizedDescription)")
+        }
+    }
+}
+
+@available(iOS 13, *)
+extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
+    func needsMultifactorCode() {
+        print(">>>>>>>>>>>>>>>>> Needs multifactor code!")
+    }
+    
+    func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
+        print(">>>>>>>>>>>>>>>>> Success!!!!")
+    }
+}

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsPicker.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsPicker.swift
@@ -1,0 +1,58 @@
+import Foundation
+import AuthenticationServices
+
+/// Thin wrapper around `ASAuthorizationController` to avoid having to set delegate methods in the VC
+/// and to modularize / abstract the logic to show Apple's UI for picking the stored credentials.
+///
+/// This picker takes care of returning the credentials that were picked (and authorized by the iOS) through a closure.
+/// It's not within the scope of this class to take care of what happens after the credentials are picked.
+///
+@available(iOS 13, *)
+class StoredCredentialsPicker: NSObject {
+    
+    typealias CompletionClosure = (Result<ASAuthorization, Error>) -> ()
+    
+    /// The closure that will be executed once the credentials are picked and returned by the OS,
+    /// or once there's an Error.
+    ///
+    private var onComplete: CompletionClosure!
+    
+    /// The window where the quick authentication flow will be shown.
+    ///
+    private var window: UIWindow!
+
+    func show(in window: UIWindow, onComplete: @escaping CompletionClosure) {
+        
+        self.onComplete = onComplete
+        self.window = window
+        
+        let requests = [ASAuthorizationPasswordProvider().createRequest()]
+        let controller = ASAuthorizationController(authorizationRequests: requests)
+        
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        controller.performRequests()
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+@available(iOS 13, *)
+extension StoredCredentialsPicker: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        onComplete(.success(authorization))
+    }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        onComplete(.failure(error))
+    }
+}
+
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+
+@available(iOS 13, *)
+extension StoredCredentialsPicker: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return window
+    }
+}

--- a/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
+++ b/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
@@ -52,7 +52,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -82,7 +82,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -115,7 +115,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
 
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -149,7 +149,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -176,7 +176,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -205,7 +205,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -234,7 +234,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -263,7 +263,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -291,7 +291,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -319,7 +319,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -346,7 +346,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         for flow in flows {


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14734
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14760

This PR:

- Implements the iCloud Keychain configuration flag.
- Implements tracking support for iCloud Keychain flow events.
- Adds class `StoredCredentialsAuthenticator` to support the iCloud Keychain login flow (and the quick AppleID login flow in the future).
- Adds class `StoredCredentialsPicker` as a thin wrapper around `ASAuthorizationController` for convenience. 

For more details and testing steps please refer to the WPiOS PR.