### PR TITLE
ULS Get Started: add Continue button

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.x"
+  s.version       = "1.24.0-beta.12"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.11"
+  s.version       = "1.24.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -10,11 +10,25 @@ class GetStartedViewController: LoginViewController {
 
     private var rows = [Row]()
 
+    // Submit button displayed in the table footer.
+    private let continueButton: NUXButton = {
+        let button = NUXButton()
+        button.isPrimary = true
+        
+        let title = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
+        button.setTitle(title, for: .normal)
+        button.setTitle(title, for: .highlighted)
+        
+        return button
+    }()
+    
     override open var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginEmail
         }
     }
+    
+    // MARK: - View
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,6 +37,7 @@ class GetStartedViewController: LoginViewController {
         setupTable()
         registerTableViewCells()
         loadRows()
+        setupContinueButton()
     }
 
     // MARK: - Overrides
@@ -59,6 +74,22 @@ private extension GetStartedViewController {
         setTableViewMargins(forWidth: view.frame.width)
     }
 
+    func setupContinueButton() {
+        let tableFooter = UIView(frame: Constants.footerFrame)
+        tableFooter.addSubview(continueButton)
+        tableFooter.pinSubviewToSafeArea(continueButton, insets: Constants.footerButtonInsets)
+        continueButton.translatesAutoresizingMaskIntoConstraints = false
+        continueButton.isEnabled = false
+        continueButton.addTarget(self, action: #selector(handleSubmitButtonTapped(_:)), for: .touchUpInside)
+        tableView.tableFooterView = tableFooter
+    }
+
+    // MARK: - Button Actions
+    
+    @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {
+        // TODO: validateForm()
+    }
+    
     // MARK: - Table Management
     
     /// Registers all of the available TableViewCells.
@@ -128,7 +159,6 @@ private extension GetStartedViewController {
         }
     }
 
-    
     /// Rows listed in the order they were created.
     ///
     enum Row {
@@ -147,6 +177,11 @@ private extension GetStartedViewController {
                 
             }
         }
+    }
+    
+    enum Constants {
+        static let footerFrame = CGRect(x: 0, y: 0, width: 0, height: 44)
+        static let footerButtonInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
     }
     
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.xib
@@ -10,14 +10,14 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextWithLinkTableViewCell" id="1v0-Gz-0yA" userLabel="TextLinkButtonTableViewCell" customClass="TextWithLinkTableViewCell" customModule="WordPressAuthenticator">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TextWithLinkTableViewCell" rowHeight="44" id="1v0-Gz-0yA" userLabel="TextWithLinkTableViewCell" customClass="TextWithLinkTableViewCell" customModule="WordPressAuthenticator">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1v0-Gz-0yA" id="H42-hC-6W2">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="vWl-fM-piV">
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="vWl-fM-piV">
                         <rect key="frame" x="16" y="11" width="288" height="22"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <state key="normal" title="Button"/>
@@ -28,9 +28,9 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="vWl-fM-piV" firstAttribute="trailing" secondItem="H42-hC-6W2" secondAttribute="trailingMargin" id="04a-ws-Jge"/>
-                    <constraint firstItem="vWl-fM-piV" firstAttribute="top" secondItem="H42-hC-6W2" secondAttribute="topMargin" id="Otd-vu-Rze"/>
+                    <constraint firstItem="vWl-fM-piV" firstAttribute="bottom" secondItem="H42-hC-6W2" secondAttribute="bottomMargin" id="GX3-tv-Mp5"/>
+                    <constraint firstItem="vWl-fM-piV" firstAttribute="top" secondItem="H42-hC-6W2" secondAttribute="topMargin" id="U6M-h5-glf"/>
                     <constraint firstItem="vWl-fM-piV" firstAttribute="leading" secondItem="H42-hC-6W2" secondAttribute="leadingMargin" id="W6H-cG-tj6"/>
-                    <constraint firstItem="vWl-fM-piV" firstAttribute="bottom" secondItem="H42-hC-6W2" secondAttribute="bottomMargin" id="qgo-hT-03b"/>
                 </constraints>
             </tableViewCellContentView>
             <accessibility key="accessibilityConfiguration">
@@ -40,7 +40,7 @@
             <connections>
                 <outlet property="button" destination="vWl-fM-piV" id="VrK-Yq-4Rp"/>
             </connections>
-            <point key="canvasLocation" x="132" y="147"/>
+            <point key="canvasLocation" x="131.8840579710145" y="164.0625"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
Ref: #404 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14800

This adds a `Continue` button to the Get Started table footer so it appears directly under the TOS link. It is not yet functional. Stay tuned!

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-08-28 at 19 00 00](https://user-images.githubusercontent.com/1816888/91624985-e6691500-e960-11ea-8a85-fabee3951f90.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-08-28 at 19 00 47](https://user-images.githubusercontent.com/1816888/91624992-ecf78c80-e960-11ea-8a6a-078fbd0679d1.png) |
|--------|-------|

| ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-08-28 at 19 02 52](https://user-images.githubusercontent.com/1816888/91625012-25976600-e961-11ea-9164-50342bdad27b.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-08-28 at 19 03 13](https://user-images.githubusercontent.com/1816888/91625027-3fd14400-e961-11ea-86eb-6a3bb54f7115.png) |
|--------|-------|

