### PR TITLE
ULS Get Started: add Email Address field

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.x"
+  s.version       = "1.24.0-beta.y"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -47,6 +47,7 @@ public struct WordPressAuthenticatorDisplayStrings {
 	public let passwordPlaceholder: String
     public let siteAddressPlaceholder: String
     public let twoFactorCodePlaceholder: String
+    public let emailAddressPlaceholder: String
 
     /// Designated initializer.
     ///
@@ -78,7 +79,8 @@ public struct WordPressAuthenticatorDisplayStrings {
                 usernamePlaceholder: String = defaultStrings.usernamePlaceholder,
                 passwordPlaceholder: String = defaultStrings.passwordPlaceholder,
                 siteAddressPlaceholder: String = defaultStrings.siteAddressPlaceholder,
-                twoFactorCodePlaceholder: String = defaultStrings.twoFactorCodePlaceholder) {
+                twoFactorCodePlaceholder: String = defaultStrings.twoFactorCodePlaceholder,
+                emailAddressPlaceholder: String = defaultStrings.emailAddressPlaceholder) {
         self.emailLoginInstructions = emailLoginInstructions
         self.getStartedInstructions = getStartedInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
@@ -108,6 +110,7 @@ public struct WordPressAuthenticatorDisplayStrings {
 		self.passwordPlaceholder = passwordPlaceholder
         self.siteAddressPlaceholder = siteAddressPlaceholder
         self.twoFactorCodePlaceholder = twoFactorCodePlaceholder
+        self.emailAddressPlaceholder = emailAddressPlaceholder
     }
 }
 
@@ -117,19 +120,19 @@ public extension WordPressAuthenticatorDisplayStrings {
             emailLoginInstructions: NSLocalizedString("Log in to your WordPress.com account with your email address.",
                                                       comment: "Instruction text on the login's email address screen."),
             getStartedInstructions: NSLocalizedString("Enter your email address to log in or create a WordPress.com account.",
-            comment: "Instruction text on the initial email address entry screen."),
+                                                      comment: "Instruction text on the initial email address entry screen."),
             jetpackLoginInstructions: NSLocalizedString("Log in to the WordPress.com account you used to connect Jetpack.",
                                                         comment: "Instruction text on the login's email address screen."),
             siteLoginInstructions: NSLocalizedString("Enter the address of the WordPress site you'd like to connect.",
                                                      comment: "Instruction text on the login's site addresss screen."),
-			siteCredentialInstructions: NSLocalizedString("Enter your account information for %@.",
-														  comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
+            siteCredentialInstructions: NSLocalizedString("Enter your account information for %@.",
+                                                          comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
             twoFactorInstructions: NSLocalizedString("Please enter the verification code from your authenticator app, or tap the link below to receive a code via SMS.",
                                                      comment: "Instruction text on the two-factor screen."),
             magicLinkSignupInstructions: NSLocalizedString("We'll email you a magic link to create your new WordPress.com account.",
-                                                     comment: "Instruction text on the Sign Up screen."),
+                                                           comment: "Instruction text on the Sign Up screen."),
             openMailSignupInstructions: NSLocalizedString("We’ve emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.",
-                                                    comment: "Instruction text after a signup Magic Link was requested."),
+                                                          comment: "Instruction text after a signup Magic Link was requested."),
             openMailLoginInstructions: NSLocalizedString("Check your email on this device, and tap the link in the email you receive from WordPress.com.",
                                                          comment: "Instruction text after a login Magic Link was requested."),
             checkSpamInstructions: NSLocalizedString("Not seeing the email? Check your Spam or Junk Mail folder.", comment: "Instructions after a Magic Link was sent, but the email can't be found in their inbox."),
@@ -139,7 +142,7 @@ public extension WordPressAuthenticatorDisplayStrings {
             applePasswordInstructions: NSLocalizedString("To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.",
                                                          comment: "Instructional text shown when requesting the user's password for Apple login."),
             continueButtonTitle: NSLocalizedString("Continue",
-                                                    comment: "The button title text when there is a next step for logging in or signing up."),
+                                                   comment: "The button title text when there is a next step for logging in or signing up."),
             magicLinkButtonTitle: NSLocalizedString("Send Link by Email",
                                                     comment: "The button title text for sending a magic link."),
             openMailButtonTitle: NSLocalizedString("Open Mail",
@@ -161,14 +164,16 @@ public extension WordPressAuthenticatorDisplayStrings {
                                            comment: "View title during the sign up process."),
             waitingForGoogleTitle: NSLocalizedString("Waiting...",
                                                      comment: "View title during the Google auth process."),
-			usernamePlaceholder: NSLocalizedString("Username",
-												   comment: "Placeholder for the username textfield."),
-			passwordPlaceholder: NSLocalizedString("Password",
-												   comment: "Placeholder for the password textfield."),
+            usernamePlaceholder: NSLocalizedString("Username",
+                                                   comment: "Placeholder for the username textfield."),
+            passwordPlaceholder: NSLocalizedString("Password",
+                                                   comment: "Placeholder for the password textfield."),
             siteAddressPlaceholder: NSLocalizedString("example.com",
-                                                  comment: "Placeholder for the site url textfield."),
+                                                      comment: "Placeholder for the site url textfield."),
             twoFactorCodePlaceholder: NSLocalizedString("Authentication code",
-                                                  comment: "Placeholder for the 2FA code textfield.")
+                                                        comment: "Placeholder for the 2FA code textfield."),
+            emailAddressPlaceholder: NSLocalizedString("Email address",
+                                                       comment: "Placeholder for the email address textfield.")
         )
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -66,6 +66,7 @@ private extension GetStartedViewController {
     func registerTableViewCells() {
         let cells = [
             TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
+            TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib(),
             TextWithLinkTableViewCell.reuseIdentifier: TextWithLinkTableViewCell.loadNib()
         ]
         
@@ -77,7 +78,7 @@ private extension GetStartedViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.instructions, .tos]
+        rows = [.instructions, .email, .tos]
     }
     
     /// Configure cells.
