### PR TITLE
UL&S: Re-establishes "signed in" tracking.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.24.1"
+  s.version       = "1.24.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -302,6 +302,8 @@ import AuthenticationServices
                 WordPressAuthenticator.track(.loginMagicLinkOpened)
             }
         }
+        
+        WordPressAuthenticator.track(.signedIn)
 
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -302,8 +302,6 @@ import AuthenticationServices
                 WordPressAuthenticator.track(.loginMagicLinkOpened)
             }
         }
-        
-        WordPressAuthenticator.track(.signedIn)
 
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -149,8 +149,11 @@ private extension AppleAuthenticator {
     }
     
     func loginSuccessful(with credentials: AuthenticatorCredentials) {
+        // This stat is part of a funnel that provides critical information.  Please
+        // consult with your lead before removing this event.
+        track(.signedIn)
+        
         tracker.track(step: .success) {
-            track(.signedIn)
             track(.loginSocialSuccess)
         }
         

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -180,6 +180,8 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         // Disconnect now that we're done with Google.
         GIDSignIn.sharedInstance().disconnect()
 
+        // This stat is part of a funnel that provides critical information.  Please
+        // consult with your lead before removing this event.
         WordPressAuthenticator.track(.signedIn)
 
         var properties = [AnyHashable:Any]()

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -292,6 +292,8 @@ extension LoginViewController {
             ]
         }
 
+        // This stat is part of a funnel that provides critical information.  Please
+        // consult with your lead before removing this event.
         WordPressAuthenticator.track(.signedIn, properties: properties)
     }
 
@@ -327,9 +329,12 @@ extension LoginViewController {
                         serviceToken: serviceToken,
                         connectParameters: appleConnectParameters,
                         success: {
+                            // This stat is part of a funnel that provides critical information.  Please
+                            // consult with your lead before removing this event.
+                            let source = appleConnectParameters != nil ? "apple" : "google"
+                            WordPressAuthenticator.track(.signedIn, properties: ["source": source])
+                            
                             if AuthenticatorAnalyticsTracker.shared.shouldUseLegacyTracker() {
-                                let source = appleConnectParameters != nil ? "apple" : "google"
-                                WordPressAuthenticator.track(.signedIn, properties: ["source": source])
                                 WordPressAuthenticator.track(.loginSocialConnectSuccess)
                                 WordPressAuthenticator.track(.loginSocialSuccess)
                             }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -278,11 +278,6 @@ extension LoginViewController {
     /// Tracks the SignIn Event
     ///
     func trackSignIn(credentials: AuthenticatorCredentials) {
-        // Once we remove legacy tracking, this whole method can go away.
-        guard tracker.shouldUseLegacyTracker() else {
-            return
-        }
-        
         var properties = [String: String]()
 
         if let wpcom = credentials.wpcom {

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -266,9 +266,12 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
     func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
         SVProgressHUD.dismiss()
         GIDSignIn.sharedInstance().disconnect()
-
+        
+        // This stat is part of a funnel that provides critical information.  Please
+        // consult with your lead before removing this event.
+        track(.signedIn)
+        
         if tracker.shouldUseLegacyTracker() {
-            track(.signedIn)
             track(.loginSocialSuccess)
         }
         
@@ -388,9 +391,12 @@ private extension GoogleAuthenticator {
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         track(.createdAccount)
-
+        
+        // This stat is part of a funnel that provides critical information.  Please
+        // consult with your lead before removing this event.
+        track(.signedIn)
+        
         tracker.track(step: .success, ifTrackingNotEnabled: {
-            track(.signedIn)
             track(.signupSocialSuccess)
         })
 
@@ -400,8 +406,12 @@ private extension GoogleAuthenticator {
     
     func logInInstead(credentials: AuthenticatorCredentials) {
         tracker.set(flow: .loginWithGoogle)
+        
+        // This stat is part of a funnel that provides critical information.  Please
+        // consult with your lead before removing this event.
+        track(.signedIn)
+        
         tracker.track(step: .start) {
-            track(.signedIn)
             track(.signupSocialToLogin)
             track(.loginSocialSuccess)
         }


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14869

In WPiOS 15.6 we removed tracking of `signed_in` in some scenarios.  This PR re-establishes tracking `signed_in`.

For testing instructions please refer to the WPiOS PR.
