### PR TITLE
Upgrade WordPressKit to 4.18.0-beta.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7.0'
-  pod 'WordPressKit', '~> 4.17' # Don't change this until we hit 5.0 in WPKit
+  pod 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
   pod 'WordPressShared', '~> 1.9-beta' # Don't change this until we hit 2.0 in WPShared
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,18 +48,18 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.5.0)
-  - WordPressKit (4.17.0):
+  - WordPressKit (4.18.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.10-beta)
-    - wpxmlrpc (= 0.8.5)
+    - wpxmlrpc (~> 0.9.0-beta)
   - WordPressShared (1.11.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.0)
-  - wpxmlrpc (0.8.5)
+  - wpxmlrpc (0.9.0-beta.1)
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.8.6)
@@ -75,7 +75,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.17)
+  - WordPressKit (~> 4.18-beta)
   - WordPressShared (~> 1.9-beta)
   - WordPressUI (~> 1.7.0)
 
@@ -123,11 +123,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
-  WordPressKit: f1a9e32cf7f46f7eb19d944591aad88b108d90e7
+  WordPressKit: 35574a223dd23320866813677d908cf81c8a4750
   WordPressShared: a6fe876744bed80d54f920f5ae6f9dcdad338863
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
-  wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
+  wpxmlrpc: 54196a1c23d1298f05895cc375a8f91385106fd0
 
-PODFILE CHECKSUM: abe634a81e8185bb31a688e332be9c395ad1767c
+PODFILE CHECKSUM: 5be116345f6997ec35daf2d31c0aa453abc4eb5a
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.11"
+  s.version       = "1.26.0-beta.12"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -43,6 +43,6 @@ Pod::Spec.new do |s|
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
-  s.dependency 'WordPressKit', '~> 4.17' # Don't change this until we hit 5.0 in WPKit
+  s.dependency 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
   s.dependency 'WordPressShared', '~> 1.11-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.6"
+  s.version       = "1.26.0-beta.7"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
This pulls in the WordPressKit changes (https://github.com/wordpress-mobile/WordPressKit-iOS/pull/286) which fixes this `wpxmlrpc` warning when building using Xcode 12:

<img src="https://user-images.githubusercontent.com/198826/94035362-354b7400-fd80-11ea-80c5-13ac7cb5a526.png" width="340">

There are [no other changes](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/4.17.0...4.18.0-beta.1) aside from the `wpxmlrpc` fix. 

## Testing

1. Confirm the build passes. 
2. Confirm that when building with Xcode 12, the `wpxmlrpc` warning shown above is no longer there. 
3. Confirm that you can still build the project with Xcode 11. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 

