### PR TITLE
ULS Get Started: add Terms of Service table cell

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.3"
+  s.version       = "1.24.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		98D9A4B12474A526002E491C /* GoogleAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */; };
 		98ED483624802F8F00992B2D /* GoogleAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ED483424802F8F00992B2D /* GoogleAuthViewController.swift */; };
 		98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98ED48382480300500992B2D /* GoogleAuth.storyboard */; };
+		98F40AF024F5E13200A72911 /* TextWithLinkTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98F40AEE24F5E13200A72911 /* TextWithLinkTableViewCell.xib */; };
+		98F40AF124F5E13200A72911 /* TextWithLinkTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F40AEF24F5E13200A72911 /* TextWithLinkTableViewCell.swift */; };
 		B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */; };
 		B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */; };
 		B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B501C040208FC52500D1E58F /* LoginFacadeTests.m */; };
@@ -207,6 +209,8 @@
 		98D9A4B02474A526002E491C /* GoogleAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleAuthenticator.swift; sourceTree = "<group>"; };
 		98ED483424802F8F00992B2D /* GoogleAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthViewController.swift; sourceTree = "<group>"; };
 		98ED48382480300500992B2D /* GoogleAuth.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GoogleAuth.storyboard; sourceTree = "<group>"; };
+		98F40AEE24F5E13200A72911 /* TextWithLinkTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TextWithLinkTableViewCell.xib; sourceTree = "<group>"; };
+		98F40AEF24F5E13200A72911 /* TextWithLinkTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextWithLinkTableViewCell.swift; sourceTree = "<group>"; };
 		AE612958059F9E80B54138B3 /* Pods-WordPressAuthenticatorTests.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release-internal.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release-internal.xcconfig"; sourceTree = "<group>"; };
 		B0D7D40BC1DE2D367761AD86 /* Pods-WordPressAuthenticatorTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginFieldsValidationTests.swift; sourceTree = "<group>"; };
@@ -783,12 +787,14 @@
 			children = (
 				CE1BBF8A24D4857F001D2E3E /* GravatarEmailTableViewCell.swift */,
 				CE1BBF8B24D48580001D2E3E /* GravatarEmailTableViewCell.xib */,
-				CE6BCD3624A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.swift */,
-				CE6BCD3724A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib */,
-				CE6BCD2C24A3A235001BCDC5 /* TextLabelTableViewCell.swift */,
-				CE6BCD2D24A3A235001BCDC5 /* TextLabelTableViewCell.xib */,
 				CE9091F52499549500AB50BD /* TextFieldTableViewCell.swift */,
 				CE9091F62499549500AB50BD /* TextFieldTableViewCell.xib */,
+				CE6BCD2C24A3A235001BCDC5 /* TextLabelTableViewCell.swift */,
+				CE6BCD2D24A3A235001BCDC5 /* TextLabelTableViewCell.xib */,
+				CE6BCD3624A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.swift */,
+				CE6BCD3724A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib */,
+				98F40AEF24F5E13200A72911 /* TextWithLinkTableViewCell.swift */,
+				98F40AEE24F5E13200A72911 /* TextWithLinkTableViewCell.xib */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -933,6 +939,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5E07FF4208FD13800657A9A /* Assets.xcassets in Resources */,
+				98F40AF024F5E13200A72911 /* TextWithLinkTableViewCell.xib in Resources */,
 				B56090CA208A4F5400399AE4 /* NUXButtonView.storyboard in Resources */,
 				B560911E208A555E00399AE4 /* Signup.storyboard in Resources */,
 				CEA2DBFE24E5DEEC00EC2AD6 /* UnifiedSignup.storyboard in Resources */,
@@ -1178,6 +1185,7 @@
 				B5609107208A54F800399AE4 /* WordPressComBlogService.swift in Sources */,
 				B560910D208A54F800399AE4 /* WordPressXMLRPCAPIFacade.m in Sources */,
 				B5ED791F207E993E00A8FD8C /* CocoaLumberjack.swift in Sources */,
