### PR TITLE
UL&S Tracking: Fixes some issues found during testing.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.23.4"
+  s.version       = "1.23.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -101,7 +101,11 @@ public class AuthenticatorAnalyticsTracker {
         
         /// The screen with a username and password visible
         ///
-        case userPasswordScreenShown = "password_challenge"
+        case usernamePassword = "username_password"
+        
+        /// The screen that requests the password
+        ///
+        case passwordChallenge = "password_challenge"
         
         /// Triggered on the epilogue screen
         ///

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -106,7 +106,8 @@ private extension AppleAuthenticator {
                                             self?.authenticationDelegate.userAuthenticatedWithAppleUserID(appleCredentials.user)
                                             
                                             guard !existingNonSocialAccount else {
-
+                                                self?.tracker.set(flow: .loginWithApple)
+                                                
                                                 if existing2faAccount {
                                                     self?.show2FA()
                                                     return

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -60,9 +60,9 @@ class PasswordViewController: LoginViewController {
         super.viewDidAppear(animated)
         
         if isMovingToParent {
-            tracker.track(step: .userPasswordScreenShown)
+            tracker.track(step: .passwordChallenge)
         } else {
-            tracker.set(step: .userPasswordScreenShown)
+            tracker.set(step: .passwordChallenge)
         }
         
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -63,9 +63,9 @@ final class SiteCredentialsViewController: LoginViewController {
         super.viewDidAppear(animated)
 
         if isMovingToParent {
-            tracker.track(step: .userPasswordScreenShown)
+            tracker.track(step: .usernamePassword)
         } else {
-            tracker.set(step: .userPasswordScreenShown)
+            tracker.set(step: .usernamePassword)
         }
         
         configureSubmitButton(animating: false)


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14832

Fixes several issues that were found while testing UL&S:

1. The username + password screen is now tracked as step `username_password`.
2. The password challenge screen is now tracked as step `password_challenge`.
3. The SIWA flow will now change to `siwa_login` when the 2FA screen is shown.  It was previously not.

For testing instructions please refer to the WPiOS PR.