### PR TITLE
UL&S Tracking: adds tracking to the WPcom button in the prologue.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.15"
+  s.version       = "1.24.0-beta.16"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -249,7 +249,7 @@ public class AuthenticatorAnalyticsTracker {
             googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
             iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
             siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress,
-            wpComEnabled: false)
+            wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedWordPress)
     }
     
     /// State for the analytics tracker.

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -133,12 +133,22 @@ class LoginPrologueViewController: LoginViewController {
                                                  comment: "Button title. Takes the user to the login by site address flow.")
 
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
-            self?.continueWithDotCom()
+            guard let self = self else {
+                return
+            }
+            
+            self.tracker.set(flow: .wpCom)
+            self.tracker.track(click: .continueWithWordPressCom)
+            self.continueWithDotCom()
         }
 
         if configuration.enableUnifiedSiteAddress {
             buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Self Hosted Login Button") { [weak self] in
-                self?.siteAddressTapped()
+                guard let self = self else {
+                    return
+                }
+                
+                self.siteAddressTapped()
             }
         }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -144,11 +144,7 @@ class LoginPrologueViewController: LoginViewController {
 
         if configuration.enableUnifiedSiteAddress {
             buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Self Hosted Login Button") { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                
-                self.siteAddressTapped()
+                self?.siteAddressTapped()
             }
         }
 


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14816

Adds tracking to the WPCom button that was added to the prologue screen in this PR: wordpress-mobile/WordPressAuthenticator-iOS#430

The Site Address button required no changes as the tracking is in the method being called.

Please refer to the WPiOS PR for testing instructions.