### PR TITLE
ULS: correct nav bar colors in iOS12

### DIFF
--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -150,8 +150,6 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         
         if forUnified {
             // Unified nav bar style
-            setupNavBarIcon(showIcon: false)
-            setHelpButtonTextColor(forUnified: true)
             backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.navBarBackgroundColor ??
                               WordPressAuthenticator.shared.style.navBarBackgroundColor
             buttonTextColor = WordPressAuthenticator.shared.unifiedStyle?.navButtonTextColor ??
@@ -161,29 +159,32 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             hideBottomBorder = true
         } else {
             // Original nav bar style
-            setupNavBarIcon()
-            setHelpButtonTextColor(forUnified: false)
             backgroundColor = WordPressAuthenticator.shared.style.navBarBackgroundColor
             buttonTextColor = WordPressAuthenticator.shared.style.navButtonTextColor
             titleTextColor = WordPressAuthenticator.shared.style.primaryTitleColor
             hideBottomBorder = false
         }
 
+        setupNavBarIcon(showIcon: !forUnified)
+        setHelpButtonTextColor(forUnified: forUnified)
+        
+        let buttonItemAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [LoginNavigationController.self])
+        buttonItemAppearance.tintColor = buttonTextColor
+        buttonItemAppearance.setTitleTextAttributes([.foregroundColor: buttonTextColor], for: .normal)
+        
         if #available(iOS 13.0, *) {
             let appearance = UINavigationBarAppearance()
             appearance.shadowColor = hideBottomBorder ? .clear : .separator
             appearance.backgroundColor = backgroundColor
             appearance.titleTextAttributes = [.foregroundColor: titleTextColor]
-            UIBarButtonItem.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).tintColor = buttonTextColor
             
             UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).standardAppearance = appearance
             UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).compactAppearance = appearance
             UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).scrollEdgeAppearance = appearance
         } else {
-            let appearance = UINavigationBar.appearance()
+            let appearance = UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self])
             appearance.barTintColor = backgroundColor
             appearance.titleTextAttributes = [.foregroundColor: titleTextColor]
-            UIBarButtonItem.appearance().tintColor = buttonTextColor
         }
     }
     


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/315
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14781

This fixes the nav bar colors when Support is shown from a unified Auth view in iOS12. 
- When Support is shown, it uses the host app nav bar style.
- When it is dismissed, the Auth views use the unified nav bar style.

Note: The podspec version has been updated to `1.23.3` in the `1.23.3` branch, so it's not updated here.

For reference - this fix is basically backporting this change that is already in `develop` - https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/402/files#diff-e5d0c11414c47546041eebbd700297f2

| ![site_address](https://user-images.githubusercontent.com/1816888/91506308-0cbe8000-e88f-11ea-8636-a80452189765.png) | ![support](https://user-images.githubusercontent.com/1816888/91506316-10520700-e88f-11ea-9063-d5f052c91658.png) |
|--------|-------|