+				98F40AF124F5E13200A72911 /* TextWithLinkTableViewCell.swift in Sources */,
 				B5609123208A557700399AE4 /* WordPressComSiteInfo.swift in Sources */,
 				B56090CC208A4F5400399AE4 /* NUXTableViewController.swift in Sources */,
 				CE30A2A722579F4100DF3CDA /* LoginUsernamePasswordViewController.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -39,6 +39,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let findSiteButtonTitle: String
     public let resetPasswordButtonTitle: String
     public let textCodeButtonTitle: String
+    public let loginTermsOfService: String
 
 	/// Placeholder text for textfields.
 	///
@@ -69,6 +70,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 findSiteButtonTitle: String = defaultStrings.findSiteButtonTitle,
                 resetPasswordButtonTitle: String = defaultStrings.resetPasswordButtonTitle,
                 textCodeButtonTitle: String = defaultStrings.textCodeButtonTitle,
+                loginTermsOfService: String = defaultStrings.loginTermsOfService,
                 getStartedTitle: String = defaultStrings.getStartedTitle,
                 logInTitle: String = defaultStrings.logInTitle,
                 signUpTitle: String = defaultStrings.signUpTitle,
@@ -97,6 +99,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.findSiteButtonTitle = findSiteButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
         self.textCodeButtonTitle = textCodeButtonTitle
+        self.loginTermsOfService = loginTermsOfService
         self.getStartedTitle = getStartedTitle
         self.logInTitle = logInTitle
         self.signUpTitle = signUpTitle
@@ -149,7 +152,7 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                         comment: "The secondary call-to-action button title text, for when the user can't remember their password."),
             textCodeButtonTitle: NSLocalizedString("Text me a code instead",
                                                    comment: "The button's title text to send a 2FA code via SMS text message."),
-            
+            loginTermsOfService:NSLocalizedString("By continuing, you agree to our _Terms of Service_.", comment: "Legal disclaimer for logging in. The underscores _..._ denote underline."),
             getStartedTitle: NSLocalizedString("Get Started",
                                                comment: "View title for initial auth views."),
             logInTitle: NSLocalizedString("Log In",

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SafariServices
 
 class GetStartedViewController: LoginViewController {
 
@@ -64,7 +65,8 @@ private extension GetStartedViewController {
     ///
     func registerTableViewCells() {
         let cells = [
-            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib()
+            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
+            TextWithLinkTableViewCell.reuseIdentifier: TextWithLinkTableViewCell.loadNib()
         ]
         
         for (reuseIdentifier, nib) in cells {
@@ -75,15 +77,17 @@ private extension GetStartedViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.instructions]
+        rows = [.instructions, .tos]
     }
     
     /// Configure cells.
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
-        case let cell as TextLabelTableViewCell where row == .instructions:
+        case let cell as TextLabelTableViewCell:
             configureInstructionLabel(cell)
+        case let cell as TextWithLinkTableViewCell:
+            configureTextWithLink(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -95,15 +99,39 @@ private extension GetStartedViewController {
         cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.getStartedInstructions)
     }
     
+    /// Configure the link cell.
+    ///
+    func configureTextWithLink(_ cell: TextWithLinkTableViewCell) {
+        cell.configureButton(markedText: WordPressAuthenticator.shared.displayStrings.loginTermsOfService)
+        
+        cell.actionHandler = { [weak self] in
+            guard let self = self,
+            let url = URL(string: WordPressAuthenticator.shared.configuration.wpcomTermsOfServiceURL) else {
+                return
+            }
+            
+            self.tracker.track(click: .termsOfService)
+
+            let safariViewController = SFSafariViewController(url: url)
+            safariViewController.modalPresentationStyle = .pageSheet
+            self.present(safariViewController, animated: true, completion: nil)
+        }
+    }
+
+    
     /// Rows listed in the order they were created.
     ///
     enum Row {
         case instructions
+        case tos
         
         var reuseIdentifier: String {
             switch self {
             case .instructions:
                 return TextLabelTableViewCell.reuseIdentifier
+            case .tos:
+                return TextWithLinkTableViewCell.reuseIdentifier
+                
             }
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -33,7 +33,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         styleBorder()
     }
     
-    public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits = .button) {
+    public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits = .button, showBorder: Bool = false) {
         button.setTitle(text, for: .normal)
         
         let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
@@ -41,6 +41,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
         button.accessibilityTraits = accessibilityTrait
+        
         borderView.isHidden = !showBorder
     }
     

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -24,14 +24,14 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         button.titleLabel?.adjustsFontForContentSizeCategory = true
     }
     
-    public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits? = .button) {
+    public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits = .button) {
         button.setTitle(text, for: .normal)
         
         let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
         let buttonHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
-        button.accessibilityTraits = accessibilityTraits
+        button.accessibilityTraits = accessibilityTrait
     }
     
     /// Toggle button enabled / disabled
@@ -39,4 +39,5 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     public func toggleButton(_ isEnabled: Bool) {
         button.isEnabled = isEnabled
     }
+
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+
+/// TextWithLinkTableViewCell: a button with the title regular text and an underlined link.
+///
+class TextWithLinkTableViewCell: UITableViewCell {
+
+    /// Public properties
+    ///
+    static let reuseIdentifier = "TextWithLinkTableViewCell"
+    var actionHandler: (() -> Void)?
+
+    /// Private properties
+    ///
+    @IBOutlet private weak var button: UIButton!
+    @IBAction private func buttonTapped(_ sender: UIButton) {
+        actionHandler?()
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+    }
+    
+    /// Creates an attributed string from the provided marked text and assigns it to the button title.
+    ///
+    /// - Parameters:
+    ///   - markedText: string with the text to be formatted as a link marked with "_".
+    ///     Example: "this _is_ a link" will format "is" as an underlined link.
+    ///   - accessibilityTrait: accessibilityTrait of button (optional)
+    ///
+    func configureButton(markedText text: String, accessibilityTrait: UIAccessibilityTraits = .link) {
+        let textColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
+        let linkColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
+        let linkHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
+
+        let attributedString = text.underlined(color: textColor, underlineColor: linkColor)
+        let highlightAttributedString = text.underlined(color: textColor, underlineColor: linkHighlightColor)
+        
+        button.setAttributedTitle(attributedString, for: .normal)
+        button.setAttributedTitle(highlightAttributedString, for: .highlighted)
+        button.accessibilityTraits = accessibilityTrait
+    }
+
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.xib
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextWithLinkTableViewCell" id="1v0-Gz-0yA" userLabel="TextLinkButtonTableViewCell" customClass="TextWithLinkTableViewCell" customModule="WordPressAuthenticator">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1v0-Gz-0yA" id="H42-hC-6W2">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="vWl-fM-piV">
+                        <rect key="frame" x="16" y="11" width="288" height="22"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                        <state key="normal" title="Button"/>
+                        <connections>
+                            <action selector="buttonTapped:" destination="1v0-Gz-0yA" eventType="touchUpInside" id="q1a-i8-DT6"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="vWl-fM-piV" firstAttribute="trailing" secondItem="H42-hC-6W2" secondAttribute="trailingMargin" id="04a-ws-Jge"/>
+                    <constraint firstItem="vWl-fM-piV" firstAttribute="top" secondItem="H42-hC-6W2" secondAttribute="topMargin" id="Otd-vu-Rze"/>
+                    <constraint firstItem="vWl-fM-piV" firstAttribute="leading" secondItem="H42-hC-6W2" secondAttribute="leadingMargin" id="W6H-cG-tj6"/>
+                    <constraint firstItem="vWl-fM-piV" firstAttribute="bottom" secondItem="H42-hC-6W2" secondAttribute="bottomMargin" id="qgo-hT-03b"/>
+                </constraints>
+            </tableViewCellContentView>
+            <accessibility key="accessibilityConfiguration">
+                <accessibilityTraits key="traits" button="YES"/>
+            </accessibility>
+            <viewLayoutGuide key="safeArea" id="qhn-AX-uHg"/>
+            <connections>
+                <outlet property="button" destination="vWl-fM-piV" id="VrK-Yq-4Rp"/>
+            </connections>
+            <point key="canvasLocation" x="132" y="147"/>
+        </tableViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
Ref: #404 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14769

This adds a new `TextWithLinkTableViewCell` that displays a button with the title containing regular text + linked text.

This is used in the Get Started view to display the login Terms of Service. Tapping the button (the entire text area) will open the TOS web page.

| ![get_started_tos](https://user-images.githubusercontent.com/1816888/91355906-11f6ce80-e7ac-11ea-8d7e-d9a8638dbbad.png) | ![tos_page](https://user-images.githubusercontent.com/1816888/91355919-16bb8280-e7ac-11ea-98dc-79e1d7dfdc61.png) |
|--------|-------|

