### PR TITLE
UL&S: Implements re-authentication flow tracking

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0-beta.15"
+  s.version       = "1.26.0-beta.16"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		F12F9FB424D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
 		F180B82424F59263000A01F5 /* StoredCredentialsPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */; };
+		F18DF0E5252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h in Sources */ = {isa = PBXBuildFile; fileRef = F18DF0E4252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h */; };
 		F1AF1BEF24E4A80F00BA453E /* LoginFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AF1BEE24E4A80F00BA453E /* LoginFacade.swift */; };
 		F1C96669250BF53400EB529D /* UIViewController+Dismissal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C96668250BF53400EB529D /* UIViewController+Dismissal.swift */; };
 		F1DE08CC24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */; };
@@ -356,6 +357,7 @@
 		F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsPicker.swift; sourceTree = "<group>"; };
+		F18DF0E4252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPressAuthenticatorTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		F1AF1BEE24E4A80F00BA453E /* LoginFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFacade.swift; sourceTree = "<group>"; };
 		F1C96668250BF53400EB529D /* UIViewController+Dismissal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Dismissal.swift"; sourceTree = "<group>"; };
 		F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsAuthenticator.swift; sourceTree = "<group>"; };
@@ -729,6 +731,7 @@
 		B5ED7901207E976500A8FD8C /* WordPressAuthenticatorTests */ = {
 			isa = PBXGroup;
 			children = (
+				F18DF0E32525009200D83AFE /* SupportingFiles */,
 				BA53D64924DFE06C001F1ABF /* Mocks */,
 				BA53D64424DFDE0B001F1ABF /* Credentials */,
 				F12F9FB524D8A7DB00771BCE /* Analytics */,
@@ -869,6 +872,14 @@
 				F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */,
 			);
 			path = Analytics;
+			sourceTree = "<group>";
+		};
+		F18DF0E32525009200D83AFE /* SupportingFiles */ = {
+			isa = PBXGroup;
+			children = (
+				F18DF0E4252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h */,
+			);
+			path = SupportingFiles;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1265,6 +1276,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F18DF0E5252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h in Sources */,
 				B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */,
 				BA53D64824DFDF97001F1ABF /* WordPressSourceTagTests.swift in Sources */,
 				BA53D64D24DFE4E6001F1ABF /* ModalViewControllerPresentingSpy.swift in Sources */,
@@ -1464,11 +1476,14 @@
 			baseConfigurationReference = B0D7D40BC1DE2D367761AD86 /* Pods-WordPressAuthenticatorTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				INFOPLIST_FILE = WordPressAuthenticatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WordPressAuthenticatorTests/SupportingFiles/WordPressAuthenticatorTests-Bridging-Header.h";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1479,11 +1494,14 @@
 			baseConfigurationReference = FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				INFOPLIST_FILE = WordPressAuthenticatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WordPressAuthenticatorTests/SupportingFiles/WordPressAuthenticatorTests-Bridging-Header.h";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1575,11 +1593,14 @@
 			baseConfigurationReference = AE612958059F9E80B54138B3 /* Pods-WordPressAuthenticatorTests.release-internal.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				INFOPLIST_FILE = WordPressAuthenticatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WordPressAuthenticatorTests/SupportingFiles/WordPressAuthenticatorTests-Bridging-Header.h";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1671,11 +1692,14 @@
 			baseConfigurationReference = 37AFD4EF492B00CA7AEC11A3 /* Pods-WordPressAuthenticatorTests.release-alpha.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				INFOPLIST_FILE = WordPressAuthenticatorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressAuthenticatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "WordPressAuthenticatorTests/SupportingFiles/WordPressAuthenticatorTests-Bridging-Header.h";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -258,10 +258,16 @@ public class AuthenticatorAnalyticsTracker {
     /// The backing analytics tracking method.  Can be overridden for testing purposes.
     ///
     let track: TrackerMethod
+    
+    /// Whether tracking is enabled or not.  This is just a convenience configuration to enable this tracker to be turned on and off
+    /// using a feature flag.  It should go away once we remove the legacy tracking.
+    ///
+    let enabled: Bool
 
     // MARK: - Initializers
 
-    init(track: @escaping TrackerMethod = WPAnalytics.track) {
+    init(enabled: Bool = WordPressAuthenticator.shared.configuration.enableUnifiedAuth, track: @escaping TrackerMethod = WPAnalytics.track) {
+        self.enabled = enabled
         self.track = track
     }
     
@@ -281,7 +287,7 @@ public class AuthenticatorAnalyticsTracker {
     /// - Returns: `true` if we can track using the state machine.
     ///
     public func canTrack() -> Bool {
-        return WordPressAuthenticator.shared.configuration.enableUnifiedAuth
+        return enabled
     }
     
     /// This is a convenience method, that's useful for cases where we simply want to check if the legacy tracking should be

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -234,33 +234,8 @@ public class AuthenticatorAnalyticsTracker {
     /// Shared Instance.
     ///
     public static var shared: AuthenticatorAnalyticsTracker = {
-        return AuthenticatorAnalyticsTracker(configuration: defaultConfiguration())
+        return AuthenticatorAnalyticsTracker()
     }()
-    
-    struct Configuration {
-        let appleEnabled: Bool
-        let googleEnabled: Bool
-        let iCloudKeychainEnabled: Bool
-        let prologueEnabled: Bool
-        let siteAddressEnabled: Bool
-        let wpComEnabled: Bool
-    }
-    
-    private class func defaultConfiguration() -> Configuration{
-        // When unit testing, WordPressAuthenticator is not always initialized.
-        // The following code ensures we have configuration defaults even if that's the case.
-        guard WordPressAuthenticator.isInitialized() else {
-            return Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        }
-        
-        return Configuration(
-            appleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-            googleEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-            iCloudKeychainEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-            prologueEnabled: true,
-            siteAddressEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-            wpComEnabled: WordPressAuthenticator.shared.configuration.enableUnifiedAuth)
-    }
     
     /// State for the analytics tracker.
     ///
@@ -276,10 +251,6 @@ public class AuthenticatorAnalyticsTracker {
         }
     }
     
-    /// The tracking configuration.
-    ///
-    private let configuration: Configuration
-    
     /// The state of this tracker.
     ///
     public let state = State()
@@ -290,8 +261,7 @@ public class AuthenticatorAnalyticsTracker {
 
     // MARK: - Initializers
 
-    init(configuration: Configuration, track: @escaping TrackerMethod = WPAnalytics.track) {
-        self.configuration = configuration
+    init(track: @escaping TrackerMethod = WPAnalytics.track) {
         self.track = track
     }
     
@@ -310,14 +280,8 @@ public class AuthenticatorAnalyticsTracker {
     ///
     /// - Returns: `true` if we can track using the state machine.
     ///
-    public func canTrackInCurrentFlow() -> Bool {
-        return isInSiteAuthenticationFlowAndCanTrack()
-            || isInAppleFlowAndCanTrack()
-            || isInGoogleFlowAndCanTrack()
-            || isInMagicLinkFlowAndCanTrack()
-            || isInWPComFlowAndCanTrack()
-            || isInPrologueFlowAndCanTrack()
-            || isInKeychainFlowAndCanTrack()
+    public func canTrack() -> Bool {
+        return WordPressAuthenticator.shared.configuration.enableUnifiedAuth
     }
     
     /// This is a convenience method, that's useful for cases where we simply want to check if the legacy tracking should be
@@ -326,37 +290,7 @@ public class AuthenticatorAnalyticsTracker {
     ///  - Returns: `true` if we must use legacy tracking, `false` otherwise.
     ///
     public func shouldUseLegacyTracker() -> Bool {
-        return !canTrackInCurrentFlow()
-    }
-
-    // MARK: - Legacy vs Unified tracking: Support Methods
-    
-    private func isInSiteAuthenticationFlowAndCanTrack() -> Bool {
-        return configuration.siteAddressEnabled && state.lastFlow == .loginWithSiteAddress
-    }
-    
-    private func isInAppleFlowAndCanTrack() -> Bool {
-        return configuration.appleEnabled && [Flow.loginWithApple, .signupWithApple].contains(state.lastFlow)
-    }
-    
-    private func isInGoogleFlowAndCanTrack() -> Bool {
-        return configuration.googleEnabled && [Flow.loginWithGoogle, .signupWithGoogle].contains(state.lastFlow)
-    }
-    
-    private func isInMagicLinkFlowAndCanTrack() -> Bool {
-        return configuration.wpComEnabled && state.lastFlow == .loginWithMagicLink
-    }
-    
-    private func isInWPComFlowAndCanTrack() -> Bool {
-        return configuration.wpComEnabled && [Flow.wpCom, .signup, .loginWithPassword].contains(state.lastFlow)
-    }
-    
-    private func isInPrologueFlowAndCanTrack() -> Bool {
-        return configuration.prologueEnabled && state.lastFlow == .prologue
-    }
-    
-    private func isInKeychainFlowAndCanTrack() -> Bool {
-        return configuration.iCloudKeychainEnabled && state.lastFlow == .loginWithiCloudKeychain
+        return !canTrack()
     }
     
     // MARK: - Tracking
@@ -364,7 +298,7 @@ public class AuthenticatorAnalyticsTracker {
     /// Track a step within a flow.
     ///
     public func track(step: Step) {
-        guard canTrackInCurrentFlow() else {
+        guard canTrack() else {
             return
         }
         
@@ -374,7 +308,7 @@ public class AuthenticatorAnalyticsTracker {
     /// Track a click interaction.
     ///
     public func track(click: ClickTarget) {
-        guard canTrackInCurrentFlow() else {
+        guard canTrack() else {
             return
         }
         
@@ -384,7 +318,7 @@ public class AuthenticatorAnalyticsTracker {
     /// Track a failure.
     ///
     public func track(failure: String) {
-        guard canTrackInCurrentFlow() else {
+        guard canTrack() else {
             return
         }
         
@@ -397,7 +331,7 @@ public class AuthenticatorAnalyticsTracker {
     /// for the flow.
     ///
     public func track(step: Step, ifTrackingNotEnabled legacyTracking: () -> ()) {
-        guard canTrackInCurrentFlow() else {
+        guard canTrack() else {
             legacyTracking()
             return
         }
@@ -409,7 +343,7 @@ public class AuthenticatorAnalyticsTracker {
     /// for the flow.
     ///
     public func track(click: ClickTarget, ifTrackingNotEnabled legacyTracking: () -> ()) {
-        guard canTrackInCurrentFlow() else {
+        guard canTrack() else {
             legacyTracking()
             return
         }
@@ -421,7 +355,7 @@ public class AuthenticatorAnalyticsTracker {
     /// for the flow.
     ///
     public func track(failure: String, ifTrackingNotEnabled legacyTracking: () -> ()) {
-        guard canTrackInCurrentFlow() else {
+        guard canTrack() else {
             legacyTracking()
             return
         }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -283,6 +283,9 @@ import AuthenticationServices
             return NUXNavigationController(rootViewController: controller)
         }
         
+        AuthenticatorAnalyticsTracker.shared.set(source: .reauthentication)
+        AuthenticatorAnalyticsTracker.shared.set(flow: .loginWithPassword)
+        
         guard let controller = PasswordViewController.instantiate(from: .password) else {
             DDLogError("WordPressAuthenticator: Failed to instantiate PasswordViewController")
             return UIViewController()
@@ -290,6 +293,7 @@ import AuthenticationServices
         
         controller.loginFields = loginFields
         controller.dismissBlock = onDismissed
+        controller.trackAsPasswordChallenge = false
         
         return NUXNavigationController(rootViewController: controller)
     }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -90,10 +90,6 @@ import AuthenticationServices
                                   unifiedStyle: WordPressAuthenticatorUnifiedStyle?,
                                   displayImages: WordPressAuthenticatorDisplayImages = .defaultImages,
                                   displayStrings: WordPressAuthenticatorDisplayStrings = .defaultStrings) {
-        guard privateInstance == nil else {
-            fatalError("WordPressAuthenticator is already initialized")
-        }
-
         privateInstance = WordPressAuthenticator(configuration: configuration,
                                                  style: style,
                                                  unifiedStyle: unifiedStyle,

--- a/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
+++ b/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
@@ -33,38 +33,6 @@ class AnalyticsTrackerTests: XCTestCase {
     /// Test that when tracking an event through the AnalyticsTracker, the backing analytics tracker
     /// receives a matching event.
     ///
-    /// Ref: pbArwn-AP-p2
-    ///
-    func testEventTracking() {
-        let source = AuthenticatorAnalyticsTracker.Source.reauthentication
-        let flow = AuthenticatorAnalyticsTracker.Flow.loginWithGoogle
-        let step = AuthenticatorAnalyticsTracker.Step.start
-        
-        let expectedEventName = AuthenticatorAnalyticsTracker.EventType.step.rawValue
-        let expectedEventProperties = self.expectedProperties(source: source, flow: flow, step: step)
-        let trackingIsOk = expectation(description: "The parameters of the tracking call are as expected")
-        
-        let track = { (event: AnalyticsEvent) in
-            if event.name == expectedEventName
-                && event.properties == expectedEventProperties {
-                
-                trackingIsOk.fulfill()
-            }
-        }
-        
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
-        
-        tracker.set(source: source)
-        tracker.set(flow: flow)
-        tracker.track(step: step)
-        
-        waitForExpectations(timeout: 0.1)
-    }
-    
-    /// Test that when tracking an event through the AnalyticsTracker, the backing analytics tracker
-    /// receives a matching event.
-    ///
     func testBackingTracker() {
         let source = AuthenticatorAnalyticsTracker.Source.reauthentication
         let flow = AuthenticatorAnalyticsTracker.Flow.loginWithGoogle
@@ -81,9 +49,8 @@ class AnalyticsTrackerTests: XCTestCase {
                 trackingIsOk.fulfill()
             }
         }
-        
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+    
+        let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
         
         tracker.set(source: source)
         tracker.set(flow: flow)
@@ -115,8 +82,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
 
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
         
         tracker.set(source: source)
         tracker.set(flow: flow)
@@ -149,8 +115,7 @@ class AnalyticsTrackerTests: XCTestCase {
             }
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
         
         tracker.set(source: source)
         tracker.set(flow: flow)
@@ -176,8 +141,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: false, track: track)
         
         tracker.set(source: source)
         
@@ -205,8 +169,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
         
         tracker.set(source: source)
         
@@ -234,8 +197,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: false, track: track)
         
         tracker.set(source: source)
         
@@ -263,8 +225,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
         
         tracker.set(source: source)
         
@@ -291,8 +252,7 @@ class AnalyticsTrackerTests: XCTestCase {
             XCTFail()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: false, googleEnabled: false, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: false, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: false, track: track)
         
         tracker.set(source: source)
         
@@ -319,8 +279,7 @@ class AnalyticsTrackerTests: XCTestCase {
             legacyTrackingExecuted.fulfill()
         }
         
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
+        let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
         
         tracker.set(source: source)
         
@@ -328,31 +287,6 @@ class AnalyticsTrackerTests: XCTestCase {
             tracker.set(flow: flow)
             tracker.track(failure: "error", ifTrackingNotEnabled: {
                 XCTFail()
-            })
-        }
-        
-        waitForExpectations(timeout: 0.1)
-    }
-    
-    /// Tests that we're using legacy tracking for all unsupported flows.
-    ///
-    func testStepLegacyTrackingForAllUnsupportedFlows() {
-        let flows: [AuthenticatorAnalyticsTracker.Flow] = [.loginWithiCloudKeychain, .loginWithPassword, .loginWithMagicLink, .signup, .wpCom]
-        
-        let legacyTrackingUsed = expectation(description: "All unsupported flows should use legacy tracking")
-        legacyTrackingUsed.expectedFulfillmentCount = flows.count
-        
-        let track = { (event: AnalyticsEvent) in
-            XCTFail()
-        }
-        
-        let configuration = AuthenticatorAnalyticsTracker.Configuration(appleEnabled: true, googleEnabled: true, iCloudKeychainEnabled: false, prologueEnabled: false, siteAddressEnabled: true, wpComEnabled: false)
-        let tracker = AuthenticatorAnalyticsTracker(configuration: configuration, track: track)
-        
-        for flow in flows {
-            tracker.set(flow: flow)
-            tracker.track(step: .start, ifTrackingNotEnabled: {
-                legacyTrackingUsed.fulfill()
             })
         }
         

--- a/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
+++ b/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
@@ -1,6 +1,7 @@
 @testable import WordPressAuthenticator
 
-struct WordpressAuthenticatorProvider {
+@objc
+public class WordpressAuthenticatorProvider: NSObject {
     static func wordPressAuthenticatorConfiguration() -> WordPressAuthenticatorConfiguration {
         return WordPressAuthenticatorConfiguration(wpcomClientId: "23456",
                                                    wpcomSecret: "arfv35dj57l3g2323",
@@ -69,6 +70,16 @@ struct WordpressAuthenticatorProvider {
 
     static func getWordpressAuthenticator() -> WordPressAuthenticator {
         return WordPressAuthenticator(
+            configuration:wordPressAuthenticatorConfiguration(),
+            style: wordPressAuthenticatorStyle(.random),
+            unifiedStyle: wordPressAuthenticatorUnifiedStyle(.random),
+            displayImages: WordPressAuthenticatorDisplayImages.defaultImages,
+            displayStrings: WordPressAuthenticatorDisplayStrings.defaultStrings)
+    }
+    
+    @objc
+    static func initializeWordPressAuthenticator() {
+        WordPressAuthenticator.initialize(
             configuration:wordPressAuthenticatorConfiguration(),
             style: wordPressAuthenticatorStyle(.random),
             unifiedStyle: wordPressAuthenticatorUnifiedStyle(.random),

--- a/WordPressAuthenticatorTests/Services/LoginFacadeTests.m
+++ b/WordPressAuthenticatorTests/Services/LoginFacadeTests.m
@@ -6,6 +6,7 @@
 #import "WordPressComOAuthClientFacade.h"
 #import "WordPressXMLRPCAPIFacade.h"
 #import "WPAuthenticator-Swift.h"
+#import "WordPressAuthenticatorTests-Swift.h"
 
 
 SpecBegin(LoginFacade)
@@ -16,6 +17,10 @@ __block id mockXMLRPCAPIFacade;
 __block id mockLoginFacade;
 __block id mockLoginFacadeDelegate;
 __block LoginFields *loginFields;
+
+beforeAll(^{
+    [WordpressAuthenticatorProvider initializeWordPressAuthenticator];
+});
 
 beforeEach(^{
     mockOAuthFacade = [OCMockObject niceMockForProtocol:@protocol(WordPressComOAuthClientFacade)];

--- a/WordPressAuthenticatorTests/SupportingFiles/WordPressAuthenticatorTests-Bridging-Header.h
+++ b/WordPressAuthenticatorTests/SupportingFiles/WordPressAuthenticatorTests-Bridging-Header.h
@@ -1,0 +1,3 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15018

This PR:

- Implements the re-authentication flow tracking.
- Removed some no-longer-necessary code that was being used to enable tracking based on multiple feature flags.
- Fixes the test target for the project, so it's possible to reference Swift code from ObjC.

For testing steps please refer to the WPiOS PR.