### PR TITLE
Fixes tracking for the iCloud Keychain flow.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.7"
+  s.version       = "1.26.0-beta.8"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -93,6 +93,7 @@ class StoredCredentialsAuthenticator: NSObject {
     ///
     private func pickerSuccess(_ authorization: ASAuthorization) {
         tracker.track(step: .start)
+        tracker.set(flow: .loginWithiCloudKeychain)
         
         switch authorization.credential {
         case _ as ASAuthorizationAppleIDCredential:


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14981

The iCloud Keychain flow was not being tracked.  This was broken due to some recent changes.  This PR fixes it.

Please refer to the WPiOS PR for testing instructions.