### PR TITLE
UL&S: Adds tracking to the prologue, and fixes some other tracking issues.

### DIFF
--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -288,10 +288,6 @@ public class AuthenticatorAnalyticsTracker {
     ///
     public let state = State()
     
-    /// The stored state
-    ///
-    private var pushedState = [State]()
-    
     /// The backing analytics tracking method.  Can be overridden for testing purposes.
     ///
     let track: TrackerMethod
@@ -301,33 +297,6 @@ public class AuthenticatorAnalyticsTracker {
     init(configuration: Configuration, track: @escaping TrackerMethod = WPAnalytics.track) {
         self.configuration = configuration
         self.track = track
-    }
-    
-    // MARK: - State
-    
-    func push(flow: Flow) {
-        let stateToPush = State(
-            lastFlow: state.lastFlow,
-            lastSource: state.lastSource,
-            lastStep: state.lastStep)
-        
-        pushedState.append(stateToPush)
-        
-        state.lastFlow = flow
-        state.lastStep = .start
-    }
-    
-    /// Pops to the previously pushed state.  If there's no previous state, this resets the state to the defaults.
-    ///
-    func popFlow() {
-        guard let stateToPop = pushedState.popLast() else {
-            resetState()
-            return
-        }
-        
-        state.lastSource = stateToPop.lastSource
-        state.lastFlow = stateToPop.lastFlow
-        state.lastStep = stateToPop.lastStep
     }
     
     /// Resets the flow and step to the defaults.  The source is left untouched, and should only be set explicitely.

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -261,7 +261,7 @@ public class AuthenticatorAnalyticsTracker {
             appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedApple,
             googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
             iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
-            prologueEnabled: false,
+            prologueEnabled: true,
             siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress,
             wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedWordPress)
     }
@@ -305,18 +305,21 @@ public class AuthenticatorAnalyticsTracker {
     
     // MARK: - State
     
-    func pushState() {
+    func push(flow: Flow) {
         let stateToPush = State(
             lastFlow: state.lastFlow,
             lastSource: state.lastSource,
             lastStep: state.lastStep)
         
         pushedState.append(stateToPush)
+        
+        state.lastFlow = flow
+        state.lastStep = .start
     }
     
     /// Pops to the previously pushed state.  If there's no previous state, this resets the state to the defaults.
     ///
-    func popState() {        
+    func popFlow() {
         guard let stateToPop = pushedState.popLast() else {
             resetState()
             return

--- a/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
+++ b/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
@@ -4,10 +4,19 @@ extension UIViewController {
 
     /// Depending on how a VC is presented we need to check different things to know whether it's being dismissed or not.
     /// A VC presented as the first VC in a navigation controller needs to check if the navigation controller is being dismissed.
-    /// A VC added to an existing navigation controller is dismissed when `isMovingToParent` is `false`.
+    /// A VC added to an existing navigation controller is dismissed when `isMovingFromParent` is `true`.
     /// For any other scenario `isBeingDismissed` will do.
     ///
     var isBeingDismissedInAnyWay: Bool {
         isMovingFromParent || isBeingDismissed || (navigationController?.isBeingDismissed ?? false)
+    }
+    
+    /// Depending on how a VC is presented we need to check different things to know whether it's being presented or not.
+    /// A VC presented as the first VC in a navigation controller needs to check if the navigation controller is being presented.
+    /// A VC added to an existing navigation controller is presented when `isMovingToParent` is `true`.
+    /// For any other scenario `isBeingPresented` will do.
+    ///
+    var isBeingPresentedInAnyWay: Bool {
+        isMovingToParent || isBeingPresented || (navigationController?.isBeingPresented ?? false)
     }
 }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -250,9 +250,6 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
         // Don't show error if user cancelled authentication.
         if let authorizationError = error as? ASAuthorizationError,
             authorizationError.code == .canceled {
-            
-            // If the user cancelled the dialogue, we should assume they somehow tapped to dismiss.
-            tracker.track(click: .dismiss)
             return
         }
         
@@ -260,7 +257,6 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
         let message = NSLocalizedString("Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication.", comment: "Message shown when Apple authentication fails.")
         delegate?.authFailedWithError(message: message)
     }
-
 }
 
 @available(iOS 13.0, *)

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -66,9 +66,9 @@ class LoginPrologueViewController: LoginViewController {
         tracker.set(flow: .prologue)
         
         if isBeingPresentedInAnyWay {
-            tracker.track(step: .start)
+            tracker.track(step: .prologue)
         } else {
-            tracker.set(step: .start)
+            tracker.set(step: .prologue)
         }
         
         showiCloudKeychainLoginFlow()

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -62,6 +62,14 @@ class LoginPrologueViewController: LoginViewController {
         }
         
         WordPressAuthenticator.track(.loginPrologueViewed)
+
+        if isBeingPresentedInAnyWay {
+            tracker.push(flow: .prologue)
+            tracker.track(step: .start)
+        } else {
+            tracker.set(flow: .prologue)
+            tracker.set(step: .start)
+        }
         
         showiCloudKeychainLoginFlow()
     }
@@ -70,6 +78,10 @@ class LoginPrologueViewController: LoginViewController {
         super.viewWillDisappear(animated)
 
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
+        
+        if isBeingDismissedInAnyWay {
+            tracker.popFlow()
+        }
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -153,7 +165,6 @@ class LoginPrologueViewController: LoginViewController {
                 return
             }
             
-            self.tracker.set(flow: .wpCom)
             self.tracker.track(click: .continueWithWordPressCom)
             self.continueWithDotCom()
         }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -63,11 +63,11 @@ class LoginPrologueViewController: LoginViewController {
         
         WordPressAuthenticator.track(.loginPrologueViewed)
 
+        tracker.set(flow: .prologue)
+        
         if isBeingPresentedInAnyWay {
-            tracker.push(flow: .prologue)
             tracker.track(step: .start)
         } else {
-            tracker.set(flow: .prologue)
             tracker.set(step: .start)
         }
         
@@ -78,10 +78,6 @@ class LoginPrologueViewController: LoginViewController {
         super.viewWillDisappear(animated)
 
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
-        
-        if isBeingDismissedInAnyWay {
-            tracker.popFlow()
-        }
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -308,7 +304,6 @@ class LoginPrologueViewController: LoginViewController {
     /// Unified "Enter your site address" prologue button action.
     ///
     private func siteAddressTapped() {
-        tracker.set(flow: .loginWithSiteAddress)
         tracker.track(click: .loginWithSiteAddress)
 
         loginToSelfHostedSite()

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -71,14 +71,24 @@ class GetStartedViewController: LoginViewController {
         super.viewDidAppear(animated)
         
         if isMovingToParent {
+            tracker.push(flow: .wpCom)
             tracker.track(step: .start)
         } else {
+            tracker.set(flow: .wpCom)
             tracker.set(step: .start)
         }
         
         errorMessage = nil
         hiddenPasswordField?.text = nil
         hiddenPasswordField?.isAccessibilityElement = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        
+        if isBeingDismissedInAnyWay {
+            tracker.popFlow()
+        }
     }
 
     // MARK: - Overrides

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -70,25 +70,17 @@ class GetStartedViewController: LoginViewController {
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        tracker.set(flow: .wpCom)
+        
         if isMovingToParent {
-            tracker.push(flow: .wpCom)
             tracker.track(step: .start)
         } else {
-            tracker.set(flow: .wpCom)
             tracker.set(step: .start)
         }
         
         errorMessage = nil
         hiddenPasswordField?.text = nil
         hiddenPasswordField?.isAccessibilityElement = false
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(true)
-        
-        if isBeingDismissedInAnyWay {
-            tracker.popFlow()
-        }
     }
 
     // MARK: - Overrides
@@ -544,7 +536,6 @@ private extension GetStartedViewController {
     }
     
     @objc func appleTapped() {
-        tracker.set(flow: .loginWithApple)
         tracker.track(click: .loginWithApple)
         
         AppleAuthenticator.sharedInstance.delegate = self
@@ -552,7 +543,6 @@ private extension GetStartedViewController {
     }
     
     @objc func googleTapped() {
-        tracker.set(flow: .loginWithGoogle)
         tracker.track(click: .loginWithGoogle)
         
         guard let toVC = GoogleAuthViewController.instantiate(from: .googleAuth) else {
@@ -606,6 +596,7 @@ extension GetStartedViewController: AppleAuthenticatorDelegate {
     
     func authFailedWithError(message: String) {
         displayErrorAlert(message, sourceTag: .loginApple)
+        tracker.set(flow: .wpCom)
     }
     
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -46,22 +46,18 @@ final class LoginMagicLinkViewController: LoginViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
+        tracker.set(flow: .loginWithMagicLink)
         
         if isMovingToParent {
-            tracker.push(flow: .loginWithMagicLink)
             tracker.track(step: .magicLinkRequested)
         } else {
-            tracker.set(flow: .loginWithMagicLink)
             tracker.set(step: .magicLinkRequested)
         }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
-        
-        if isBeingDismissedInAnyWay {
-            tracker.popFlow()
-        }
     }
 
     // MARK: - Overrides

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -48,10 +48,10 @@ final class LoginMagicLinkViewController: LoginViewController {
         super.viewDidAppear(animated)
         
         if isMovingToParent {
-            tracker.pushState()
-            tracker.set(flow: .loginWithMagicLink)
+            tracker.push(flow: .loginWithMagicLink)
             tracker.track(step: .magicLinkRequested)
         } else {
+            tracker.set(flow: .loginWithMagicLink)
             tracker.set(step: .magicLinkRequested)
         }
     }
@@ -60,7 +60,7 @@ final class LoginMagicLinkViewController: LoginViewController {
         super.viewWillDisappear(true)
         
         if isBeingDismissedInAnyWay {
-            tracker.popState()
+            tracker.popFlow()
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -71,11 +71,11 @@ class PasswordViewController: LoginViewController {
                 tracker.set(step: .passwordChallenge)
             }
         } else {
+            tracker.set(flow: .loginWithPassword)
+            
             if isMovingToParent {
-                tracker.push(flow: .loginWithPassword)
                 tracker.track(step: .start)
             } else {
-                tracker.set(flow: .loginWithPassword)
                 tracker.set(step: .start)
             }
         }
@@ -89,10 +89,6 @@ class PasswordViewController: LoginViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
-        
-        if isBeingDismissedInAnyWay && !trackAsPasswordChallenge {
-            tracker.popFlow()
-        }
     }
     
     // MARK: - Overrides

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -72,10 +72,10 @@ class PasswordViewController: LoginViewController {
             }
         } else {
             if isMovingToParent {
-                tracker.pushState()
-                tracker.set(flow: .loginWithPassword)
+                tracker.push(flow: .loginWithPassword)
                 tracker.track(step: .start)
             } else {
+                tracker.set(flow: .loginWithPassword)
                 tracker.set(step: .start)
             }
         }
@@ -90,8 +90,8 @@ class PasswordViewController: LoginViewController {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
         
-        if !trackAsPasswordChallenge {
-            tracker.popState()
+        if isBeingDismissedInAnyWay && !trackAsPasswordChallenge {
+            tracker.popFlow()
         }
     }
     

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -38,10 +38,10 @@ class UnifiedSignupViewController: LoginViewController {
         super.viewDidAppear(animated)
         
         if isMovingToParent {
-            tracker.pushState()
-            tracker.set(flow: .signup)
+            tracker.push(flow: .signup)
             tracker.track(step: .start)
         } else {
+            tracker.set(flow: .signup)
             tracker.set(step: .start)
         }
     }
@@ -50,7 +50,7 @@ class UnifiedSignupViewController: LoginViewController {
         super.viewWillDisappear(true)
         
         if isBeingDismissedInAnyWay {
-            tracker.popState()
+            tracker.popFlow()
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -37,20 +37,12 @@ class UnifiedSignupViewController: LoginViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        tracker.set(flow: .signup)
+        
         if isMovingToParent {
-            tracker.push(flow: .signup)
             tracker.track(step: .start)
         } else {
-            tracker.set(flow: .signup)
             tracker.set(step: .start)
-        }
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(true)
-        
-        if isBeingDismissedInAnyWay {
-            tracker.popFlow()
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -52,6 +52,8 @@ final class SiteAddressViewController: LoginViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
+        tracker.set(flow: .loginWithSiteAddress)
+        
         if isMovingToParent {
             tracker.track(step: .start)
         } else {


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14931

This PR:

- Enabled tracking for the prologue flow.
- Fixes some issues with tracking clicks in the prologue screen.
- Removes some state stack I had created and opted to roll it back to a simpler solution
- Adds `isBeingPresentedInAnyWay` to view controllers for convenience.
- Removes the dismissal of the SIWA sheet, since we're not tracking that for iCloud Keychain either (matching Android's behavior).
- Some other small tracking fixes.