### PR TITLE
ULS: Remove enableUnifiedSiteAddress flag.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.25.0"
+  s.version       = "1.26.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -258,7 +258,7 @@ public class AuthenticatorAnalyticsTracker {
             googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
             iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
             prologueEnabled: true,
-            siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress,
+            siteAddressEnabled: true,
             wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedWordPress)
     }
     

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -246,7 +246,7 @@ import AuthenticationServices
     /// Returns a Site Address view controller: allows the user to log into a WordPress.org website.
     ///
     @objc public class func signinForWPOrg() -> UIViewController? {
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress else {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             return LoginSiteAddressViewController.instantiate(from: .login)
         }
         

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -55,6 +55,11 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSignUp: Bool
 
+    /// Hint buttons help users complete a step in the unified auth flow. Enabled by default.
+    /// If enabled, "Find your site address", "Reset your password", and others will be displayed.
+    /// If disabled, none of the hint buttons will appear on the unified auth flows.
+    let displayHintButtons: Bool
+    
     /// Flag indicating if the Sign In With Apple option should be displayed.
     ///
     let enableSignInWithApple: Bool
@@ -72,15 +77,6 @@ public struct WordPressAuthenticatorConfiguration {
     /// If enabled, allows selected unified flows to display.
     ///
     let enableUnifiedAuth: Bool
-
-    /// Hint buttons help users complete a step in the unified auth flow. Enabled by default.
-    /// If enabled, "Find your site address", "Reset your password", and others will be displayed.
-    /// If disabled, none of the hint buttons will appear on the unified auth flows.
-    let displayHintButtons: Bool
-
-    /// Flag indicating if the unified login by Site Address flow should display.
-    ///
-    let enableUnifiedSiteAddress: Bool
 
     /// Flag indicating if the unified Google flow should display.
     ///
@@ -116,7 +112,6 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
                  displayHintButtons: Bool = true,
-                 enableUnifiedSiteAddress: Bool = false,
                  enableUnifiedGoogle: Bool = false,
                  enableUnifiedApple: Bool = false,
                  enableUnifiedWordPress: Bool = false,
@@ -137,7 +132,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
         self.displayHintButtons = displayHintButtons
-        self.enableUnifiedSiteAddress = enableUnifiedAuth && enableUnifiedSiteAddress
         self.enableUnifiedGoogle = enableUnifiedAuth && enableUnifiedGoogle
         self.enableSignupWithGoogle = enableSignupWithGoogle
         self.enableUnifiedApple = enableUnifiedAuth && enableUnifiedApple

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -199,7 +199,7 @@ class LoginPrologueViewController: LoginViewController {
             self.continueWithDotCom()
         }
 
-        if configuration.enableUnifiedSiteAddress {
+        if configuration.enableUnifiedAuth {
             buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Prologue Self Hosted Button") { [weak self] in
                 self?.siteAddressTapped()
             }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -210,7 +210,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         
         let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedGoogle && loginFields.meta.socialService == .google
         let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
-        let unifiedSiteAddress = WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress && !loginFields.siteAddress.isEmpty
+        let unifiedSiteAddress = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && !loginFields.siteAddress.isEmpty
         let unifiedWordPress = WordPressAuthenticator.shared.configuration.enableUnifiedWordPress && loginFields.meta.userIsDotCom
         
         guard (unifiedGoogle || unifiedApple || unifiedSiteAddress || unifiedWordPress) else {
@@ -516,7 +516,7 @@ extension LoginViewController: LoginSocialErrorViewControllerDelegate {
     /// Displays the self-hosted login form.
     ///
     @objc func loginToSelfHostedSite() {
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedSiteAddress else {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             presentSelfHostedView()
             return
         }


### PR DESCRIPTION
This removes the `enableUnifiedSiteAddress` and replaces any checks with `enableUnifiedAuth`. 

Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/14954.