### PR TITLE
Release 1.28.0 in trunk

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.27.1-beta"
+  s.version       = "1.28.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.28.0-beta.2"
+  s.version       = "1.28.0"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.27.0"
+  s.version       = "1.27.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.27.1"
+  s.version       = "1.27.1-beta"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.28.0-beta.1"
+  s.version       = "1.28.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -11,6 +11,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let jetpackLoginInstructions: String
     public let siteLoginInstructions: String
 	public let siteCredentialInstructions: String
+    public let usernamePasswordInstructions: String
     public let twoFactorInstructions: String
     public let magicLinkSignupInstructions: String
     public let openMailSignupInstructions: String
@@ -58,6 +59,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 jetpackLoginInstructions: String = defaultStrings.jetpackLoginInstructions,
                 siteLoginInstructions: String = defaultStrings.siteLoginInstructions,
                 siteCredentialInstructions: String = defaultStrings.siteCredentialInstructions,
+                usernamePasswordInstructions: String = defaultStrings.usernamePasswordInstructions,
                 twoFactorInstructions: String = defaultStrings.twoFactorInstructions,
                 magicLinkSignupInstructions: String = defaultStrings.magicLinkSignupInstructions,
                 openMailSignupInstructions: String = defaultStrings.openMailSignupInstructions,
@@ -90,6 +92,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.jetpackLoginInstructions = jetpackLoginInstructions
         self.siteLoginInstructions = siteLoginInstructions
 		self.siteCredentialInstructions = siteCredentialInstructions
+        self.usernamePasswordInstructions = usernamePasswordInstructions
         self.twoFactorInstructions = twoFactorInstructions
         self.magicLinkSignupInstructions = magicLinkSignupInstructions
         self.openMailSignupInstructions = openMailSignupInstructions
@@ -133,6 +136,8 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                      comment: "Instruction text on the login's site addresss screen."),
             siteCredentialInstructions: NSLocalizedString("Enter your account information for %@.",
                                                           comment: "Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site."),
+            usernamePasswordInstructions: NSLocalizedString("Log in with your WordPress.com username and password.",
+                                                            comment: "Instructions on the WordPress.com username / password log in form."),
             twoFactorInstructions: NSLocalizedString("Please enter the verification code from your authenticator app, or tap the link below to receive a code via SMS.",
                                                      comment: "Instruction text on the two-factor screen."),
             magicLinkSignupInstructions: NSLocalizedString("We'll email you a signup link to create your new WordPress.com account.",

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17503.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17502"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -568,7 +568,7 @@
         <!--LoginWPComViewController-->
         <scene sceneID="brQ-1M-iPT">
             <objects>
-                <viewController storyboardIdentifier="LoginWPComViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="lmD-c6-SLs" userLabel="LoginWPComViewController" customClass="LoginWPComViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginWPComViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="lmD-c6-SLs" userLabel="LoginWPComViewController" customClass="LoginWPComViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="dAs-4b-ACP"/>
                         <viewControllerLayoutGuide type="bottom" id="kOH-fr-1L0"/>
@@ -906,7 +906,7 @@
         <!--Login Link Request View Controller-->
         <scene sceneID="lHx-fY-p45">
             <objects>
-                <viewController storyboardIdentifier="LoginLinkRequestViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Kvo-Y2-yhG" customClass="LoginLinkRequestViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginLinkRequestViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Kvo-Y2-yhG" customClass="LoginLinkRequestViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="q8R-wf-TMO"/>
                         <viewControllerLayoutGuide type="bottom" id="h4a-j8-84P"/>
@@ -1095,7 +1095,7 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" red="0.02390592004" green="1" blue="0.002390008849" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -1384,7 +1384,7 @@
         <!--Login Prologue Login Method View Controller-->
         <scene sceneID="4ov-Vw-tga">
             <objects>
-                <viewController storyboardIdentifier="LoginPrologueLoginMethodViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hed-vB-osh" customClass="LoginPrologueLoginMethodViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginPrologueLoginMethodViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hed-vB-osh" customClass="LoginPrologueLoginMethodViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="EBT-D5-afP"/>
                         <viewControllerLayoutGuide type="bottom" id="wML-ff-0Cg"/>

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1371,6 +1371,7 @@
                         <outlet property="bottomContentConstraint" destination="RM5-Rp-H2z" id="LrI-5r-4sV"/>
                         <outlet property="errorLabel" destination="Vpd-vq-FQH" id="F3O-nu-HTr"/>
                         <outlet property="forgotPasswordButton" destination="XI0-rr-yUh" id="GPG-Np-wEi"/>
+                        <outlet property="instructionLabel" destination="au1-mY-r58" id="lXl-Oj-b3l"/>
                         <outlet property="passwordField" destination="pHh-Ma-Bb7" id="hW8-2o-n1g"/>
                         <outlet property="siteHeaderView" destination="vkO-HN-aFE" id="Eyg-MS-QDE"/>
                         <outlet property="submitButton" destination="YGE-OB-HmV" id="39T-xt-cuq"/>

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -76,6 +76,8 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
     @objc func localizeControls() {
+        instructionLabel?.text = WordPressAuthenticator.shared.displayStrings.usernamePasswordInstructions
+
         usernameField.placeholder = NSLocalizedString("Username", comment: "Username placeholder")
         passwordField.placeholder = NSLocalizedString("Password", comment: "Password placeholder")
 


### PR DESCRIPTION
Release of 1.28.0 (trunk)

CHANGELOG (from git log since 1.27):

* Removes a green background color from a stack view.
* Wire up outlet to info text label.
* Adds display string for UsernamePassword vc info label.
* Set configurable text on instruction label.
