### PR TITLE
Unified Google: don't track unknown user error

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.9"
+  s.version       = "1.26.0-beta.x"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -330,9 +330,10 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
             if tracker.shouldUseLegacyTracker() {
                 track(.loginSocialErrorUnknownUser)
             }
+        } else {
+            // Don't track unknown user for unified Auth.
+            tracker.track(failure: errorDescription)
         }
-
-        tracker.track(failure: errorDescription)
 
         loginDelegate?.googleLoginFailed(errorTitle: errorTitle, errorDescription: errorDescription, loginFields: loginFields)
         delegate?.googleLoginFailed(errorTitle: errorTitle, errorDescription: errorDescription, loginFields: loginFields, unknownUser: unknownUser)


### PR DESCRIPTION
Fixes: #455 
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14986

Don't track unknown user error when Google login fails due to ... unknown user.