### PR TITLE
Login Prologue button view: make constraints optional.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.28.0"
+  s.version       = "1.29.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -23,8 +23,8 @@ class LoginPrologueViewController: LoginViewController {
 
     /// Constraints on the button view container.
     /// Used to adjust the button width in unified views.
-    @IBOutlet private weak var buttonViewLeadingConstraint: NSLayoutConstraint!
-    @IBOutlet private weak var buttonViewTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var buttonViewLeadingConstraint: NSLayoutConstraint?
+    @IBOutlet private weak var buttonViewTrailingConstraint: NSLayoutConstraint?
     private var defaultButtonViewMargin: CGFloat = 0
 
     // Called when login button is tapped
@@ -544,8 +544,8 @@ private extension LoginPrologueViewController {
         
         guard traitCollection.horizontalSizeClass == .regular &&
             traitCollection.verticalSizeClass == .regular else {
-                buttonViewLeadingConstraint.constant = defaultButtonViewMargin
-                buttonViewTrailingConstraint.constant = defaultButtonViewMargin
+                buttonViewLeadingConstraint?.constant = defaultButtonViewMargin
+                buttonViewTrailingConstraint?.constant = defaultButtonViewMargin
                 return
         }
         
@@ -555,8 +555,8 @@ private extension LoginPrologueViewController {
         
         let margin = viewWidth * marginMultiplier
         
-        buttonViewLeadingConstraint.constant = margin
-        buttonViewTrailingConstraint.constant = margin
+        buttonViewLeadingConstraint?.constant = margin
+        buttonViewTrailingConstraint?.constant = margin
     }
     
     private enum ButtonViewMarginMultipliers {


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15094

This makes the constraints on the Login Prologue button view optional. Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/15232.