### PR TITLE
UL&S fixes some tracking issues.

### DIFF
--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -194,10 +194,6 @@ public class AuthenticatorAnalyticsTracker {
         ///
         case requestMagicLink = "request_magic_link"
         
-        /// Used on the magic link screen to use password instead of magic link
-        ///
-        case loginWithPassword = "login_with_password"
-        
         /// Click on “Create new site” button after a successful signup
         ///
         case createNewSite = "create_new_site"

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -162,10 +162,7 @@ private extension GoogleAuthenticator {
                 track(.loginSocialButtonClick)
             }
         case .signup:
-            tracker.set(flow: .signupWithGoogle)
-            tracker.track(step: .start) {
-                track(.createAccountInitiated)
-            }
+            track(.createAccountInitiated)
         }
 
         guard let googleInstance = GIDSignIn.sharedInstance() else {
@@ -352,9 +349,6 @@ private extension GoogleAuthenticator {
     func createWordPressComUser(user: GIDGoogleUser, token: String, email: String) {
         SVProgressHUD.show()
         let service = SignupService()
-        
-        tracker.set(flow: .signupWithGoogle)
-        tracker.track(step: .start)
 
         service.createWPComUserWithGoogle(token: token, success: { [weak self] accountCreated, wpcomUsername, wpcomToken in
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
@@ -33,6 +33,18 @@ class GoogleSignupConfirmationViewController: LoginViewController {
         loadRows()
         configureForAccessibility()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        tracker.set(flow: .signupWithGoogle)
+        
+        if isBeingPresentedInAnyWay {
+            tracker.track(step: .start)
+        } else {
+            tracker.set(step: .start)
+        }
+    }
 
     // MARK: - Overrides
 


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14943

Fixes some Google Signup tracking issues.

In this PR:

- We relocate the start of the Google Signup flow to when the confirmation screen is shown.
- We make it so that when you press in "Create account" in the confirmation screen, the flow is set to `google_signup`.
- We remove a click target that no longer exists.

For testing instructions please refer to the WPiOS PR.