### PR TITLE
Login Prologue button view: make background color a parameter

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -192,6 +192,9 @@ public struct WordPressAuthenticatorUnifiedStyle {
     /// Style: Auth view background colors
     ///
     public let viewControllerBackgroundColor: UIColor
+    
+    /// Style: Auth Prologue buttons background color
+    public let prologueButtonsBackgroundColor: UIColor
 
     /// Style: Status bar style. Defaults to `default`.
     ///
@@ -212,6 +215,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
                 textButtonColor: UIColor,
                 textButtonHighlightColor: UIColor,
                 viewControllerBackgroundColor: UIColor,
+                prologueButtonsBackgroundColor: UIColor = .clear,
                 statusBarStyle: UIStatusBarStyle = .default,
                 navBarBackgroundColor: UIColor,
                 navButtonTextColor: UIColor,
@@ -223,6 +227,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
         self.textButtonColor = textButtonColor
         self.textButtonHighlightColor = textButtonHighlightColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
+        self.prologueButtonsBackgroundColor = prologueButtonsBackgroundColor
         self.statusBarStyle = statusBarStyle
         self.navBarBackgroundColor = navBarBackgroundColor
         self.navButtonTextColor = navButtonTextColor

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -223,9 +223,9 @@ class LoginPrologueViewController: LoginViewController {
                 self?.dismiss(animated: true, completion: nil)
             }
         }
-
-        // Set the button background color to clear so the blur effect blurs the Prologue background color.
-        buttonViewController.backgroundColor = .clear
+        
+        let backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.prologueButtonsBackgroundColor ?? .clear
+        buttonViewController.backgroundColor = backgroundColor
         buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
     }
 


### PR DESCRIPTION
Closes #514 
Ref: woocommerce/woocommerce-ios#3144

This PR:
* adds a property to WordPressAuthenticatorStyle for the background color with default value of `.clear` . This should not break the API (at least it didn't for WooCommerce)
* sets the background color of LoginViewController's buttonViewController to the property passed via WordPressAuthenticatorStyle, defaulting to `.clear` again if unified styles is nil.

Note: I tried to add a test but I didn't find the proper place to do so. Let me know if that's something you would like me to explore, please.