### PR TITLE
ULS Get Started: add "OR" divider view

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.x"
+  s.version       = "1.24.0-beta.15"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.14"
+  s.version       = "1.24.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -26,6 +26,12 @@ extension WPStyleGuide {
         static let verticalLabelSpacing: CGFloat = 10.0
     }
 
+    /// Calculate the border based on the display
+    ///
+    class var hairlineBorderWidth: CGFloat {
+        return 1.0 / UIScreen.main.scale
+    }
+    
     /// Common view style for signin view controllers.
     ///
     /// - Parameters:

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStarted.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStarted.storyboard
@@ -20,19 +20,41 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="449"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="456"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
                                             <outlet property="delegate" destination="aQT-Gx-U3x" id="2xB-Wr-Hdh"/>
                                         </connections>
                                     </tableView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n9k-F6-dyh" userLabel="Other Options Separator">
-                                        <rect key="frame" x="0.0" y="449" width="375" height="33"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="f1j-fj-w73" userLabel="Divider Stack View">
+                                        <rect key="frame" x="0.0" y="456" width="375" height="16"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Lc-Sw-Jlx" userLabel="Leading LIne">
+                                                <rect key="frame" x="0.0" y="7.5" width="173.5" height="1"/>
+                                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="Z6B-bC-BjQ"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OR" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QDu-95-gF8" userLabel="Divider Label">
+                                                <rect key="frame" x="178.5" y="0.0" width="18.5" height="16"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GHG-oC-OAf" userLabel="Trailing LIne">
+                                                <rect key="frame" x="202" y="7.5" width="173" height="1"/>
+                                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="2ZE-YT-ZFH"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="33" id="RKT-f1-s6Z"/>
+                                            <constraint firstItem="QDu-95-gF8" firstAttribute="centerX" secondItem="f1j-fj-w73" secondAttribute="centerX" id="dze-LI-gGD"/>
                                         </constraints>
-                                    </view>
+                                    </stackView>
                                     <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c0A-wK-EYS" userLabel="Button Container View">
                                         <rect key="frame" x="0.0" y="482" width="375" height="185"/>
                                         <constraints>
@@ -45,8 +67,8 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstItem="n9k-F6-dyh" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="Odd-QL-CxQ"/>
-                                    <constraint firstItem="c0A-wK-EYS" firstAttribute="top" secondItem="n9k-F6-dyh" secondAttribute="bottom" id="gga-bc-wyq"/>
+                                    <constraint firstItem="c0A-wK-EYS" firstAttribute="top" secondItem="f1j-fj-w73" secondAttribute="bottom" constant="10" id="OYW-cs-zFh"/>
+                                    <constraint firstItem="f1j-fj-w73" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="RGk-wN-Zgt"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -55,11 +77,11 @@
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="c0A-wK-EYS" secondAttribute="bottom" id="73l-a1-EZl"/>
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
+                            <constraint firstItem="f1j-fj-w73" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="DU0-wo-2QI"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
-                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="n9k-F6-dyh" secondAttribute="trailing" id="UWa-K9-KOE"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
-                            <constraint firstItem="n9k-F6-dyh" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="fYW-4x-6rp"/>
+                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="f1j-fj-w73" secondAttribute="trailing" id="ir4-hA-zeL"/>
                             <constraint firstItem="c0A-wK-EYS" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="k1g-Ot-UbY"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="c0A-wK-EYS" secondAttribute="trailing" id="m0w-6D-5q6"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
@@ -69,9 +91,14 @@
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="Dva-c1-u2U" id="Mq1-PI-MuN"/>
+                        <outlet property="dividerLabel" destination="QDu-95-gF8" id="Mjt-XK-h7a"/>
+                        <outlet property="leadingDividerLine" destination="8Lc-Sw-Jlx" id="EVQ-Jg-oKZ"/>
+                        <outlet property="leadingDividerLineWidth" destination="Z6B-bC-BjQ" id="Tor-0G-bt8"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="MGk-sG-xGv"/>
                         <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
                         <outlet property="tableViewTrailingConstraint" destination="7MD-ux-8i0" id="jbD-Z7-rAn"/>
