### PR TITLE
iCloud Keychain: Show HUD after account is selected.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.x"
+  s.version       = "1.26.0-beta.9"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.8"
+  s.version       = "1.26.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AuthenticationServices
+import SVProgressHUD
 
 /// The authorization flow handled by this class starts by showing Apple's `ASAuthorizationController`
 /// through our class `StoredCredentialsPicker`.  This controller lets the user pick the credentials they
@@ -94,6 +95,7 @@ class StoredCredentialsAuthenticator: NSObject {
     private func pickerSuccess(_ authorization: ASAuthorization) {
         tracker.track(step: .start)
         tracker.set(flow: .loginWithiCloudKeychain)
+        SVProgressHUD.show()
         
         switch authorization.credential {
         case _ as ASAuthorizationAppleIDCredential:
@@ -140,6 +142,7 @@ class StoredCredentialsAuthenticator: NSObject {
 extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
     func displayRemoteError(_ error: Error) {
         tracker.track(failure: error.localizedDescription)
+        SVProgressHUD.dismiss()
         
         guard authConfig.enableUnifiedAuth else {
             presentLoginEmailView(error: error)
@@ -150,6 +153,7 @@ extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
     }
     
     func needsMultifactorCode() {
+        SVProgressHUD.dismiss()
         presentTwoFactorAuthenticationView()
     }
 
@@ -162,6 +166,7 @@ extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
         
         authenticationDelegate.sync(credentials: credentials) { [weak self] in
+            SVProgressHUD.dismiss()
             self?.presentLoginEpilogue(credentials: credentials)
         }
     }


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14985

After selecting an account from iCloud keychain, sometimes there is a few seconds delay before the next view is displayed, making it appear as if nothing is happening. This shows a `SVProgressHUD` after the account is selected, and dismisses it in the `LoginFacadeDelegate` methods (i.e. after `LoginFacade` has determined what to do next).

![hud](https://user-images.githubusercontent.com/1816888/94186068-71a3d080-fe63-11ea-9ecb-6e26c8ae03e5.jpg)


 