### PR TITLE
UL&S iCloud Keychain: implements 2FA support.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.10"
+  s.version       = "1.24.0-beta.11"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -128,8 +128,8 @@ extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
             return
         }
         
-        guard let vc = Login2FAViewController.instantiate(from: .login) else {
-            DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
+        guard let vc = TwoFAViewController.instantiate(from: .twoFA) else {
+            DDLogError("Failed to navigate from LoginViewController to TwoFAViewController")
             return
         }
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14734
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14783

This PR implements 2FA support for iCloud Keychain.

Please refer to the WPiOS PR for testing instructions.