### PR TITLE
ULS: add accessibility identifiers used by WPiOS UI tests

### DIFF
--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -44,6 +44,7 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
         let primaryTitle = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
         submitButton?.setTitle(primaryTitle, for: .normal)
         submitButton?.setTitle(primaryTitle, for: .highlighted)
+        submitButton?.accessibilityIdentifier = "Continue Button"
     }
     
     open func enableSubmit(animating: Bool) -> Bool {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -160,7 +160,7 @@ class LoginPrologueViewController: LoginViewController {
         let siteAddressTitle = NSLocalizedString("Enter your site address",
                                                  comment: "Button title. Takes the user to the login by site address flow.")
 
-        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button") { [weak self] in
             guard let self = self else {
                 return
             }
@@ -171,7 +171,7 @@ class LoginPrologueViewController: LoginViewController {
         }
 
         if configuration.enableUnifiedSiteAddress {
-            buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Self Hosted Login Button") { [weak self] in
+            buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Prologue Self Hosted Button") { [weak self] in
                 self?.siteAddressTapped()
             }
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -149,6 +149,7 @@ private extension GetStartedViewController {
         continueButton.translatesAutoresizingMaskIntoConstraints = false
         continueButton.isEnabled = false
         continueButton.addTarget(self, action: #selector(handleSubmitButtonTapped(_:)), for: .touchUpInside)
+        continueButton.accessibilityIdentifier = "Get Started Email Continue Button"
         tableView.tableFooterView = tableFooter
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -66,6 +66,7 @@ final class LoginMagicLinkViewController: LoginViewController {
     ///
     override func localizePrimaryButton() {
         submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.openMailButtonTitle, for: .normal)
+        submitButton?.accessibilityIdentifier = "Open Mail Button"
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -371,7 +371,7 @@ private extension PasswordViewController {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.getLoginLinkButtonTitle,
                              accessibilityTrait: .link,
                              showBorder: true)
-
+        cell.accessibilityIdentifier = "Get Login Link Button"
         cell.actionHandler = { [weak self] in
             guard let self = self else {
                 return
@@ -387,6 +387,7 @@ private extension PasswordViewController {
     ///
     func configureErrorLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: errorMessage, style: .error)
+        cell.accessibilityIdentifier = "Password Error"
         if shouldChangeVoiceOverFocus {
             UIAccessibility.post(notification: .layoutChanged, argument: cell)
         }


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14872

This adds accessibility identifiers to be used by WPiOS UI tests to test unified flows. See WPiOS PR for deets.