### PR TITLE
Password view: Disable login link button after tapped.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.6"
+  s.version       = "1.26.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -14,6 +14,7 @@ class PasswordViewController: LoginViewController {
     private var rows = [Row]()
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
+    private var loginLinkCell: TextLinkButtonTableViewCell?
     
     /// Depending on where we're coming from, this screen needs to track a password challenge
     /// (if logging on with a Social account) or not (if logging in through WP.com).
@@ -59,6 +60,7 @@ class PasswordViewController: LoginViewController {
         
         loginFields.meta.userIsDotCom = true
         configureSubmitButton(animating: false)
+        loginLinkCell?.enableButton(true)
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -400,10 +402,16 @@ private extension PasswordViewController {
                              accessibilityTrait: .link,
                              showBorder: true)
         cell.accessibilityIdentifier = "Get Login Link Button"
+        
+        // Save reference to the login link cell so it can be enabled/disabled.
+        loginLinkCell = cell
+        
         cell.actionHandler = { [weak self] in
             guard let self = self else {
                 return
             }
+            
+            cell.enableButton(false)
             
             self.tracker.track(click: .requestMagicLink)
             self.requestAuthenticationLink()

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -41,7 +41,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     
     /// Toggle button enabled / disabled
     ///
-    public func toggleButton(_ isEnabled: Bool) {
+    public func enableButton(_ isEnabled: Bool) {
         button.isEnabled = isEnabled
     }
 


### PR DESCRIPTION
Fixes: #453 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14975

On the Password view, when `Get a login link by email` is tapped, it is disabled. It is re-enabled on `viewDidAppear`. 

![password](https://user-images.githubusercontent.com/1816888/94058950-faa50400-fd9e-11ea-8fe0-abd3057fb3b5.png)
