### PR TITLE
ULS Get Started: add Social login options

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.0-beta.15"
+  s.version       = "1.24.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -41,6 +41,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let getLoginLinkButtonTitle: String
     public let textCodeButtonTitle: String
     public let loginTermsOfService: String
+    public let signupTermsOfService: String
 
 	/// Placeholder text for textfields.
 	///
@@ -74,6 +75,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 getLoginLinkButtonTitle: String = defaultStrings.getLoginLinkButtonTitle,
                 textCodeButtonTitle: String = defaultStrings.textCodeButtonTitle,
                 loginTermsOfService: String = defaultStrings.loginTermsOfService,
+                signupTermsOfService: String = defaultStrings.signupTermsOfService,
                 getStartedTitle: String = defaultStrings.getStartedTitle,
                 logInTitle: String = defaultStrings.logInTitle,
                 signUpTitle: String = defaultStrings.signUpTitle,
@@ -105,6 +107,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.getLoginLinkButtonTitle = getLoginLinkButtonTitle
         self.textCodeButtonTitle = textCodeButtonTitle
         self.loginTermsOfService = loginTermsOfService
+        self.signupTermsOfService = signupTermsOfService
         self.getStartedTitle = getStartedTitle
         self.logInTitle = logInTitle
         self.signUpTitle = signUpTitle
@@ -161,6 +164,7 @@ public extension WordPressAuthenticatorDisplayStrings {
             textCodeButtonTitle: NSLocalizedString("Text me a code instead",
                                                    comment: "The button's title text to send a 2FA code via SMS text message."),
             loginTermsOfService:NSLocalizedString("By continuing, you agree to our _Terms of Service_.", comment: "Legal disclaimer for logging in. The underscores _..._ denote underline."),
+            signupTermsOfService: NSLocalizedString("If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_.", comment: "Legal disclaimer for signing up. The underscores _..._ denote underline."),
             getStartedTitle: NSLocalizedString("Get Started",
                                                comment: "View title for initial auth views."),
             logInTitle: NSLocalizedString("Log In",

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -285,7 +285,27 @@ extension WPStyleGuide {
         return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: .center)
     }
 
-    private class func textButton(normal normalString: NSAttributedString, highlighted highlightString: NSAttributedString, font: UIFont, alignment: UIControl.NaturalContentHorizontalAlignment = .leading) -> UIButton {
+    /// Creates a button to open our T&C.
+    /// Specifically, the Sign Up verbiage on the Get Started view.
+    /// - Returns: A properly styled UIButton
+    ///
+    class func signupTermsButton() -> UIButton {
+        let unifiedStyle = WordPressAuthenticator.shared.unifiedStyle
+        let originalStyle = WordPressAuthenticator.shared.style
+        let baseString = WordPressAuthenticator.shared.displayStrings.signupTermsOfService
+        let textColor = unifiedStyle?.textSubtleColor ?? originalStyle.subheadlineColor
+        let linkColor = unifiedStyle?.textButtonColor ?? originalStyle.textButtonColor
+        
+        let attrStrNormal = baseString.underlined(color: textColor, underlineColor: linkColor)
+        let attrStrHighlight = baseString.underlined(color: textColor, underlineColor: linkColor)
+        let font = WPStyleGuide.mediumWeightFont(forStyle: .footnote)
+
+        let button = textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: .center, forUnified: true)
+        button.titleLabel?.textAlignment = .center
+        return button
+    }
+    
+    private class func textButton(normal normalString: NSAttributedString, highlighted highlightString: NSAttributedString, font: UIFont, alignment: UIControl.NaturalContentHorizontalAlignment = .leading, forUnified: Bool = false) -> UIButton {
         let button = SubheadlineButton()
         button.clipsToBounds = true
 
@@ -294,15 +314,16 @@ extension WPStyleGuide {
         button.titleLabel?.font = font
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.lineBreakMode = .byWordWrapping
-        button.setTitleColor(WordPressAuthenticator.shared.style.subheadlineColor, for: .normal) 
+        button.setTitleColor(WordPressAuthenticator.shared.style.subheadlineColor, for: .normal)
 
         // These constraints work around some issues with multiline buttons and
         // vertical layout.  Without them the button's height may not account
         // for the titleLabel's height.
-        button.titleLabel?.topAnchor.constraint(equalTo: button.topAnchor, constant: Constants.verticalLabelSpacing).isActive = true
-        button.titleLabel?.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -Constants.verticalLabelSpacing).isActive = true
+        
+        let verticalLabelSpacing = forUnified ? 0 : Constants.verticalLabelSpacing
+        button.titleLabel?.topAnchor.constraint(equalTo: button.topAnchor, constant: verticalLabelSpacing).isActive = true
+        button.titleLabel?.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -verticalLabelSpacing).isActive = true
         button.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.textButtonMinHeight).isActive = true
