### PR TITLE
ULS: Show unified views for Jetpack login and re-authentication

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -179,6 +179,35 @@ import AuthenticationServices
             trackOpenedLogin()
         }
 
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedWordPress else {
+            showEmailLogin(from: presenter, xmlrpc: xmlrpc, username: username, connectedEmail: connectedEmail)
+            return
+        }
+        
+        showGetStarted(from: presenter, xmlrpc: xmlrpc, username: username, connectedEmail: connectedEmail)
+    }
+
+    /// Shows the unified Login/Signup flow.
+    ///
+    private class func showGetStarted(from presenter: UIViewController, xmlrpc: String? = nil, username: String? = nil, connectedEmail: String? = nil) {
+        guard let controller = GetStartedViewController.instantiate(from: .getStarted) else {
+            DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
+            return
+        }
+        
+        controller.loginFields.restrictToWPCom = true
+        controller.loginFields.meta.jetpackBlogXMLRPC = xmlrpc
+        controller.loginFields.meta.jetpackBlogUsername = username
+        controller.loginFields.username = connectedEmail ?? ""
+        
+        let navController = LoginNavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .fullScreen
+        presenter.present(navController, animated: true, completion: nil)
+    }
+    
+    /// Shows the Email Login view with Signup option.
+    ///
+    private class func showEmailLogin(from presenter: UIViewController, xmlrpc: String? = nil, username: String? = nil, connectedEmail: String? = nil) {
         guard let controller = LoginEmailViewController.instantiate(from: .login) else {
             return
         }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -198,7 +198,7 @@ import AuthenticationServices
         controller.loginFields.restrictToWPCom = true
         controller.loginFields.meta.jetpackBlogXMLRPC = xmlrpc
         controller.loginFields.meta.jetpackBlogUsername = username
-        controller.loginFields.username = connectedEmail ?? ""
+        controller.loginFields.username = connectedEmail ?? String()
         
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen
@@ -260,16 +260,28 @@ import AuthenticationServices
         loginFields.emailAddress = dotcomEmailAddress ?? String()
         loginFields.username = dotcomUsername ?? String()
 
-        guard let controller = LoginWPComViewController.instantiate(from: .login) else {
-            fatalError("unable to create wpcom password screen")
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedWordPress else {
+            guard let controller = LoginWPComViewController.instantiate(from: .login) else {
+                DDLogError("WordPressAuthenticator: Failed to instantiate LoginWPComViewController")
+                return UIViewController()
+            }
+            
+            controller.loginFields = loginFields
+            controller.dismissBlock = onDismissed
+            
+            return NUXNavigationController(rootViewController: controller)
         }
-
+        
+        guard let controller = PasswordViewController.instantiate(from: .password) else {
+            DDLogError("WordPressAuthenticator: Failed to instantiate PasswordViewController")
+            return UIViewController()
+        }
+        
         controller.loginFields = loginFields
         controller.dismissBlock = onDismissed
-
+        
         return NUXNavigationController(rootViewController: controller)
     }
-
 
     /// Returns an instance of LoginEmailViewController.
     /// This allows the host app to configure the controller's features.


### PR DESCRIPTION
Ref: #404, #352
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14861

This updates the Jetpack login and re-authentication flows to show the unified views.
- During the Jetpack install process, when prompted to login, the flow now shows the Get Started view.
- When the user is prompted to re-authenticate in the app, the new Password view is displayed.

See the WPiOS PR for details.
