### PR TITLE
Login: show correct message when login limit reached

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.25.0-beta.3"
+  s.version       = "1.25.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -99,14 +99,26 @@ class PasswordViewController: LoginViewController {
 
     override func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
-
-        let errorCode = (error as NSError).code
-        let errorDomain = (error as NSError).domain
-        if errorDomain == WordPressComOAuthClient.WordPressComOAuthErrorDomain, errorCode == WordPressComOAuthError.invalidRequest.rawValue {
-            let message = NSLocalizedString("It seems like you've entered an incorrect password. Want to give it another try?", comment: "An error message shown when a wpcom user provides the wrong password.")
-            displayError(message: message, moveVoiceOverFocus: true)
+        
+        let nsError = error as NSError
+        let errorCode = nsError.code
+        let errorDomain = nsError.domain
+        
+        if errorDomain == WordPressComOAuthClient.WordPressComOAuthErrorDomain,
+            errorCode == WordPressComOAuthError.invalidRequest.rawValue {
+            
+            // The only difference between an incorrect password error and exceeded login limit error
+            // is the actual error string. So check for "password" in the error string, and show the custom
+            // error message. Otherwise, show the actual response error.
+            var displayMessage: String {
+                if nsError.localizedDescription.contains(NSLocalizedString("password", comment: "")) {
+                    return NSLocalizedString("It seems like you've entered an incorrect password. Want to give it another try?", comment: "An error message shown when a wpcom user provides the wrong password.")
+                }
+                return nsError.localizedDescription
+            }
+            displayError(message: displayMessage, moveVoiceOverFocus: true)
         } else {
-            displayError(error as NSError, sourceTag: sourceTag)
+            displayError(nsError, sourceTag: sourceTag)
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/237
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/13977
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14914

This adds a check to the login response error for one indicating a password issue. If found, display the custom incorrect password message. Otherwise, show the response error. The effect is, when the max number of failed login attempts is reached, the correct error message is displayed.

| ![incorrect_password](https://user-images.githubusercontent.com/1816888/93280265-6a573580-f786-11ea-921c-0e60895c512a.jpg) | ![exceeded_limit](https://user-images.githubusercontent.com/1816888/93280273-70e5ad00-f786-11ea-9422-22a56ce68bc4.jpg) |
|--------|-------|
