### PR TITLE
UL&S: Implements tracking for the WPcom flow and Magic Links.

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
 		F180B82424F59263000A01F5 /* StoredCredentialsPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */; };
 		F1AF1BEF24E4A80F00BA453E /* LoginFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AF1BEE24E4A80F00BA453E /* LoginFacade.swift */; };
+		F1C96669250BF53400EB529D /* UIViewController+Dismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C96668250BF53400EB529D /* UIViewController+Dismissal.swift */; };
 		F1DE08CC24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */; };
 		FF629D9622393500004C4106 /* WordPressAuthenticator.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */; };
 /* End PBXBuildFile section */
@@ -356,6 +357,7 @@
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsPicker.swift; sourceTree = "<group>"; };
 		F1AF1BEE24E4A80F00BA453E /* LoginFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFacade.swift; sourceTree = "<group>"; };
+		F1C96668250BF53400EB529D /* UIViewController+Dismissal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Dismissal.swift"; sourceTree = "<group>"; };
 		F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsAuthenticator.swift; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
 		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; };
@@ -651,6 +653,7 @@
 				CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */,
 				CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */,
 				CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */,
+				F1C96668250BF53400EB529D /* UIViewController+Dismissal.swift */,
 				CE9091FD249A720E00AB50BD /* UIView+AuthHelpers.swift */,
 			);
 			path = Extensions;
@@ -1176,6 +1179,7 @@
 				B560910F208A54F800399AE4 /* SafariCredentialsService.swift in Sources */,
 				B5CDBED420B4714500BC1EF2 /* UIImage+Assets.swift in Sources */,
 				B5609116208A555600399AE4 /* LoginTextField.swift in Sources */,
