### PR TITLE
ULS: Remove enableUnifiedApple flag. 

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.3"
+  s.version       = "1.26.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -254,11 +254,11 @@ public class AuthenticatorAnalyticsTracker {
         }
         
         return Configuration(
-            appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedApple,
-            googleEnabled: true,
+            appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
+            googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
             iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
             prologueEnabled: true,
-            siteAddressEnabled: true,
+            siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
             wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedWordPress)
     }
     

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -78,10 +78,6 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableUnifiedAuth: Bool
 
-    /// Flag indicating if the unified Apple flow should display.
-    ///
-    let enableUnifiedApple: Bool
-
     /// Flag indicating if the unified WordPress flow should display.
     ///
     let enableUnifiedWordPress: Bool
@@ -108,7 +104,6 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
                  displayHintButtons: Bool = true,
-                 enableUnifiedApple: Bool = false,
                  enableUnifiedWordPress: Bool = false,
                  enableUnifiedKeychainLogin: Bool = false) {
 
@@ -128,7 +123,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableUnifiedAuth = enableUnifiedAuth
         self.displayHintButtons = displayHintButtons
         self.enableSignupWithGoogle = enableSignupWithGoogle
-        self.enableUnifiedApple = enableUnifiedAuth && enableUnifiedApple
         self.enableUnifiedWordPress = enableUnifiedAuth && enableUnifiedWordPress
         self.enableUnifiedKeychainLogin = enableUnifiedAuth && enableUnifiedKeychainLogin
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -444,7 +444,7 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
     func showWPComLogin(loginFields: LoginFields) {
         self.loginFields = loginFields
 
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedApple else {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             presentWPLogin()
             return
         }

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -19,6 +19,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
     
     private var forUnified: Bool = false
     private var actionButtonTapped: Bool = false
+    private let unifiedAuthEnabled = WordPressAuthenticator.shared.configuration.enableUnifiedAuth
     
     fileprivate enum Sections: Int {
         case titleAndDescription = 0
@@ -61,8 +62,8 @@ class LoginSocialErrorViewController: NUXTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && loginFields.meta.socialService == .google
-        let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
+        let unifiedGoogle = unifiedAuthEnabled && loginFields.meta.socialService == .google
+        let unifiedApple = unifiedAuthEnabled && loginFields.meta.socialService == .apple
         forUnified = unifiedGoogle || unifiedApple
 
         styleNavigationBar(forUnified: forUnified)
@@ -139,8 +140,8 @@ extension LoginSocialErrorViewController {
         
         // Don't show the Signup Retry if showing unified social flows.
         // At this point, we've already tried signup and are past it.
-        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && loginFields.meta.socialService == .google
-        let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
+        let unifiedGoogle = unifiedAuthEnabled && loginFields.meta.socialService == .google
+        let unifiedApple = unifiedAuthEnabled && loginFields.meta.socialService == .apple
 
         if unifiedGoogle || unifiedApple {
             buttonCount -= 1

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -208,9 +208,10 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             WordPressAuthenticator.track(.twoFactorCodeRequested)
         }
         
-        let unifiedGoogle = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && loginFields.meta.socialService == .google
-        let unifiedApple = WordPressAuthenticator.shared.configuration.enableUnifiedApple && loginFields.meta.socialService == .apple
-        let unifiedSiteAddress = WordPressAuthenticator.shared.configuration.enableUnifiedAuth && !loginFields.siteAddress.isEmpty
+        let unifiedAuthEnabled = WordPressAuthenticator.shared.configuration.enableUnifiedAuth
+        let unifiedGoogle = unifiedAuthEnabled && loginFields.meta.socialService == .google
+        let unifiedApple = unifiedAuthEnabled && loginFields.meta.socialService == .apple
+        let unifiedSiteAddress = unifiedAuthEnabled && !loginFields.siteAddress.isEmpty
         let unifiedWordPress = WordPressAuthenticator.shared.configuration.enableUnifiedWordPress && loginFields.meta.userIsDotCom
         
         guard (unifiedGoogle || unifiedApple || unifiedSiteAddress || unifiedWordPress) else {
@@ -437,7 +438,7 @@ extension LoginViewController {
         loginFields.nonceInfo = nonceInfo
         loginFields.nonceUserID = userID
 
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedApple else {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             presentLogin2FA()
             return
         }


### PR DESCRIPTION
This removes the `enableUnifiedApple` and replaces any checks with `enableUnifiedAuth`. 

Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/14970.