### PR TITLE
Remove localization from accessibility IDs

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.26.0"
+  s.version       = "1.27.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -89,13 +89,13 @@ private extension TextFieldTableViewCell {
             textField.returnKeyType = .continue
             registerTextFieldAction()
             textField.accessibilityLabel = Constants.siteAddress
-            textField.accessibilityIdentifier = Constants.siteAddress
+            textField.accessibilityIdentifier = Constants.siteAddressID
         case .username:
             textField.keyboardType = .default
             textField.returnKeyType = .next
             setupOnePasswordButtonIfNeeded()
             textField.accessibilityLabel = Constants.username
-            textField.accessibilityIdentifier = Constants.username
+            textField.accessibilityIdentifier = Constants.usernameID
         case .password:
             textField.keyboardType = .default
             textField.returnKeyType = .continue
@@ -103,19 +103,19 @@ private extension TextFieldTableViewCell {
             showSecureTextEntryToggle = true
             configureSecureTextEntryToggle()
             textField.accessibilityLabel = Constants.password
-            textField.accessibilityIdentifier = Constants.password
+            textField.accessibilityIdentifier = Constants.passwordID
         case .numericCode:
             textField.keyboardType = .numberPad
             textField.returnKeyType = .continue
             textField.accessibilityLabel = Constants.otp
-            textField.accessibilityIdentifier = Constants.otp
+            textField.accessibilityIdentifier = Constants.otpID
         case .email:
             textField.keyboardType = .emailAddress
             textField.returnKeyType = .continue
             textField.textContentType = .username // So the password autofill appears on the keyboard
             setupOnePasswordButtonIfNeeded()
             textField.accessibilityLabel = Constants.email
-            textField.accessibilityIdentifier = Constants.email
+            textField.accessibilityIdentifier = Constants.emailID
         }
     }
 
@@ -236,11 +236,17 @@ extension TextFieldTableViewCell {
                                                    comment: "Accessibility label of the site address field shown when adding a self-hosted site.")
         static let username = NSLocalizedString("Username",
                                                 comment: "Accessibility label for the username text field in the self-hosted login page.")
+
         static let password = NSLocalizedString("Password",
                                                 comment: "Accessibility label for the password text field in the self-hosted login page.")
         static let otp = NSLocalizedString("Authentication code",
                                            comment: "Accessibility label for the 2FA text field.")
         static let email = NSLocalizedString("Email address",
                                              comment: "Accessibility label for the email address text field.")
+        static let siteAddressID = "Site address"
+        static let usernameID = "Username"
+        static let passwordID = "Password"
+        static let otpID = "Authentication code"
+        static let emailID = "Email address"
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -236,7 +236,6 @@ extension TextFieldTableViewCell {
                                                    comment: "Accessibility label of the site address field shown when adding a self-hosted site.")
         static let username = NSLocalizedString("Username",
                                                 comment: "Accessibility label for the username text field in the self-hosted login page.")
-
         static let password = NSLocalizedString("Password",
                                                 comment: "Accessibility label for the password text field in the self-hosted login page.")
         static let otp = NSLocalizedString("Authentication code",


### PR DESCRIPTION
This PR changes the accessibility identifiers on text fields (e.g. site URL, username, password) to use non-localized strings.  (User-facing strings such as accessibility labels are still localized as expected.)

This ensures the accessibility IDs are the same regardless of the device language, so tests can run in any language.

To test:

Ensure UI tests pass (regardless of device language) on this WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15055