+				F1C96669250BF53400EB529D /* UIViewController+Dismissal.swift in Sources */,
 				CE811D6724EDC0FB00F4CCD6 /* LoginMagicLinkViewController.swift in Sources */,
 				B56090E2208A4F9D00399AE4 /* WPNUXSecondaryButton.m in Sources */,
 				B56090E6208A4F9D00399AE4 /* WPNUXPrimaryButton.m in Sources */,

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -268,10 +268,10 @@ public class AuthenticatorAnalyticsTracker {
     
     /// State for the analytics tracker.
     ///
-    private class State {
-        var lastFlow: Flow
-        var lastSource: Source
-        var lastStep: Step
+    public class State {
+        internal(set) public var lastFlow: Flow
+        internal(set) public var lastSource: Source
+        internal(set) public var lastStep: Step
         
         init(lastFlow: Flow = AuthenticatorAnalyticsTracker.defaultFlow, lastSource: Source = AuthenticatorAnalyticsTracker.defaultSource, lastStep: Step = AuthenticatorAnalyticsTracker.defaultStep) {
             self.lastFlow = lastFlow
@@ -286,7 +286,7 @@ public class AuthenticatorAnalyticsTracker {
     
     /// The state of this tracker.
     ///
-    private let state = State()
+    public let state = State()
     
     /// The backing analytics tracking method.  Can be overridden for testing purposes.
     ///
@@ -486,19 +486,19 @@ public class AuthenticatorAnalyticsTracker {
     
     /// Allows the caller to set the flow without tracking.
     ///
-    func set(flow: Flow) {
+    public func set(flow: Flow) {
         state.lastFlow = flow
     }
     
     /// Allows the caller to set the source without tracking.
     ///
-    func set(source: Source) {
+    public func set(source: Source) {
         state.lastSource = source
     }
     
     /// Allows the caller to set the step without tracking.
     ///
-    func set(step: Step) {
+    public func set(step: Step) {
         state.lastStep = step
     }
     

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -4,6 +4,10 @@ import Foundation
 ///
 public class AuthenticatorAnalyticsTracker {
     
+    private static let defaultSource: Source = .default
+    private static let defaultFlow: Flow = .prologue
+    private static let defaultStep: Step = .prologue
+    
     /// The method used for analytics tracking.  Useful for overriding in automated tests.
     ///
     typealias TrackerMethod = (_ event: AnalyticsEvent) -> ()
@@ -269,7 +273,7 @@ public class AuthenticatorAnalyticsTracker {
         var lastSource: Source
         var lastStep: Step
         
-        init(lastFlow: Flow = .prologue, lastSource: Source = .default, lastStep: Step = .prologue) {
+        init(lastFlow: Flow = AuthenticatorAnalyticsTracker.defaultFlow, lastSource: Source = AuthenticatorAnalyticsTracker.defaultSource, lastStep: Step = AuthenticatorAnalyticsTracker.defaultStep) {
             self.lastFlow = lastFlow
             self.lastSource = lastSource
             self.lastStep = lastStep
@@ -293,6 +297,15 @@ public class AuthenticatorAnalyticsTracker {
     init(configuration: Configuration, track: @escaping TrackerMethod = WPAnalytics.track) {
         self.configuration = configuration
         self.track = track
+    }
+    
+    // MARK: - State
+    
+    /// Resets the flow and step to the defaults.  The source is left untouched, and should only be set explicitely.
+    ///
+    func resetState() {
+        set(flow: Self.defaultFlow)
+        set(step: Self.defaultStep)
     }
     
     // MARK: - Legacy vs Unified tracking

--- a/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
+++ b/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension UIViewController {
+
+    /// Depending on how a VC is presented we need to check different things to know whether it's being dismissed or not.
+    /// A VC presented as the first VC in a navigation controller needs to check if the navigation controller is being dismissed.
+    /// A VC added to an existing navigation controller is dismissed when `isMovingToParent` is `false`.
+    /// For any other scenario `isBeingDismissed` will do.
+    ///
+    func isBeingDismissedInAnyWay() -> Bool {
+        return isMovingFromParent || isBeingDismissed || (navigationController?.isBeingDismissed ?? false)
+    }
+}

--- a/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
+++ b/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
@@ -7,7 +7,7 @@ extension UIViewController {
     /// A VC added to an existing navigation controller is dismissed when `isMovingToParent` is `false`.
     /// For any other scenario `isBeingDismissed` will do.
     ///
-    func isBeingDismissedInAnyWay() -> Bool {
-        return isMovingFromParent || isBeingDismissed || (navigationController?.isBeingDismissed ?? false)
+    var isBeingDismissedInAnyWay: Bool {
+        isMovingFromParent || isBeingDismissed || (navigationController?.isBeingDismissed ?? false)
     }
 }

--- a/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
@@ -26,6 +26,8 @@ class NUXLinkAuthViewController: LoginViewController {
 
         let wpcom = WordPressComCredentials(authToken: token, isJetpackLogin: isJetpackLogin, multifactor: false, siteURL: loginFields.siteAddress)
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
+        
+        tracker.track(step: .success)
         syncWPComAndPresentEpilogue(credentials: credentials)
 
         // Count this as success since we're authed. Even if there is a glitch

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -326,7 +326,6 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             fatalError()
         }
 
-        AuthenticatorAnalyticsTracker.shared.track(step: .help)
         WordPressAuthenticator.shared.delegate?.presentSupport(from: navigationController, sourceTag: source)
     }
 }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -251,7 +251,7 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
         if let authorizationError = error as? ASAuthorizationError,
             authorizationError.code == .canceled {
             
-            // If the user cancelled the dialogue, we should assume he somehow tapped to dismiss.
+            // If the user cancelled the dialogue, we should assume they somehow tapped to dismiss.
             tracker.track(click: .dismiss)
             return
         }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -243,10 +243,13 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-
+        
         // Don't show error if user cancelled authentication.
         if let authorizationError = error as? ASAuthorizationError,
-        authorizationError.code == .canceled {
+            authorizationError.code == .canceled {
+            
+            // If the user cancelled the dialogue, we should assume he somehow tapped to dismiss.
+            tracker.track(click: .dismiss)
             return
         }
         

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -16,7 +16,10 @@ class LoginPrologueViewController: LoginViewController {
     private let style = WordPressAuthenticator.shared.style
 
     @available(iOS 13, *)
-    private lazy var storedCredentialsAuthenticator = StoredCredentialsAuthenticator()
+    private lazy var storedCredentialsAuthenticator = StoredCredentialsAuthenticator(onCancel: {
+        // Since the authenticator has its own flow
+        self.tracker.resetState()
+    })
     
     @IBOutlet private weak var topContainerView: UIView!
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -19,12 +19,6 @@ class LoginPrologueViewController: LoginViewController {
     private lazy var storedCredentialsAuthenticator = StoredCredentialsAuthenticator()
     
     @IBOutlet private weak var topContainerView: UIView!
-    
-    /// We can't rely on `isMovingToParent` to know if we need to track the `.prologue` step
-    /// because for the root view in an App, it's always `false`.  We're relying this variiable
-    /// instead, since the `.prologue` step only needs to be tracked once.
-    ///
-    private var prologueFlowTracked = false
 
     // MARK: - Lifecycle Methods
 
@@ -51,15 +45,6 @@ class LoginPrologueViewController: LoginViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        tracker.set(flow: .prologue)
-        
-        if !prologueFlowTracked {
-            tracker.track(step: .prologue)
-            prologueFlowTracked = true
-        } else {
-            tracker.set(step: .prologue)
-        }
         
         WordPressAuthenticator.track(.loginPrologueViewed)
         

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -64,7 +64,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     }
 
     override open func viewWillDisappear(_ animated: Bool) {
-        if isMovingFromParent {
+        if isBeingDismissedInAnyWay {
             tracker.track(click: .dismiss)
         }
     }

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -71,12 +71,6 @@ class StoredCredentialsAuthenticator: NSObject {
             return
         }
         
-        // We're silently setting the flow and step because if there's an error we want it to be
-        // recognized as an iCloud Keychain flow error.  At the same time we don't want to start
-        // this flow unless the user has selected a credential.
-        tracker.set(flow: .loginWithiCloudKeychain)
-        tracker.set(step: .start)
-        
         picker.show(in: window) { [weak self] result in
             guard let self = self else {
                 return
@@ -127,8 +121,13 @@ class StoredCredentialsAuthenticator: NSObject {
         switch authError.code {
         case .canceled:
             // The user cancelling the flow is not really an error, so we're not reporting or tracking
-            // this as an error.  We're only tracking this as a regular UI dismissal.
-            tracker.track(click: .dismiss)
+            // this as an error.
+            //
+            // We're not tracking this either, since the Android App doesn't for SmartLock.  The reason is
+            // that it's not trivial to know when the credentials picker UI is shown to the user, so knowing
+            // it's being dismissed is also not trivial.  This was decided during the Unified Login & Signup
+            // project in a conversation between myself (Diego Rey Mendez) and Renan Ferrari.
+            break
         case .failed, .invalidResponse, .notHandled, .unknown:
             tracker.track(failure: authError.localizedDescription)
             DDLogError("ASAuthorizationError: \(authError.localizedDescription)")

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -421,12 +421,11 @@ private extension GetStartedViewController {
                                             self?.configureViewLoading(false)
 
             }, failure: { [weak self] (error: Error) in
-                // TODO: Tracks.
-                // WordPressAuthenticator.track(.loginMagicLinkFailed)
-                // WordPressAuthenticator.track(.loginFailed, error: error)
                 guard let self = self else {
                     return
                 }
+                
+                self.tracker.track(failure: error.localizedDescription)
 
                 self.displayError(error as NSError, sourceTag: self.sourceTag)
                 self.configureViewLoading(false)
@@ -493,6 +492,8 @@ private extension GetStartedViewController {
     func showSelfHostedWithError(_ error: Error) {
         loginFields.siteAddress = "https://wordpress.com"
         errorToPresent = error
+        
+        tracker.track(failure: error.localizedDescription)
 
         guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
             DDLogError("Failed to navigate to SiteCredentialsViewController from GetStartedViewController")

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -555,7 +555,20 @@ private extension GetStartedViewController {
         
         let safariViewController = SFSafariViewController(url: url)
         safariViewController.modalPresentationStyle = .pageSheet
+        safariViewController.delegate = self
         self.present(safariViewController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - SFSafariViewControllerDelegate
+
+extension GetStartedViewController: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        // This will only work when the user taps "Done" in the terms of service screen.
+        // It won't be executed if the user dismisses the terms of service VC by sliding it out of view.
+        // Unfortunately I haven't found a way to track that scenario.
+        //
+        tracker.track(click: .dismiss)
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -167,6 +167,7 @@ private extension GetStartedViewController {
     // MARK: - Continue Button Action
     
     @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {
+        tracker.track(click: .submit)
         validateForm()
     }
     
@@ -468,6 +469,10 @@ private extension GetStartedViewController {
     /// When password autofill has entered a password on this screen, attempt to login immediately
     ///
     func attemptAutofillLogin() {
+        // Even though there was no explicit submit action by the user, we'll interpret
+        // the credentials selection as such.
+        tracker.track(click: .submit)
+        
         loginFields.password = hiddenPasswordField?.text ?? ""
         loginFields.meta.socialService = nil
         displayError(message: "")

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -69,6 +69,13 @@ class GetStartedViewController: LoginViewController {
     
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        
+        if isMovingToParent {
+            tracker.track(step: .start)
+        } else {
+            tracker.set(step: .start)
+        }
+        
         errorMessage = nil
         hiddenPasswordField?.text = nil
         hiddenPasswordField?.isAccessibilityElement = false

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -20,8 +20,8 @@ final class LoginMagicLinkViewController: LoginViewController {
 
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
-        // TODO: - Tracks.
-        // WordPressAuthenticator.track(.loginMagicLinkOpenEmailClientViewed)
+        tracker.track(click: .openEmailClient)
+        
         let linkMailPresenter = LinkMailPresenter(emailAddress: loginFields.username)
         let appSelector = AppSelector(sourceView: sender)
         linkMailPresenter.presentEmailClients(on: self, appSelector: appSelector)

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -21,6 +21,7 @@ final class LoginMagicLinkViewController: LoginViewController {
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         tracker.track(click: .openEmailClient)
+        tracker.track(step: .emailOpened)
         
         let linkMailPresenter = LinkMailPresenter(emailAddress: loginFields.username)
         let appSelector = AppSelector(sourceView: sender)
@@ -58,7 +59,7 @@ final class LoginMagicLinkViewController: LoginViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
         
-        if isMovingFromParent || isBeingDismissed || || (navigationController?.isBeingDismissed ?? false) {
+        if isBeingDismissedInAnyWay {
             tracker.popState()
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -11,7 +11,7 @@ final class LoginMagicLinkViewController: LoginViewController {
     private var rows = [Row]()
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
-
+    
     override var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginMagicLink
@@ -41,6 +41,26 @@ final class LoginMagicLinkViewController: LoginViewController {
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if isMovingToParent {
+            tracker.pushState()
+            tracker.set(flow: .loginWithMagicLink)
+            tracker.track(step: .start)
+        } else {
+            tracker.set(step: .start)
+        }
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        
+        if isMovingFromParent || isBeingDismissed || || (navigationController?.isBeingDismissed ?? false) {
+            tracker.popState()
+        }
     }
 
     // MARK: - Overrides

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -354,6 +354,8 @@ private extension PasswordViewController {
             guard let self = self else {
                 return
             }
+            
+            self.tracker.track(click: .forgottenPassword)
 
             // If information is currently processing, ignore button tap.
             guard self.enableSubmit(animating: false) else {
@@ -376,10 +378,9 @@ private extension PasswordViewController {
             guard let self = self else {
                 return
             }
-
+            
+            self.tracker.track(click: .requestMagicLink)
             self.requestAuthenticationLink()
-            // TODO: Tracks.
-            // Track the "login magic link requested" event
         }
     }
     

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -363,7 +363,6 @@ private extension PasswordViewController {
             }
 
             WordPressAuthenticator.openForgotPasswordURL(self.loginFields)
-            self.tracker.track(click: .forgottenPassword)
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -437,12 +437,11 @@ private extension PasswordViewController {
                                             self?.configureViewLoading(false)
 
             }, failure: { [weak self] (error: Error) in
-                // TODO: Tracks.
-                // WordPressAuthenticator.track(.loginMagicLinkFailed)
-                // WordPressAuthenticator.track(.loginFailed, error: error)
                 guard let self = self else {
                     return
                 }
+                
+                self.tracker.track(failure: error.localizedDescription)
 
                 self.displayError(error as NSError, sourceTag: self.sourceTag)
                 self.configureViewLoading(false)
@@ -452,8 +451,6 @@ private extension PasswordViewController {
     /// When a magic link successfully sends, navigate the user to the next step.
     ///
     func didRequestAuthenticationLink() {
-        // TODO: Tracks.
-        // WordPressAuthenticator.track(.loginMagicLinkRequested)
         WordPressAuthenticator.storeLoginInfoForTokenAuth(loginFields)
 
         guard let vc = LoginMagicLinkViewController.instantiate(from: .unifiedLoginMagicLink) else {


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14878

Implements tracking for the new unified WPcom login flow, and for magic links.

Changes in this PR:

- `AuthenticatorAnalyticsTracker`'s state is now publicly readable in case the client app needs to remember the tracking state.
- `AuthenticatorAnalyticsTracker`'s source, flow and step can be set from outside WPAuth.
- `AuthenticatorAnalyticsTracker` has a new `resetState()` method, so that the default flow and step can be re-established when necessary.
- Removed the prologue flow start tracking, since we don't currently have the new prologue.
- Tracks several events that were still not being tracked in the WPcom and Magic Link flows.
- Fixes an issue that was causing the flow not to be restablished when the support VC was dismissed.

For details please refer to the WPiOS PR.