### PR TITLE
ULS: Remove enableUnifiedKeychainLogin flag.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.4"
+  s.version       = "1.26.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -256,7 +256,7 @@ public class AuthenticatorAnalyticsTracker {
         return Configuration(
             appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
             googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-            iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
+            iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
             prologueEnabled: true,
             siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
             wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedWordPress)

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -81,10 +81,6 @@ public struct WordPressAuthenticatorConfiguration {
     /// Flag indicating if the unified WordPress flow should display.
     ///
     let enableUnifiedWordPress: Bool
-    
-    /// Flag indicating if keychain login is enabled
-    ///
-    let enableUnifiedKeychainLogin: Bool
 
     /// Designated Initializer
     ///
@@ -104,8 +100,7 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
                  displayHintButtons: Bool = true,
-                 enableUnifiedWordPress: Bool = false,
-                 enableUnifiedKeychainLogin: Bool = false) {
+                 enableUnifiedWordPress: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -124,6 +119,5 @@ public struct WordPressAuthenticatorConfiguration {
         self.displayHintButtons = displayHintButtons
         self.enableSignupWithGoogle = enableSignupWithGoogle
         self.enableUnifiedWordPress = enableUnifiedAuth && enableUnifiedWordPress
-        self.enableUnifiedKeychainLogin = enableUnifiedAuth && enableUnifiedKeychainLogin
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -122,7 +122,7 @@ class LoginPrologueViewController: LoginViewController {
     ///
     private func showiCloudKeychainLoginFlow() {
         guard #available(iOS 13, *),
-            WordPressAuthenticator.shared.configuration.enableUnifiedKeychainLogin,
+            WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
             let navigationController = navigationController else {
                 return
         }


### PR DESCRIPTION
This removes the `enableUnifiedKeychainLogin` and replaces any checks with `enableUnifiedAuth`. 

Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/14971.