@@ -86,6 +87,8 @@ private extension GetStartedViewController {
         switch cell {
         case let cell as TextLabelTableViewCell:
             configureInstructionLabel(cell)
+        case let cell as TextFieldTableViewCell:
+            configureEmailField(cell)
         case let cell as TextWithLinkTableViewCell:
             configureTextWithLink(cell)
         default:
@@ -97,6 +100,13 @@ private extension GetStartedViewController {
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.getStartedInstructions)
+    }
+    
+    /// Configure the textfield cell.
+    ///
+    func configureEmailField(_ cell: TextFieldTableViewCell) {
+        cell.configureTextFieldStyle(with: .email,
+                                     and: WordPressAuthenticator.shared.displayStrings.emailAddressPlaceholder)
     }
     
     /// Configure the link cell.
@@ -123,12 +133,15 @@ private extension GetStartedViewController {
     ///
     enum Row {
         case instructions
+        case email
         case tos
         
         var reuseIdentifier: String {
             switch self {
             case .instructions:
                 return TextLabelTableViewCell.reuseIdentifier
+            case .email:
+                return TextFieldTableViewCell.reuseIdentifier
             case .tos:
                 return TextWithLinkTableViewCell.reuseIdentifier
                 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -111,6 +111,11 @@ private extension TextFieldTableViewCell {
             textField.returnKeyType = .continue
             textField.accessibilityLabel = Constants.otp
             textField.accessibilityIdentifier = Constants.otp
+        case .email:
+            textField.keyboardType = .emailAddress
+            textField.returnKeyType = .continue
+            textField.accessibilityLabel = Constants.email
+            textField.accessibilityIdentifier = Constants.email
         }
     }
 
@@ -215,6 +220,7 @@ extension TextFieldTableViewCell {
         case username
         case password
         case numericCode
+        case email
     }
 
     struct Constants {
@@ -234,5 +240,7 @@ extension TextFieldTableViewCell {
                                                 comment: "Accessibility label for the password text field in the self-hosted login page.")
         static let otp = NSLocalizedString("Authentication code",
                                            comment: "Accessibility label for the 2FA text field.")
+        static let email = NSLocalizedString("Email address",
+                                             comment: "Accessibility label for the email address text field.")
     }
 }


### PR DESCRIPTION
Ref: #404 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14771

This shows an Email Address field in the Get Started view. It doesn't do anything yet.

To note, it is _not_ made first responder because the keyboard will cover the social options at the bottom (coming soon). If you tap in the email field, the keyboard will then show.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-08-26 at 16 30 48](https://user-images.githubusercontent.com/1816888/91363280-88e69400-e7b9-11ea-9ab8-9187b041d6ac.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-08-26 at 16 30 51](https://user-images.githubusercontent.com/1816888/91363291-8f750b80-e7b9-11ea-980d-822bd29b6ef4.png) |
|--------|-------|
