### PR TITLE
ULS: Remove enableUnifiedGoogle flag.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.2"
+  s.version       = "1.26.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -255,7 +255,7 @@ public class AuthenticatorAnalyticsTracker {
         
         return Configuration(
             appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedApple,
-            googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedGoogle,
+            googleEnabled: true,
             iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
             prologueEnabled: true,
             siteAddressEnabled: true,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -78,10 +78,6 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableUnifiedAuth: Bool
 
-    /// Flag indicating if the unified Google flow should display.
-    ///
-    let enableUnifiedGoogle: Bool
-
     /// Flag indicating if the unified Apple flow should display.
     ///
     let enableUnifiedApple: Bool
@@ -112,7 +108,6 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
                  displayHintButtons: Bool = true,
-                 enableUnifiedGoogle: Bool = false,
                  enableUnifiedApple: Bool = false,
                  enableUnifiedWordPress: Bool = false,
                  enableUnifiedKeychainLogin: Bool = false) {
@@ -132,7 +127,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
         self.displayHintButtons = displayHintButtons
-        self.enableUnifiedGoogle = enableUnifiedAuth && enableUnifiedGoogle
         self.enableSignupWithGoogle = enableSignupWithGoogle
         self.enableUnifiedApple = enableUnifiedAuth && enableUnifiedApple
         self.enableUnifiedWordPress = enableUnifiedAuth && enableUnifiedWordPress

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -233,7 +233,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
                 
                 self.tracker.track(click: .signupWithGoogle)
                 
-                guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
+                guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
                     self.presentGoogleSignupView()
                     return
                 }
@@ -502,7 +502,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     @objc func googleTapped() {
         self.tracker.track(click: .loginWithGoogle)
         
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedGoogle else {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             GoogleAuthenticator.sharedInstance.loginDelegate = self
             GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
             return

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -294,7 +294,7 @@ class LoginPrologueViewController: LoginViewController {
                 return
             }
             
-            guard self.configuration.enableUnifiedGoogle else {
+            guard self.configuration.enableUnifiedAuth else {
                 self.presentGoogleSignupView()
                 return
             }
@@ -315,7 +315,7 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func googleTapped() {
-        guard configuration.enableUnifiedGoogle else {
+        guard configuration.enableUnifiedAuth else {
             GoogleAuthenticator.sharedInstance.loginDelegate = self
             GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
             return

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -61,7 +61,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedGoogle && loginFields.meta.socialService == .google
+        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && loginFields.meta.socialService == .google
         let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
         forUnified = unifiedGoogle || unifiedApple
 
@@ -139,7 +139,7 @@ extension LoginSocialErrorViewController {
         
         // Don't show the Signup Retry if showing unified social flows.
         // At this point, we've already tried signup and are past it.
-        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedGoogle && loginFields.meta.socialService == .google
+        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && loginFields.meta.socialService == .google
         let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
 
         if unifiedGoogle || unifiedApple {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -208,7 +208,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             WordPressAuthenticator.track(.twoFactorCodeRequested)
         }
         
-        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedGoogle && loginFields.meta.socialService == .google
+        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && loginFields.meta.socialService == .google
         let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
         let unifiedSiteAddress = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && !loginFields.siteAddress.isEmpty
         let unifiedWordPress = WordPressAuthenticator.shared.configuration.enableUnifiedWordPress && loginFields.meta.userIsDotCom

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -235,7 +235,7 @@ extension GoogleAuthenticator: GIDSignInDelegate {
         loginFields.meta.socialServiceIDToken = token
         loginFields.meta.googleUser = user
 
-        guard authConfig.enableUnifiedGoogle else {
+        guard authConfig.enableUnifiedAuth else {
             // Initiate separate WP login / signup paths.
             switch authType {
             case .login:


### PR DESCRIPTION
This removes the `enableUnifiedGoogle` and replaces any checks with `enableUnifiedAuth`. 

Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/14969.