### PR TITLE
Increases podspec version.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.25.0-beta.1"
+  s.version       = "1.25.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
We need to release a new version of what's on `develop` since there was a merge back from `release/1.24.2` that didn't get included into any `1.15.x` release yet.