### PR TITLE
Fixes an issue with the save password prompt.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.8"
+  s.version       = "1.24.0-beta.9"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -70,6 +70,10 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
             // There was a bug that was causing iOS's update password prompt to come up
             // when this VC was being dismissed pressing the "< Back" button.  The following
             // line ensures that such prompt doesn't come up anymore.
+            //
+            // More information can be found in the PR where this workaround is introduced:
+            //  https://git.io/JUkak
+            //
             passwordField?.text = ""
         }
     }

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -65,6 +65,13 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
+        
+        if isMovingFromParent {
+            // There was a bug that was causing iOS's update password prompt to come up
+            // when this VC was being dismissed pressing the "< Back" button.  The following
+            // line ensures that such prompt doesn't come up anymore.
+            passwordField?.text = ""
+        }
     }
 
 


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14772

The original issue was that the App was prompting the user to update their password in the keychain, in a scenario where the user was dismissing the VC by pressing "< Back".

Please check the WPiOS PR for reproduction and testing instructions.