### PR TITLE
Issues/configure instruction text

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.28.0-beta.1"
+  s.version       = "1.28.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -11,6 +11,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let jetpackLoginInstructions: String
     public let siteLoginInstructions: String
 	public let siteCredentialInstructions: String
+    public let usernamePasswordInstructions: String
     public let twoFactorInstructions: String
     public let magicLinkSignupInstructions: String
     public let openMailSignupInstructions: String
@@ -58,6 +59,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 jetpackLoginInstructions: String = defaultStrings.jetpackLoginInstructions,
                 siteLoginInstructions: String = defaultStrings.siteLoginInstructions,
                 siteCredentialInstructions: String = defaultStrings.siteCredentialInstructions,
+                usernamePasswordInstructions: String = defaultStrings.usernamePasswordInstructions,
                 twoFactorInstructions: String = defaultStrings.twoFactorInstructions,
                 magicLinkSignupInstructions: String = defaultStrings.magicLinkSignupInstructions,
                 openMailSignupInstructions: String = defaultStrings.openMailSignupInstructions,
@@ -90,6 +92,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
 		self.siteCredentialInstructions = siteCredentialInstructions
+        self.usernamePasswordInstructions = usernamePasswordInstructions
         self.twoFactorInstructions = twoFactorInstructions
         self.magicLinkSignupInstructions = magicLinkSignupInstructions
         self.openMailSignupInstructions = openMailSignupInstructions
@@ -133,6 +136,8 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                      comment: "Instruction text on the login's site addresss screen."),
             siteCredentialInstructions: NSLocalizedString("Enter your account information for %@.",
                                                           comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
+            usernamePasswordInstructions: NSLocalizedString("Log in with your WordPress.com username and password.",
+                                                            comment: "Instructions on the WordPress.com username / password log in form."),
             twoFactorInstructions: NSLocalizedString("Please enter the verification code from your authenticator app, or tap the link below to receive a code via SMS.",
                                                      comment: "Instruction text on the two-factor screen."),
             magicLinkSignupInstructions: NSLocalizedString("We'll email you a signup link to create your new WordPress.com account.",

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1371,6 +1371,7 @@
                         <outlet property="bottomContentConstraint" destination="RM5-Rp-H2z" id="LrI-5r-4sV"/>
                         <outlet property="errorLabel" destination="Vpd-vq-FQH" id="F3O-nu-HTr"/>
                         <outlet property="forgotPasswordButton" destination="XI0-rr-yUh" id="GPG-Np-wEi"/>
+                        <outlet property="instructionLabel" destination="au1-mY-r58" id="lXl-Oj-b3l"/>
                         <outlet property="passwordField" destination="pHh-Ma-Bb7" id="hW8-2o-n1g"/>
                         <outlet property="siteHeaderView" destination="vkO-HN-aFE" id="Eyg-MS-QDE"/>
                         <outlet property="submitButton" destination="YGE-OB-HmV" id="39T-xt-cuq"/>

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -76,6 +76,8 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
     @objc func localizeControls() {
+        instructionLabel?.text = WordPressAuthenticator.shared.displayStrings.usernamePasswordInstructions
+
         usernameField.placeholder = NSLocalizedString("Username", comment: "Username placeholder")
         passwordField.placeholder = NSLocalizedString("Password", comment: "Password placeholder")
 


### PR DESCRIPTION
This PR makes the instruction text on the LoginUsernamePasswordViewController customizable/configurable.  Up to this point the text was hard coded in the Storyboard (and not localized 😱).  With these changes it can be configured via the corresponding displayString and can be localized. I've introduced this change in order to configure the text for NiOS.

I've opted to make the default text generic rather than reference WooCommerce directly for consistency with the other strings in the auth library.  This will require a follow up patch to WooCommerceiOS to keep the text consistent until it implements the unified auth flow.

To Test:
Test the companion [WCiOS PR](https://github.com/woocommerce/woocommerce-ios/pull/3061) and confirm the instructions can be configured.
