### PR TITLE
Prologue Carousel: Extend top container below button blur view

### DIFF
--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17503.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17502"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -78,10 +78,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6cw-FO-hjb">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="501"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="tlO-rf-p4Q"/>
-                                </constraints>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <connections>
                                     <segue destination="TP5-re-Ncg" kind="embed" id="mLC-uB-YYS"/>
                                 </connections>
@@ -97,7 +94,7 @@
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G3G-Ap-6ix">
                                 <rect key="frame" x="0.0" y="501" width="375" height="166"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="166" placeholder="YES" id="Cxl-Vh-qEI"/>
+                                    <constraint firstAttribute="height" constant="166" id="Cxl-Vh-qEI"/>
                                 </constraints>
                                 <connections>
                                     <segue destination="A3H-HK-nmU" kind="embed" id="swV-lc-6gI"/>
@@ -107,15 +104,15 @@
                         <constraints>
                             <constraint firstItem="6cw-FO-hjb" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="7Z8-mD-FWN"/>
                             <constraint firstAttribute="trailing" secondItem="G3G-Ap-6ix" secondAttribute="trailing" id="96a-eB-JlD"/>
-                            <constraint firstItem="G3G-Ap-6ix" firstAttribute="top" secondItem="6cw-FO-hjb" secondAttribute="bottom" id="Cuw-sd-C5k"/>
+                            <constraint firstAttribute="bottom" secondItem="s7U-M4-ZVd" secondAttribute="bottom" id="FDX-0B-GRu"/>
                             <constraint firstAttribute="trailing" secondItem="6cw-FO-hjb" secondAttribute="trailing" id="Hgo-qC-AqF"/>
-                            <constraint firstItem="s7U-M4-ZVd" firstAttribute="top" secondItem="G3G-Ap-6ix" secondAttribute="top" id="ISb-cY-EO1"/>
                             <constraint firstAttribute="trailing" secondItem="s7U-M4-ZVd" secondAttribute="trailing" id="L02-E4-5Ik"/>
+                            <constraint firstItem="G3G-Ap-6ix" firstAttribute="top" secondItem="s7U-M4-ZVd" secondAttribute="top" id="aCC-H1-FES"/>
                             <constraint firstItem="6cw-FO-hjb" firstAttribute="top" secondItem="EnO-7f-1yO" secondAttribute="top" id="dXg-NZ-hRY"/>
                             <constraint firstItem="s7U-M4-ZVd" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="fqH-CW-3Ry"/>
                             <constraint firstAttribute="bottom" secondItem="G3G-Ap-6ix" secondAttribute="bottom" id="lOP-Up-00c"/>
-                            <constraint firstItem="s7U-M4-ZVd" firstAttribute="bottom" secondItem="G3G-Ap-6ix" secondAttribute="bottom" id="qfx-iK-Dth"/>
                             <constraint firstItem="G3G-Ap-6ix" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="uzT-mw-eJq"/>
+                            <constraint firstAttribute="bottom" secondItem="6cw-FO-hjb" secondAttribute="bottom" id="vmP-xG-cTW"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>


### PR DESCRIPTION
Closes #495 
Testing branch: https://github.com/wordpress-mobile/WordPress-iOS/tree/feature/15073-extend-carousel-background

All further carousel PRs will be merging back to a feature branch that's separate from develop. Once the carousel changes are complete, the feature branch will merge into develop. I was going to maintain the old prologue carousel while building the new one, but that became too complex very quickly. 

This PR adjust the top container to extend below the button blur view for the unified prologue carousel. 

**Not in this PR**
- the correct positioning for the headline text in the unified prologue carousel

### To test
1. Log out if logged in.
2. Notice the blurred blue background.

| Light mode | Dark mode |
| --- | --- |
| ![Simulator Screen Shot - iPhone 11 Pro (14 0) - 2020-10-16 at 15 03 30](https://user-images.githubusercontent.com/1062444/96304214-54c16f80-0fc1-11eb-8a27-4ee76863be3c.png) | ![Simulator Screen Shot - iPhone 11 Pro (14 0) - 2020-10-16 at 15 03 50](https://user-images.githubusercontent.com/1062444/96304237-5be87d80-0fc1-11eb-80a5-6ae756f9debe.png) | 