### PR TITLE
Add an optional completion block to login UI presentation completion

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.12"
+  s.version       = "1.26.0-beta.13"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.13"
+  s.version       = "1.26.0-beta.14"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -156,7 +156,16 @@ import AuthenticationServices
         showLogin(from: presenter, animated: animated)
     }
 
-    public class func showLogin(from presenter: UIViewController, animated: Bool, showCancel: Bool = false, restrictToWPCom: Bool = false, onLoginButtonTapped: (() -> Void)? = nil) {
+    /// Shows login UI from the given presenter view controller.
+    ///
+    /// - Parameters:
+    ///   - presenter: The view controller that presents the login UI.
+    ///   - animated: Whether the login UI is presented with animation.
+    ///   - showCancel: Whether a cancel CTA is shown on the login prologue screen.
+    ///   - restrictToWPCom: Whether only WordPress.com login is enabled.
+    ///   - onLoginButtonTapped: Called when the login button on the prologue screen is tapped.
+    ///   - onCompletion: Called when the login UI presentation completes.
+    public class func showLogin(from presenter: UIViewController, animated: Bool, showCancel: Bool = false, restrictToWPCom: Bool = false, onLoginButtonTapped: (() -> Void)? = nil, onCompletion: (() -> Void)? = nil) {
         defer {
             trackOpenedLogin()
         }
@@ -169,7 +178,7 @@ import AuthenticationServices
                 childController.onLoginButtonTapped = onLoginButtonTapped
             }
             controller.modalPresentationStyle = .fullScreen
-            presenter.present(controller, animated: animated, completion: nil)
+            presenter.present(controller, animated: animated, completion: onCompletion)
         }
     }
 


### PR DESCRIPTION
## Background

This PR enables the caller of `WordPressAuthenticator.showLogin` to pass a completion block on presentation completion. For a refactoring task in WCiOS https://github.com/woocommerce/woocommerce-ios/issues/2884, we're aiming to reset the tab view controllers after the app is logged out and we can only do so **after** the login UI presentation finishes. Otherwise, the last logged in UI disappears for a split second before the login UI is presented.

## Changes

- In `WordPressAuthenticator.showLogin`, added a completion block to be called when the login UI presentation completes.

## Testing

No user-facing changes are expected from this change, since the default value for `onCompletion` is the same as the value before (`nil`).

For confidence check:

- In `Podfile` of WPiOS/WPiOS, point `WordPressAuthenticator` to branch `wcios-2884/authenticator-presentation-completion` and run `bundle exec pod install`
- Log out from the app
- Log in to a site --> the login flow should be the same as before