### PR TITLE
Upgrade WordPressKit to fix Xcode 12 build error

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7.0'
-  pod 'WordPressKit', '~> 4.16.beta' # Don't change this until we hit 5.0 in WPKit
+  pod 'WordPressKit', '~> 4.17' # Don't change this until we hit 5.0 in WPKit
   pod 'WordPressShared', '~> 1.9-beta' # Don't change this until we hit 2.0 in WPShared
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.5.0)
-  - WordPressKit (4.16.0-beta.6):
+  - WordPressKit (4.17.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -75,7 +75,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.16.beta)
+  - WordPressKit (~> 4.17)
   - WordPressShared (~> 1.9-beta)
   - WordPressUI (~> 1.7.0)
 
@@ -123,11 +123,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
-  WordPressKit: 6e1b2953ccb53e5867d22759f219b7991afa1234
+  WordPressKit: f1a9e32cf7f46f7eb19d944591aad88b108d90e7
   WordPressShared: a6fe876744bed80d54f920f5ae6f9dcdad338863
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: 227d3f7f8499c650f92b4171c4b7a5cde085cb65
+PODFILE CHECKSUM: abe634a81e8185bb31a688e332be9c395ad1767c
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -43,6 +43,6 @@ Pod::Spec.new do |s|
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
-  s.dependency 'WordPressKit', '~> 4.16-beta' # Don't change this until we hit 5.0 in WPKit
+  s.dependency 'WordPressKit', '~> 4.17' # Don't change this until we hit 5.0 in WPKit
   s.dependency 'WordPressShared', '~> 1.11-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.25.0"
+  s.version       = "1.26.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
## Problem

The WCiOS project does not compile on Xcode 12 because of a compilation error in WPKit, which is a dependency of this library. WCiOS only depends on WPAuth. 

![image](https://user-images.githubusercontent.com/198826/93821638-103df080-fc1c-11ea-9575-002c7d4826d4.png)

The compilation error was already fixed by @jkmassel in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/280. 

## Solution

This PR upgrades WPKit from `4.16.0-beta.6` to `4.17` in order to fix the compilation error. [Here is a comparison](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/4.16.0-beta.6...4.17.0) of what changed from these versions.

As far as I can tell, these are the PRs:

- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/279
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/283
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/280

They seem to be non-breaking fixes so I don't expect any regression from this upgrade. But please double-check. 😅 

## Testing

1. Use Xcode 12 and open the `WordPressAuthenticator` workspace. 
2. Build the library. 
3. Confirm that you do not see the compilation errors shown above. 
4. Confirm that you can still build the project using Xcode 11.

I wanted to create a PR in WP and WC to help with regression testing but we still have other compilation errors in WC. As for WP, I'm having trouble installing Gutenberg dependencies. 🙈 Sorry! 

## Expected Warnings

These warnings are expected when building with Xcode 12 and are not a result of this upgrade. 🙃 

<img src="https://user-images.githubusercontent.com/198826/93821946-9eb27200-fc1c-11ea-8138-cc83bbff8055.png" width="340">


## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
