### PR TITLE
ULS: fix unified Google issues

### DIFF
--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -134,7 +134,19 @@ extension LoginSocialErrorViewController {
 
 extension LoginSocialErrorViewController {
     private func numberOfButtonsToShow() -> Int {
-        return loginFields.restrictToWPCom ? Buttons.count - 1 : Buttons.count
+        
+        var buttonCount = loginFields.restrictToWPCom ? Buttons.count - 1 : Buttons.count
+        
+        // Don't show the Signup Retry if showing unified social flows.
+        // At this point, we've already tried signup and are past it.
+        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedGoogle && loginFields.meta.socialService == .google
+        let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
+
+        if unifiedGoogle || unifiedApple {
+            buttonCount -= 1
+        }
+        
+        return buttonCount
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -8,6 +8,7 @@ protocol LoginSocialErrorViewControllerDelegate {
     func retryWithEmail()
     func retryWithAddress()
     func retryAsSignup()
+    func errorDismissed()
 }
 
 /// ViewController for presenting recovery options when social login fails
@@ -17,6 +18,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
     @objc var delegate: LoginSocialErrorViewControllerDelegate?
     
     private var forUnified: Bool = false
+    private var actionButtonTapped: Bool = false
     
     fileprivate enum Sections: Int {
         case titleAndDescription = 0
@@ -67,6 +69,14 @@ class LoginSocialErrorViewController: NUXTableViewController {
         styleBackground()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if !actionButtonTapped {
+            delegate?.errorDismissed()
+        }
+    }
+    
     private func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
             view.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
@@ -82,6 +92,8 @@ class LoginSocialErrorViewController: NUXTableViewController {
             return
         }
 
+        actionButtonTapped = true
+        
         switch indexPath.row {
         case Buttons.tryEmail.rawValue:
             delegate.retryWithEmail()

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -504,6 +504,11 @@ extension LoginViewController: LoginSocialErrorViewControllerDelegate {
         }
     }
     
+    func errorDismissed() {
+        loginFields.username = ""
+        navigationController?.popToRootViewController(animated: true)
+    }
+    
     private func cleanupAfterSocialErrors() {
         dismiss(animated: true) {}
     }

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -196,7 +196,6 @@ private extension GoogleAuthenticator {
         static let googleConnected = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
         static let googleConnectedError = NSLocalizedString("The Google account \"%@\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
         static let googleUnableToConnect = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
-        static let processing = NSLocalizedString("Processing Account", comment: "Shown while the app waits for the account process to complete.")
     }
 
 }
@@ -243,7 +242,7 @@ extension GoogleAuthenticator: GIDSignInDelegate {
             // Initiate separate WP login / signup paths.
             switch authType {
             case .login:
-                SVProgressHUD.show(withStatus: LocalizedText.processing)
+                SVProgressHUD.show()
                 loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
             case .signup:
                 createWordPressComUser(user: user, token: token, email: email)
@@ -253,7 +252,7 @@ extension GoogleAuthenticator: GIDSignInDelegate {
         }
 
         // Initiate unified path by attempting to login first.
-        SVProgressHUD.show(withStatus: LocalizedText.processing)
+        SVProgressHUD.show()
         loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
     }
     
@@ -348,7 +347,7 @@ private extension GoogleAuthenticator {
     /// Creates a WordPress.com account with the associated Google User + Google Token + Google Email.
     ///
     func createWordPressComUser(user: GIDGoogleUser, token: String, email: String) {
-        SVProgressHUD.show(withStatus: LocalizedText.processing)
+        SVProgressHUD.show()
         let service = SignupService()
         
         tracker.set(flow: .signupWithGoogle)

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuth.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuth.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -13,17 +13,17 @@
             <objects>
                 <viewController storyboardIdentifier="GoogleAuthViewController" id="nkP-9y-aas" customClass="GoogleAuthViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qQD-Kd-Dmk">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="social-signup-waiting" translatesAutoresizingMaskIntoConstraints="NO" id="UWt-Xu-XZp">
-                                <rect key="frame" x="375.5" y="308" width="273" height="152"/>
+                                <rect key="frame" x="70.5" y="377" width="273" height="152"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="UWt-Xu-XZp" secondAttribute="height" multiplier="273:152" id="rJg-QF-nzN"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Waiting for Google to complete…" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzq-mF-V4b">
-                                <rect key="frame" x="20" y="490" width="984" height="21"/>
+                                <rect key="frame" x="20" y="559" width="374" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="GL3-rH-WLV"/>
                                 </constraints>

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuth.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuth.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -11,19 +11,19 @@
         <!--Google Auth View Controller-->
         <scene sceneID="MMt-yQ-y29">
             <objects>
-                <viewController storyboardIdentifier="GoogleAuthViewController" id="nkP-9y-aas" customClass="GoogleAuthViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="GoogleAuthViewController" id="nkP-9y-aas" customClass="GoogleAuthViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qQD-Kd-Dmk">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="social-signup-waiting" translatesAutoresizingMaskIntoConstraints="NO" id="UWt-Xu-XZp">
-                                <rect key="frame" x="80" y="382.5" width="254" height="141"/>
+                                <rect key="frame" x="375.5" y="308" width="273" height="152"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="UWt-Xu-XZp" secondAttribute="height" multiplier="273:152" id="rJg-QF-nzN"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Waiting for Google to complete…" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzq-mF-V4b">
-                                <rect key="frame" x="20" y="553.5" width="374" height="21"/>
+                                <rect key="frame" x="20" y="490" width="984" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="GL3-rH-WLV"/>
                                 </constraints>
@@ -35,7 +35,6 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="wzq-mF-V4b" firstAttribute="centerX" secondItem="UWt-Xu-XZp" secondAttribute="centerX" id="0LH-s7-5YN"/>
-                            <constraint firstItem="UWt-Xu-XZp" firstAttribute="leading" secondItem="qQD-Kd-Dmk" secondAttribute="leading" constant="80" id="22D-HU-NSr"/>
                             <constraint firstItem="wzq-mF-V4b" firstAttribute="top" secondItem="UWt-Xu-XZp" secondAttribute="bottom" constant="30" id="PCR-54-cOa"/>
                             <constraint firstItem="v8C-Wi-7gi" firstAttribute="trailing" secondItem="wzq-mF-V4b" secondAttribute="trailing" constant="20" id="QgU-Ot-BdI"/>
                             <constraint firstItem="wzq-mF-V4b" firstAttribute="leading" secondItem="v8C-Wi-7gi" secondAttribute="leading" constant="20" id="ZEh-9u-dC6"/>


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/282
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14779

This fixes several issues in the unified Google flow:
- The Waiting for Google view is now removed when the Social Error view is dismissed by a means other than selecting an option (i.e dragging down, tapping off).
- On the Social Error view, the signup option is no longer shown for unified social flows. 1) It was showing the old signup, mucking up the nav bar. 2) At this point, we've already tried signup, so allowing this option is pointless.
- The `Processing Account` message has been removed from the HUD.
- The Waiting for Google image is now a proper size on iPad.

Note: The podspec version has been updated to `1.23.3` in the `1.23.3` branch, so it's not updated here.