### PR TITLE
UL&S Tracking: fix several tracking issues

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.3"
+  s.version       = "1.23.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -77,6 +77,10 @@ public class AuthenticatorAnalyticsTracker {
         /// This flow represents the signup (when the user inputs an email that’s not registered with a .com account)
         ///
         case signup
+        
+        /// This flow represents the prologue screen.
+        ///
+        case prologue
     }
     
     public enum Step: String {
@@ -257,7 +261,7 @@ public class AuthenticatorAnalyticsTracker {
         var lastSource: Source
         var lastStep: Step
         
-        init(lastFlow: Flow = .wpCom, lastSource: Source = .default, lastStep: Step = .prologue) {
+        init(lastFlow: Flow = .prologue, lastSource: Source = .default, lastStep: Step = .prologue) {
             self.lastFlow = lastFlow
             self.lastSource = lastSource
             self.lastStep = lastStep
@@ -296,6 +300,7 @@ public class AuthenticatorAnalyticsTracker {
             || isInAppleFlowAndCanTrack()
             || isInGoogleFlowAndCanTrack()
             || isInWPComFlowAndCanTrack()
+            || isInPrologueFlow()
     }
     
     /// This is a convenience method, that's useful for cases where we simply want to check if the legacy tracking should be
@@ -323,6 +328,10 @@ public class AuthenticatorAnalyticsTracker {
     
     private func isInWPComFlowAndCanTrack() -> Bool {
         return configuration.wpComEnabled && state.lastFlow == .wpCom
+    }
+    
+    private func isInPrologueFlow() -> Bool {
+        return state.lastFlow == .prologue
     }
     
     // MARK: - Tracking
@@ -449,12 +458,22 @@ public class AuthenticatorAnalyticsTracker {
     
     // MARK: - Source & Flow
     
+    /// Allows the caller to set the flow without tracking.
+    ///
     func set(flow: Flow) {
         state.lastFlow = flow
     }
     
+    /// Allows the caller to set the source without tracking.
+    ///
     func set(source: Source) {
         state.lastSource = source
+    }
+    
+    /// Allows the caller to set the step without tracking.
+    ///
+    func set(step: Step) {
+        state.lastStep = step
     }
     
     // MARK: - Properties

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -236,6 +236,7 @@ public class AuthenticatorAnalyticsTracker {
     struct Configuration {
         let appleEnabled: Bool
         let googleEnabled: Bool
+        let prologueEnabled: Bool
         let siteAddressEnabled: Bool
         let wpComEnabled: Bool
     }
@@ -244,12 +245,13 @@ public class AuthenticatorAnalyticsTracker {
         // When unit testing, WordPressAuthenticator is not always initialized.
         // The following code ensures we have configuration defaults even if that's the case.
         guard WordPressAuthenticator.isInitialized() else {
-            return Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+            return Configuration(appleEnabled: false, googleEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         }
         
         return Configuration(
             appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedApple,
             googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
+            prologueEnabled: false,
             siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress,
             wpComEnabled: false)
     }
@@ -331,7 +333,7 @@ public class AuthenticatorAnalyticsTracker {
     }
     
     private func isInPrologueFlow() -> Bool {
-        return state.lastFlow == .prologue
+        return configuration.prologueEnabled && state.lastFlow == .prologue
     }
     
     // MARK: - Tracking

--- a/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -20,7 +20,12 @@ extension FancyAlertViewController {
         }
     }
 
-    static func siteAddressHelpController(loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
+    static func siteAddressHelpController(
+        loginFields: LoginFields,
+        sourceTag: WordPressSupportSourceTag,
+        moreHelpTapped: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil) -> FancyAlertViewController {
+        
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
             controller.dismiss(animated: true) {
                 // Find the topmost view controller that we can present from
@@ -30,21 +35,27 @@ extension FancyAlertViewController {
                     return
                 }
 
+                moreHelpTapped?()
                 WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag)
             }
         }
 
         let image = WordPressAuthenticator.shared.displayImages.siteAddressModalPlaceholder
 
+        let okButton = ButtonConfig(Strings.OK) { controller, _ in
+            onDismiss?()
+            controller.dismiss(animated: true, completion: nil)
+        }
+        
         let config = FancyAlertViewController.Config(titleText: Strings.titleText,
                                                      bodyText: Strings.bodyText,
                                                      headerImage: image,
                                                      dividerPosition: .top,
-                                                     defaultButton: defaultButton(),
+                                                     defaultButton: okButton,
                                                      cancelButton: nil,
                                                      moreInfoButton: moreHelpButton,
                                                      titleAccessoryButton: nil,
-                                                     dismissAction: nil)
+                                                     dismissAction: onDismiss)
 
         let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
         return controller

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -16,6 +16,12 @@ class LoginPrologueViewController: LoginViewController {
     private let style = WordPressAuthenticator.shared.style
 
     @IBOutlet private weak var topContainerView: UIView!
+    
+    /// We can't rely on `isMovingToParent` to know if we need to track the `.prologue` step
+    /// because for the root view in an App, it's always `false`.  We're relying on a static variable
+    /// instead, since the `.prologue` step only needs to be tracked once.
+    ///
+    private static var prologueFlowTracked = false
 
     // MARK: - Lifecycle Methods
 
@@ -35,12 +41,22 @@ class LoginPrologueViewController: LoginViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
         configureButtonVC()
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        
+        tracker.set(flow: .prologue)
+        
+        if !Self.prologueFlowTracked {
+            tracker.track(step: .prologue)
+            Self.prologueFlowTracked = true
+        } else {
+            tracker.set(step: .prologue)
+        }
         
         WordPressAuthenticator.track(.loginPrologueViewed)
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -18,10 +18,10 @@ class LoginPrologueViewController: LoginViewController {
     @IBOutlet private weak var topContainerView: UIView!
     
     /// We can't rely on `isMovingToParent` to know if we need to track the `.prologue` step
-    /// because for the root view in an App, it's always `false`.  We're relying on a static variable
+    /// because for the root view in an App, it's always `false`.  We're relying this variiable
     /// instead, since the `.prologue` step only needs to be tracked once.
     ///
-    private static var prologueFlowTracked = false
+    private var prologueFlowTracked = false
 
     // MARK: - Lifecycle Methods
 
@@ -51,9 +51,9 @@ class LoginPrologueViewController: LoginViewController {
         
         tracker.set(flow: .prologue)
         
-        if !Self.prologueFlowTracked {
+        if !prologueFlowTracked {
             tracker.track(step: .prologue)
-            Self.prologueFlowTracked = true
+            prologueFlowTracked = true
         } else {
             tracker.set(step: .prologue)
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -51,6 +51,8 @@ final class TwoFAViewController: LoginViewController {
         
         if isMovingToParent {
             tracker.track(step: .twoFactorAuthentication)
+        } else {
+            tracker.set(step: .twoFactorAuthentication)
         }
         
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -61,6 +61,8 @@ class PasswordViewController: LoginViewController {
         
         if isMovingToParent {
             tracker.track(step: .userPasswordScreenShown)
+        } else {
+            tracker.set(step: .userPasswordScreenShown)
         }
         
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -60,6 +60,8 @@ final class SiteAddressViewController: LoginViewController {
         
         if isMovingToParent {
             tracker.track(step: .start)
+        } else {
+            tracker.set(step: .start)
         }
         
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
@@ -303,14 +305,27 @@ private extension SiteAddressViewController {
                 return
             }
             
-            self.tracker.track(click: .helpFindingSiteAddress)
+            self.tracker.track(click: .showHelp)
 
-            let alert = FancyAlertViewController.siteAddressHelpController(loginFields: self.loginFields, sourceTag: self.sourceTag)
+            let alert = FancyAlertViewController.siteAddressHelpController(
+                loginFields: self.loginFields,
+                sourceTag: self.sourceTag,
+                moreHelpTapped: {
+                    self.tracker.track(click: .helpFindingSiteAddress)
+            },
+                onDismiss: {
+                    self.tracker.track(click: .dismiss)
+                    
+                    // Since we're showing an alert on top of this VC, `viewDidAppear` will not be called
+                    // once the alert is dismissed (which is where the step would be reset automagically),
+                    // so we need to manually reset the step here.
+                    self.tracker.set(step: .start)
+            })
             alert.modalPresentationStyle = .custom
             alert.transitioningDelegate = self
-            self.present(alert, animated: true, completion: nil)
-            // TODO: - Tracks.
-            // WordPressAuthenticator.track(.loginURLHelpScreenViewed)
+            self.present(alert, animated: true, completion: { [weak self] in
+                self?.tracker.track(step: .help)
+            })
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -64,6 +64,8 @@ final class SiteCredentialsViewController: LoginViewController {
 
         if isMovingToParent {
             tracker.track(step: .userPasswordScreenShown)
+        } else {
+            tracker.set(step: .userPasswordScreenShown)
         }
         
         configureSubmitButton(animating: false)

--- a/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
+++ b/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
@@ -52,7 +52,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -82,7 +82,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -115,7 +115,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
 
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -149,7 +149,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -176,7 +176,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -205,7 +205,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -234,7 +234,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -263,7 +263,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -291,7 +291,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -319,7 +319,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         tracker.set(source: source)
@@ -346,7 +346,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, siteAddressEnabled: true, wpComEnabled: false)
+        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
         let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
         
         for flow in flows {


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14824

This PR fixes several issues we found in the tracking in 15.6.

We're adding a .prologue flow, which was completely missing, and tracking it properly.
We're resetting to the previous step when the user goes back in the flows.
The tracking for the site address "Help me find my address" section should be working fine now.

For testing instruction please check out the WPiOS PR.