-
 
         button.setAttributedTitle(normalString, for: .normal)
         button.setAttributedTitle(highlightString, for: .highlighted)

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -111,6 +111,10 @@ open class NUXButtonViewController: UIViewController {
         topButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
     }
 
+    func setupTopButtonFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) {
+        topButtonConfig = buttonConfigFor(socialService: socialService, onTap: callback)
+    }
+    
     func setupBottomButton(title: String, isPrimary: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {
         bottomButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
     }
@@ -128,6 +132,10 @@ open class NUXButtonViewController: UIViewController {
         tertiaryButtonConfig = buttonConfigFor(socialService: socialService, onTap: callback)
     }
 
+    func hideShadowView() {
+        shadowView?.isHidden = true
+    }
+    
     // MARK: - Helpers
 
     private func buttonConfigFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) -> NUXButtonConfig {

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStarted.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStarted.storyboard
@@ -20,7 +20,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="456"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="451"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
@@ -28,7 +28,7 @@
                                         </connections>
                                     </tableView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="f1j-fj-w73" userLabel="Divider Stack View">
-                                        <rect key="frame" x="0.0" y="456" width="375" height="16"/>
+                                        <rect key="frame" x="0.0" y="451" width="375" height="16"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Lc-Sw-Jlx" userLabel="Leading LIne">
                                                 <rect key="frame" x="0.0" y="7.5" width="173.5" height="1"/>
@@ -56,9 +56,9 @@
                                         </constraints>
                                     </stackView>
                                     <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c0A-wK-EYS" userLabel="Button Container View">
-                                        <rect key="frame" x="0.0" y="482" width="375" height="185"/>
+                                        <rect key="frame" x="0.0" y="467" width="375" height="200"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="185" id="yDo-SO-kax"/>
+                                            <constraint firstAttribute="height" constant="200" placeholder="YES" id="yDo-SO-kax"/>
                                         </constraints>
                                         <connections>
                                             <segue destination="X2o-oZ-7LG" kind="embed" id="FOr-lU-Bf2"/>
@@ -67,7 +67,7 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstItem="c0A-wK-EYS" firstAttribute="top" secondItem="f1j-fj-w73" secondAttribute="bottom" constant="10" id="OYW-cs-zFh"/>
+                                    <constraint firstItem="c0A-wK-EYS" firstAttribute="top" secondItem="f1j-fj-w73" secondAttribute="bottom" id="OYW-cs-zFh"/>
                                     <constraint firstItem="f1j-fj-w73" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="RGk-wN-Zgt"/>
                                 </constraints>
                             </view>
@@ -82,8 +82,8 @@
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="f1j-fj-w73" secondAttribute="trailing" id="ir4-hA-zeL"/>
-                            <constraint firstItem="c0A-wK-EYS" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="k1g-Ot-UbY"/>
-                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="c0A-wK-EYS" secondAttribute="trailing" id="m0w-6D-5q6"/>
+                            <constraint firstItem="c0A-wK-EYS" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" id="k1g-Ot-UbY"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="c0A-wK-EYS" secondAttribute="trailing" id="m0w-6D-5q6"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
                         </constraints>


### PR DESCRIPTION
Ref: #404 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14817

This adds Apple, Google, and TOS buttons to the bottom button view. All are functional, so:
- Apple shows the unified Apple flow.
- Google shows the unified Google flow.
- TOS shows the TOS web page.

| ![iphone_light](https://user-images.githubusercontent.com/1816888/91914374-238d1a00-ec75-11ea-987d-5c418075a5be.png) | ![iphone_dark](https://user-images.githubusercontent.com/1816888/91914388-2a1b9180-ec75-11ea-80f8-1d946b9ae226.png) |
|--------|-------|

| ![ipad_light](https://user-images.githubusercontent.com/1816888/91914484-71a21d80-ec75-11ea-9fd3-23f281b840f6.png) | ![ipad_dark](https://user-images.githubusercontent.com/1816888/91914494-75ce3b00-ec75-11ea-9d09-c63b24d583c8.png) |
|--------|-------|