+                        <outlet property="trailingDividerLine" destination="GHG-oC-OAf" id="ObM-ec-SqR"/>
+                        <outlet property="trailingDividerLineWidth" destination="2ZE-YT-ZFH" id="Dul-FQ-qlg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ipm-G3-kY7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -7,6 +7,11 @@ class GetStartedViewController: LoginViewController {
     
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+    @IBOutlet private weak var leadingDividerLine: UIView!
+    @IBOutlet private weak var leadingDividerLineWidth: NSLayoutConstraint!
+    @IBOutlet private weak var dividerLabel: UILabel!
+    @IBOutlet private weak var trailingDividerLine: UIView!
+    @IBOutlet private weak var trailingDividerLineWidth: NSLayoutConstraint!
 
     private var rows = [Row]()
 
@@ -38,6 +43,7 @@ class GetStartedViewController: LoginViewController {
         registerTableViewCells()
         loadRows()
         setupContinueButton()
+        configureDivider()
     }
 
     // MARK: - Overrides
@@ -84,6 +90,18 @@ private extension GetStartedViewController {
         tableView.tableFooterView = tableFooter
     }
 
+    /// Style the "OR" divider.
+    ///
+    func configureDivider() {
+        let color = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
+        leadingDividerLine.backgroundColor = color
+        leadingDividerLineWidth.constant = WPStyleGuide.hairlineBorderWidth
+        trailingDividerLine.backgroundColor = color
+        trailingDividerLineWidth.constant = WPStyleGuide.hairlineBorderWidth
+        dividerLabel.textColor = color
+        dividerLabel.text = NSLocalizedString("Or", comment: "Divider on initial auth view separating auth options.").localizedUppercase
+    }
+    
     // MARK: - Button Actions
     
     @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -14,10 +14,6 @@ final class TextFieldTableViewCell: UITableViewCell {
     private var secureTextEntryImageHidden: UIImage?
     private var textfieldStyle: TextFieldStyle = .url
 
-    private var hairlineBorderWidth: CGFloat {
-        return 1.0 / UIScreen.main.scale
-    }
-
     /// Register an action for the SiteAddress URL textfield.
     /// - Note: we have to manually add an action to the textfield
     ///	        because the delegate method `textFieldDidChangeSelection(_ textField: UITextField)`
@@ -71,7 +67,7 @@ private extension TextFieldTableViewCell {
     func styleBorder() {
         let borderColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         borderView.backgroundColor = borderColor
-        borderWidth.constant = hairlineBorderWidth
+        borderWidth.constant = WPStyleGuide.hairlineBorderWidth
     }
 
     /// Apply common keyboard traits and font styles.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -13,12 +13,6 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     @IBAction private func textLinkButtonTapped(_ sender: UIButton) {
         actionHandler?()
     }
-
-    /// Calculate the border based on the display
-    ///
-    private var hairlineBorderWidth: CGFloat {
-        return 1.0 / UIScreen.main.scale
-    }
     
     /// Public properties
     ///
@@ -62,6 +56,6 @@ private extension TextLinkButtonTableViewCell {
     func styleBorder() {
         let borderColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         borderView.backgroundColor = borderColor
-        borderWidth.constant = hairlineBorderWidth
+        borderWidth.constant = WPStyleGuide.hairlineBorderWidth
     }
 }


### PR DESCRIPTION
Ref: #404 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14811

This adds the "OR" divider view above the bottom button view (which is still unconfigured, so it's still a big blank space). 

| ![iphone_light](https://user-images.githubusercontent.com/1816888/91884879-1441a880-ec44-11ea-82b4-408f405e9d77.png) | ![iphone_dark](https://user-images.githubusercontent.com/1816888/91884895-199ef300-ec44-11ea-86e4-316b81689eed.png) |
|--------|-------|


| ![ipad_light](https://user-images.githubusercontent.com/1816888/91884912-1f94d400-ec44-11ea-81f5-a5261d16589d.png) | ![ipad_dark](https://user-images.githubusercontent.com/1816888/91884927-24f21e80-ec44-11ea-989f-7d5c834b502d.png) |
|--------|-------|