### PR TITLE
Open magic links to the correct screen

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.1"
+  s.version       = "1.24.thuy"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.thuy"
+  s.version       = "1.24.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -205,6 +205,7 @@ extension UnifiedSignupViewController {
     /// Makes the call to request a magic signup link be emailed to the user.
     ///
     func requestAuthenticationLink() {
+        loginFields.meta.emailMagicLinkSource = .signup
 
         configureSubmitButton(animating: true)
 


### PR DESCRIPTION
When using the new DotCom signup flow and opening a magic link to complete signup, the sign up epilogue was getting skipped. 

**Steps to reproduce bug**
1. Get started > enter new email address (+ modifiers work) > Continue > Send link by email
2. Check email and activate link
3. Actual: Magic link processes and skips straight to the no sites interstitial. Expected: Magic link processes and goes to the signup epilogue.

Testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14863
