### PR TITLE
UL&S: Send the correct errors to the user when SMS requests exceeded

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.14"
+  s.version       = "1.26.0-beta.15"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.25.0-beta.4"
+  s.version       = "1.25.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Services/LoginFacade.swift
+++ b/WordPressAuthenticator/Services/LoginFacade.swift
@@ -5,7 +5,7 @@ extension LoginFacade {
         AuthenticatorAnalyticsTracker.shared
     }
     
-    func requestOneTimeCode(with loginFields: LoginFields) {
+    func requestOneTimeCode(with loginFields: LoginFields, completion: @escaping (_ error: Error?, _ success: Bool) -> Void) {
         wordpressComOAuthClientFacade.requestOneTimeCode(
             withUsername: loginFields.username, 
             password: loginFields.password,
@@ -17,12 +17,15 @@ extension LoginFacade {
                 if self.tracker.shouldUseLegacyTracker() {
                     WordPressAuthenticator.track(.twoFactorSentSMS)
                 }
-        }) { _ in
+
+                completion(nil, true)
+        }) { error in
             DDLogError("Failed to request one time code")
+            completion(error, false)
         }
     }
 
-    func requestSocial2FACode(with loginFields: LoginFields) {
+    func requestSocial2FACode(with loginFields: LoginFields, completion: @escaping (_ error: Error?, _ success: Bool) -> Void) {
         guard let nonce = loginFields.nonceInfo?.nonceSMS else {
             return
         }
@@ -42,11 +45,15 @@ extension LoginFacade {
                 if self.tracker.shouldUseLegacyTracker() {
                     WordPressAuthenticator.track(.twoFactorSentSMS)
                 }
+
+                completion(nil, true)
         }) { (error, newNonce) in
             if let newNonce = newNonce {
                 loginFields.nonceInfo?.nonceSMS = newNonce
             }
+
             DDLogError("Failed to request one time code");
+            completion(error, false)
         }
     }
     

--- a/WordPressAuthenticator/Services/LoginFacade.swift
+++ b/WordPressAuthenticator/Services/LoginFacade.swift
@@ -48,12 +48,14 @@ extension LoginFacade {
 
                 completion(nil, true)
         }) { (error, newNonce) in
-            if let newNonce = newNonce {
-                loginFields.nonceInfo?.nonceSMS = newNonce
+            guard let newNonce = newNonce else {
+                DDLogError("Failed to request one time code");
+                completion(error, false)
+                return
             }
 
-            DDLogError("Failed to request one time code");
-            completion(error, false)
+            loginFields.nonceInfo?.nonceSMS = newNonce
+            completion(nil, true)
         }
     }
     

--- a/WordPressAuthenticator/Services/LoginFacade.swift
+++ b/WordPressAuthenticator/Services/LoginFacade.swift
@@ -20,8 +20,11 @@ extension LoginFacade {
 
                 completion(nil, true)
         }) { error in
-            DDLogError("Failed to request one time code")
-            completion(error, false)
+            /// So these new completion handlers allow API request failure messages to bubble up to the user layer.
+            /// However, we receive a false negative in this situation. The API reports a failure, but still successfully
+            /// sends an SMS OTP. So we'll log it, but not report the error to the user.
+            DDLogError("Possible failure when requesting a one time code: \(error?.localizedDescription)")
+            completion(nil, true)
         }
     }
 

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -266,16 +266,36 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         self.tracker.track(click: .sendCodeWithText)
         
         let message = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
-        SVProgressHUD.showSuccess(withStatus: message)
-        SVProgressHUD.dismiss(withDelay: Constants.headsUpDismissDelay)
+        SVProgressHUD.show()
+        SVProgressHUD.dismiss(withDelay: 1)
 
         if let _ = loginFields.nonceInfo {
             // social login
-            loginFacade.requestSocial2FACode(with: loginFields)
+            loginFacade.requestSocial2FACode(with: loginFields) { [weak self] (error, success) in
+                    if success {
+                        SVProgressHUD.show(withStatus: message)
+                        SVProgressHUD.dismiss(withDelay: 1)
+                        return
+                    }
+
+                    if let error = error {
+                        self?.displayRemoteError(error)
+                    }
+                }
         } else {
-            loginFacade.requestOneTimeCode(with: loginFields)
+            loginFacade.requestOneTimeCode(with: loginFields) { [weak self] (error, success) in
+            if success {
+                SVProgressHUD.show(withStatus: message)
+                SVProgressHUD.dismiss(withDelay: 1)
+                return
+            }
+
+            if let error = error {
+                self?.displayRemoteError(error)
+            }
         }
     }
+}
 
 
 

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -158,14 +158,34 @@ private extension TwoFAViewController {
     }
 
     func requestCode() {
-        SVProgressHUD.showSuccess(withStatus: LocalizedText.smsSent)
-        SVProgressHUD.dismiss(withDelay: TimeInterval(1))
+        SVProgressHUD.show()
+        SVProgressHUD.dismiss(withDelay: 1)
 
         if loginFields.nonceInfo != nil {
             // social login
-            loginFacade.requestSocial2FACode(with: loginFields)
+            loginFacade.requestSocial2FACode(with: loginFields) { [weak self] (error, success) in
+                if success {
+                    SVProgressHUD.show(withStatus: LocalizedText.smsSent)
+                    SVProgressHUD.dismiss(withDelay: 1)
+                    return
+                }
+
+                if let error = error {
+                    self?.displayRemoteError(error)
+                }
+            }
         } else {
-            loginFacade.requestOneTimeCode(with: loginFields)
+            loginFacade.requestOneTimeCode(with: loginFields) { [weak self] (error, success) in
+                if success {
+                    SVProgressHUD.show(withStatus: LocalizedText.smsSent)
+                    SVProgressHUD.dismiss(withDelay: 1)
+                    return
+                }
+
+                if let error = error {
+                    self?.displayRemoteError(error)
+                }
+            }
         }
     }
     


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/13807
Testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14924

### To test
**Test Case 1**
1. Use an account that receives 2fa codes through a mobile app (like Authy)
2. Log in normally and wait for the 2fa view to appear
3. Tap "Text me a code instead"
4. **Expected:** This should continue to work normally, with no error messages appearing.

**Test Case 2**
1. Use an account that receives 2fa codes by SMS.
2. Log in normally and wait for the 2fa view to appear.
3. Tap "Text me a code instead".
4. Back out of logging in and go through the flow again.
5. Tap "Text me a code instead".
6. An error message should appear

**Expected:**
<a href="https://user-images.githubusercontent.com/1062444/93394323-ab5c5200-f839-11ea-931e-893ae25ddb84.png"><img src="https://user-images.githubusercontent.com/1062444/93394323-ab5c5200-f839-11ea-931e-893ae25ddb84.png" width="350" /></a>

