### PR TITLE
UL&S: Update the prologue buttons

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.11"
+  s.version       = "1.24.0-beta.pbj"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.pbj"
+  s.version       = "1.24.0-beta.14"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -89,6 +89,17 @@ class LoginPrologueViewController: LoginViewController {
             return
         }
 
+        guard configuration.enableUnifiedWordPress else {
+            buildPrologueButtons(buttonViewController)
+            return
+        }
+
+        buildUnifiedPrologueButtons(buttonViewController)
+    }
+
+    /// Displays the old UI prologue buttons.
+    ///
+    private func buildPrologueButtons(_ buttonViewController: NUXButtonViewController) {
         let loginTitle = NSLocalizedString("Log In", comment: "Button title.  Tapping takes the user to the login form.")
         let createTitle = NSLocalizedString("Sign up for WordPress.com", comment: "Button title. Tapping begins the process of creating a WordPress.com account.")
 
@@ -102,12 +113,43 @@ class LoginPrologueViewController: LoginViewController {
                 self?.signupTapped()
             }
         }
+
         if showCancel {
             let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
             buttonViewController.setupTertiaryButton(title: cancelTitle, isPrimary: false) { [weak self] in
                 self?.dismiss(animated: true, completion: nil)
             }
         }
+
+        buttonViewController.backgroundColor = style.buttonViewBackgroundColor
+    }
+
+    /// Displays the Unified prologue buttons.
+    ///
+    private func buildUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController) {
+        let loginTitle = NSLocalizedString("Continue with WordPress.com",
+                                           comment: "Button title. Takes the user to the login by email flow.")
+        let siteAddressTitle = NSLocalizedString("Enter your site address",
+                                                 comment: "Button title. Takes the user to the login by site address flow.")
+
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
+            self?.onLoginButtonTapped?()
+            self?.loginTapped()
+        }
+
+        if configuration.enableUnifiedSiteAddress {
+            buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Self Hosted Login Button") { [weak self] in
+                self?.siteAddressTapped()
+            }
+        }
+
+        if showCancel {
+            let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
+            buttonViewController.setupTertiaryButton(title: cancelTitle, isPrimary: false) { [weak self] in
+                self?.dismiss(animated: true, completion: nil)
+            }
+        }
+
         buttonViewController.backgroundColor = style.buttonViewBackgroundColor
     }
 
@@ -228,6 +270,15 @@ class LoginPrologueViewController: LoginViewController {
         }
         
         presentUnifiedGoogleView()
+    }
+
+    /// Unified prologue button "Enter your site address" tap action.
+    ///
+    private func siteAddressTapped() {
+        tracker.set(flow: .loginWithSiteAddress)
+        tracker.track(click: .loginWithSiteAddress)
+
+        loginToSelfHostedSite()
     }
 
     private func presentSignUpEmailView() {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -134,7 +134,7 @@ class LoginPrologueViewController: LoginViewController {
 
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
             self?.onLoginButtonTapped?()
-            self?.loginTapped()
+            self?.continueWithDotCom()
         }
 
         if configuration.enableUnifiedSiteAddress {
@@ -155,58 +155,48 @@ class LoginPrologueViewController: LoginViewController {
 
     // MARK: - Actions
 
+    /// Old UI. "Log In" button action.
+    ///
     private func loginTapped() {
         tracker.set(source: .default)
-        
-        if configuration.showLoginOptions {
-            guard let vc = LoginPrologueLoginMethodViewController.instantiate(from: .login) else {
-                DDLogError("Failed to navigate to LoginPrologueLoginMethodViewController from LoginPrologueViewController")
-                return
-            }
 
-            vc.transitioningDelegate = self
-
-            // Continue with WordPress.com button action
-            vc.emailTapped = { [weak self] in
-                guard let self = self else {
-                    return
-                }
-
-                guard self.configuration.enableUnifiedWordPress else {
-                    self.presentLoginEmailView()
-                    return
-                }
-
-                self.presentGetStartedView()
-            }
-
-            // Continue with Google button action
-            vc.googleTapped = { [weak self] in
-                self?.googleTapped()
-            }
-
-            // Site address text link button action
-            vc.selfHostedTapped = { [weak self] in
-                self?.loginToSelfHostedSite()
-            }
-
-            // Sign In With Apple (SIWA) button action
-            vc.appleTapped = { [weak self] in
-                self?.appleTapped()
-            }
-
-            vc.modalPresentationStyle = .custom
-            navigationController?.present(vc, animated: true, completion: nil)
-        } else {
-            guard let vc = GetStartedViewController.instantiate(from: .getStarted) else {
-                DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
-                return
-            }
-
-            navigationController?.pushViewController(vc, animated: true)
+        guard let vc = LoginPrologueLoginMethodViewController.instantiate(from: .login) else {
+            DDLogError("Failed to navigate to LoginPrologueLoginMethodViewController from LoginPrologueViewController")
+            return
         }
+
+        vc.transitioningDelegate = self
+
+        // Continue with WordPress.com button action
+        vc.emailTapped = { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            self.presentLoginEmailView()
+        }
+
+        // Continue with Google button action
+        vc.googleTapped = { [weak self] in
+            self?.googleTapped()
+        }
+
+        // Site address text link button action
+        vc.selfHostedTapped = { [weak self] in
+            self?.loginToSelfHostedSite()
+        }
+
+        // Sign In With Apple (SIWA) button action
+        vc.appleTapped = { [weak self] in
+            self?.appleTapped()
+        }
+
+        vc.modalPresentationStyle = .custom
+        navigationController?.present(vc, animated: true, completion: nil)
     }
 
+    /// Old UI. "Sign up with WordPress.com" button action.
+    ///
     private func signupTapped() {
         tracker.set(source: .default)
         
@@ -272,7 +262,18 @@ class LoginPrologueViewController: LoginViewController {
         presentUnifiedGoogleView()
     }
 
-    /// Unified prologue button "Enter your site address" tap action.
+    /// Unified "Continue with WordPress.com" prologue button action.
+    ///
+    private func continueWithDotCom() {
+        guard let vc = GetStartedViewController.instantiate(from: .getStarted) else {
+            DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
+            return
+        }
+
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
+    /// Unified "Enter your site address" prologue button action.
     ///
     private func siteAddressTapped() {
         tracker.set(flow: .loginWithSiteAddress)

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -133,7 +133,6 @@ class LoginPrologueViewController: LoginViewController {
                                                  comment: "Button title. Takes the user to the login by site address flow.")
 
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
-            self?.onLoginButtonTapped?()
             self?.continueWithDotCom()
         }
 


### PR DESCRIPTION
Closes #429 
Testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14805

This PR updates the prologue buttons' title, colors, and behaviors. 

When the host app has enabled the `.unifiedWordPress` flag and the `.unifiedSiteAddress` flag, display the new prologue buttons.

1. Tapping on "Continue with WordPress.com" navigates the user to the new Get Started view (aka unified WP.com login & signup flow).
2. Tapping on "Enter your site address" navigates the user to the unified Site Address flow.

<img width="252" alt="Screen Shot 2020-08-31 at 11 57 01 AM" src="https://user-images.githubusercontent.com/1062444/91745750-17c02b80-eb81-11ea-9697-6d0246086b13.png">
