### PR TITLE
UL&S iCloud Keychain: attempt to fix backgrounding issue.

### DIFF
--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -52,6 +52,18 @@ class LoginPrologueViewController: LoginViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        // We've found some instances where the iCloud Keychain login flow was being started
+        // when the device was idle and the app was logged out and in the background.  I couldn't
+        // find precise reproduction steps for this issue but my guess is that some background
+        // operation is triggering a call to this method while the app is in the background.
+        // The proposed solution is based off this StackOverflow reply:
+        //
+        // https://stackoverflow.com/questions/30584356/viewdidappear-is-called-when-app-is-started-due-to-significant-location-change
+        //
+        guard UIApplication.shared.applicationState != .background else {
+            return
+        }
+        
         tracker.set(flow: .prologue)
         
         if !prologueFlowTracked {


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14866

As reported by @ScoutHarris via a private conversation, it seems that some conditions are making the iCloud Keychain flow to sometimes start under these conditions:

1. WPiOS is running in the background.
2. WPiOS is logged out.
3. The device is idling.

## Theory:

My theory is that there's some background process that triggers calls to `viewDidAppear` in the root VC.

### Examples of this being an issue:
- [PushKit background notifications triggering calls to `viewDidAppear` in root VC](https://stackoverflow.com/questions/53881314/pushkit-background-notification-triggers-viewdidappear-on-initial-view-controlle)
- [Location changes triggering calls to `viewDidAppear` in root VC](https://stackoverflow.com/questions/30584356/viewdidappear-is-called-when-app-is-started-due-to-significant-location-change)

## Attempts to reproduce the issue:

I tried to reproduce this issue by sending notifications to the device:

1. I first logged in to WPiOS to enable notifications.
2. Then I logged back out.

Then I tried simulating notifications using `xcrun simctl push <SIMULATOR_DEVICE_ID> <YOUR_APP_BUNDLE_ID> <APNS_FILE_NAME>` but those notifications weren't really triggering calls to:

```swift
func application(_:, didReceiveRemoteNotification:, fetchCompletionHandler:)
```

I also tried a tool provided by @jkmassel, but that tool would only work while logged in.  I wonder if there's any type of notification or background update that we use that can trigger activity in the app while logged out and in the background.

## Proposed solution:

The submitted code is a proposed solution IF the issue is caused by background processes triggering a call to `viewDidAppear`.