### PR TITLE
ULS: Remove enableUnifiedWordPress flag.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.5"
+  s.version       = "1.26.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -259,7 +259,7 @@ public class AuthenticatorAnalyticsTracker {
             iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
             prologueEnabled: true,
             siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-            wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedWordPress)
+            wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth)
     }
     
     /// State for the analytics tracker.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -179,7 +179,7 @@ import AuthenticationServices
             trackOpenedLogin()
         }
 
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedWordPress else {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             showEmailLogin(from: presenter, xmlrpc: xmlrpc, username: username, connectedEmail: connectedEmail)
             return
         }
@@ -260,7 +260,7 @@ import AuthenticationServices
         loginFields.emailAddress = dotcomEmailAddress ?? String()
         loginFields.username = dotcomUsername ?? String()
 
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedWordPress else {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             guard let controller = LoginWPComViewController.instantiate(from: .login) else {
                 DDLogError("WordPressAuthenticator: Failed to instantiate LoginWPComViewController")
                 return UIViewController()

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -74,13 +74,9 @@ public struct WordPressAuthenticatorConfiguration {
     
     /// Flag for the unified login/signup flows.
     /// If disabled, none of the unified flows will display.
-    /// If enabled, allows selected unified flows to display.
+    /// If enabled, all unified flows will display.
     ///
     let enableUnifiedAuth: Bool
-
-    /// Flag indicating if the unified WordPress flow should display.
-    ///
-    let enableUnifiedWordPress: Bool
 
     /// Designated Initializer
     ///
@@ -99,8 +95,7 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSignInWithApple: Bool = false,
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
-                 displayHintButtons: Bool = true,
-                 enableUnifiedWordPress: Bool = false) {
+                 displayHintButtons: Bool = true) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -118,6 +113,5 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableUnifiedAuth = enableUnifiedAuth
         self.displayHintButtons = displayHintButtons
         self.enableSignupWithGoogle = enableSignupWithGoogle
-        self.enableUnifiedWordPress = enableUnifiedAuth && enableUnifiedWordPress
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -145,7 +145,7 @@ class LoginPrologueViewController: LoginViewController {
             return
         }
 
-        guard configuration.enableUnifiedWordPress else {
+        guard configuration.enableUnifiedAuth else {
             buildPrologueButtons(buttonViewController)
             return
         }
@@ -281,7 +281,7 @@ class LoginPrologueViewController: LoginViewController {
                 return
             }
 
-            guard self.configuration.enableUnifiedWordPress else {
+            guard self.configuration.enableUnifiedAuth else {
                 self.presentSignUpEmailView()
                 return
             }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -212,7 +212,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         let unifiedGoogle = unifiedAuthEnabled && loginFields.meta.socialService == .google
         let unifiedApple = unifiedAuthEnabled && loginFields.meta.socialService == .apple
         let unifiedSiteAddress = unifiedAuthEnabled && !loginFields.siteAddress.isEmpty
-        let unifiedWordPress = WordPressAuthenticator.shared.configuration.enableUnifiedWordPress && loginFields.meta.userIsDotCom
+        let unifiedWordPress = unifiedAuthEnabled && loginFields.meta.userIsDotCom
         
         guard (unifiedGoogle || unifiedApple || unifiedSiteAddress || unifiedWordPress) else {
             presentLogin2FA()

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -140,7 +140,7 @@ extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
     func displayRemoteError(_ error: Error) {
         tracker.track(failure: error.localizedDescription)
         
-        guard authConfig.enableUnifiedWordPress else {
+        guard authConfig.enableUnifiedAuth else {
             presentLoginEmailView(error: error)
             return
         }


### PR DESCRIPTION
This removes the `enableUnifiedWordPress` and replaces any checks with `enableUnifiedAuth`. 

Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/14972.