### PR TITLE
Updates to WordPressKit with Alamofire 5

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7.0'
-  pod 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
+  # pod 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'upgrade/Alamofire-5-3-0'
   pod 'WordPressShared', '~> 1.12-beta' # Don't change this until we hit 2.0 in WPShared
 
 
@@ -19,7 +20,7 @@ def wordpress_authenticator_pods
   ## =====================
   ##
   pod '1PasswordExtension', '1.8.6'
-  pod 'Alamofire', '4.8'
+  pod 'Alamofire', '5.4'
   pod 'CocoaLumberjack', '3.5.2'
   pod 'GoogleSignIn', '5.0.2'
   pod 'lottie-ios', '3.1.6'

--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,6 @@ def wordpress_authenticator_pods
   ## =====================
   ##
   pod '1PasswordExtension', '1.8.6'
-  pod 'Alamofire', '5.4'
   pod 'CocoaLumberjack', '3.5.2'
   pod 'GoogleSignIn', '5.0.2'
   pod 'lottie-ios', '3.1.6'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -63,7 +63,6 @@ PODS:
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.8.6)
-  - Alamofire (= 5.4)
   - CocoaLumberjack (= 3.5.2)
   - Expecta (= 1.0.6)
   - GoogleSignIn (= 5.0.2)
@@ -137,6 +136,6 @@ SPEC CHECKSUMS:
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
-PODFILE CHECKSUM: 72b5b30ee253f9c306e93b76e44f790de5f2329f
+PODFILE CHECKSUM: 9997624b1285be0677945aaa15ab36a9a6de5b81
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - 1PasswordExtension (1.8.6)
-  - Alamofire (4.8.0)
+  - Alamofire (5.4.0)
   - AppAuth (1.3.0):
     - AppAuth/Core (= 1.3.0)
     - AppAuth/ExternalUserAgent (= 1.3.0)
@@ -48,8 +48,8 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.5.0)
-  - WordPressKit (4.18.0):
-    - Alamofire (~> 4.8.0)
+  - WordPressKit (4.20.0-beta.2):
+    - Alamofire (~> 5.4.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
@@ -63,7 +63,7 @@ PODS:
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.8.6)
-  - Alamofire (= 4.8)
+  - Alamofire (= 5.4)
   - CocoaLumberjack (= 3.5.2)
   - Expecta (= 1.0.6)
   - GoogleSignIn (= 5.0.2)
@@ -75,7 +75,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.18-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `upgrade/Alamofire-5-3-0`)
   - WordPressShared (~> 1.12-beta)
   - WordPressUI (~> 1.7.0)
 
@@ -99,14 +99,23 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
 
+EXTERNAL SOURCES:
+  WordPressKit:
+    :branch: upgrade/Alamofire-5-3-0
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: cd4b6c3262ac7bb194b104594936d650046cc708
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
-  Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
+  Alamofire: 3b6a534a3df22db367e4dedeeca73d1ddfcf0e2f
   AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -123,11 +132,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
-  WordPressKit: 1d10fa14ea185600472d31cf25e677c7d938b17d
+  WordPressKit: b4852dba531b809fd00647fc9ba18ec45bff36b1
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
-PODFILE CHECKSUM: dcfabc4bf0a259cb16d29a95a5acdfe5327cb221
+PODFILE CHECKSUM: 72b5b30ee253f9c306e93b76e44f790de5f2329f
 
 COCOAPODS: 1.8.4

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -42,6 +42,6 @@ Pod::Spec.new do |s|
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
-  s.dependency 'WordPressKit', '~> 4.20.0-beta' # Don't change this until we hit 5.0 in WPKit
+  s.dependency 'WordPressKit', '~> 4.21.0-beta' # Don't change this until we hit 5.0 in WPKit
   s.dependency 'WordPressShared', '~> 1.12-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -42,6 +42,6 @@ Pod::Spec.new do |s|
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
-  s.dependency 'WordPressKit', '~> 4.20-beta' # Don't change this until we hit 5.0 in WPKit
+  s.dependency 'WordPressKit', '~> 4.20.0-beta' # Don't change this until we hit 5.0 in WPKit
   s.dependency 'WordPressShared', '~> 1.12-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -31,7 +31,6 @@ Pod::Spec.new do |s|
   s.header_dir    = 'WordPressAuthenticator'
 
   s.dependency '1PasswordExtension', '1.8.6'
-  s.dependency 'Alamofire', '5.4'
   s.dependency 'CocoaLumberjack', '~> 3.5'
   s.dependency 'lottie-ios', '3.1.6'
   s.dependency 'NSURL+IDN', '0.4'

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.28.0"
+  s.version       = "1.29.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.header_dir    = 'WordPressAuthenticator'
 
   s.dependency '1PasswordExtension', '1.8.6'
-  s.dependency 'Alamofire', '4.8'
+  s.dependency 'Alamofire', '5.4'
   s.dependency 'CocoaLumberjack', '~> 3.5'
   s.dependency 'lottie-ios', '3.1.6'
   s.dependency 'NSURL+IDN', '0.4'
@@ -43,6 +43,6 @@ Pod::Spec.new do |s|
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
-  s.dependency 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
+  s.dependency 'WordPressKit', '~> 4.20-beta' # Don't change this until we hit 5.0 in WPKit
   s.dependency 'WordPressShared', '~> 1.12-beta' # Don't change this until we hit 2.0 in WPShared
 end


### PR DESCRIPTION
This PR updates WordPressKit to the version that was upgraded to Alamofire 5

**Note: do not merge before updating the Podfile with the correct version on WordPressKit. Now it's pointing directly to a branch**