### PR TITLE
Login Prologue Button View: Customize order of buttons

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -82,6 +82,12 @@ public struct WordPressAuthenticatorConfiguration {
     /// If disabled, displays the old carousel.
     /// If enabled, displays the new carousel.
     let enableUnifiedCarousel: Bool
+    
+    /// Flag for the unified login/signup flows.
+    /// If disabled, the "Continue With WordPress" button in the login prologue is shown first.
+    /// If enabled, the "Enter your site Address" button in the login prologue is shown first.
+    /// Default value is disabled
+    let continueWithSiteAddressFirst: Bool
 
     /// Designated Initializer
     ///
@@ -101,7 +107,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
                  enableUnifiedCarousel: Bool = false,
-                 displayHintButtons: Bool = true) {
+                 displayHintButtons: Bool = true,
+                 continueWithSiteAddressFirst: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -120,5 +127,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableUnifiedCarousel = enableUnifiedCarousel
         self.displayHintButtons = displayHintButtons
         self.enableSignupWithGoogle = enableSignupWithGoogle
+        self.continueWithSiteAddressFirst = continueWithSiteAddressFirst
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -201,7 +201,7 @@ class LoginPrologueViewController: LoginViewController {
                                                  comment: "Button title. Takes the user to the login by site address flow.")
         
         if configuration.continueWithSiteAddressFirst {
-            buildWooUnifiedPrologueButtons(buttonViewController, loginTitle: loginTitle, siteAddressTitle: siteAddressTitle)
+            buildUnifiedPrologueButtonsWithSiteAddressFirst(buttonViewController, loginTitle: loginTitle, siteAddressTitle: siteAddressTitle)
             return
         }
         
@@ -223,7 +223,7 @@ class LoginPrologueViewController: LoginViewController {
         setButtonViewControllerBackground(buttonViewController)
     }
     
-    private func buildWooUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController, loginTitle: String, siteAddressTitle: String) {
+    private func buildUnifiedPrologueButtonsWithSiteAddressFirst(_ buttonViewController: NUXButtonViewController, loginTitle: String, siteAddressTitle: String) {
         guard configuration.enableUnifiedAuth == true else {
             return
         }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -195,6 +195,15 @@ class LoginPrologueViewController: LoginViewController {
     /// Displays the Unified prologue buttons.
     ///
     private func buildUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController) {
+        if configuration.continueWithSiteAddressFirst {
+            buildWooUnifiedPrologueButtons(buttonViewController)
+            return
+        }
+        
+        buildDefaultUnifiedPrologueButtons(buttonViewController)
+    }
+    
+    private func buildDefaultUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController) {
         let loginTitle = NSLocalizedString("Continue with WordPress.com",
                                            comment: "Button title. Takes the user to the login by email flow.")
         let siteAddressTitle = NSLocalizedString("Enter your site address",
@@ -217,6 +226,43 @@ class LoginPrologueViewController: LoginViewController {
             }
         }
 
+        if showCancel {
+            let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
+            buttonViewController.setupTertiaryButton(title: cancelTitle, isPrimary: false) { [weak self] in
+                self?.dismiss(animated: true, completion: nil)
+            }
+        }
+
+        // Set the button background color to clear so the blur effect blurs the Prologue background color.
+        buttonViewController.backgroundColor = .clear
+        buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
+    }
+    
+    private func buildWooUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController) {
+        guard configuration.enableUnifiedAuth == true else {
+            return
+        }
+        
+        let loginTitle = NSLocalizedString("Continue with WordPress.com",
+                                           comment: "Button title. Takes the user to the login by email flow.")
+        let siteAddressTitle = NSLocalizedString("Enter your site address",
+                                                 comment: "Button title. Takes the user to the login by site address flow.")
+
+        setButtonViewMargins(forWidth: view.frame.width)
+        
+        buttonViewController.setupTopButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Prologue Self Hosted Button") { [weak self] in
+            self?.siteAddressTapped()
+        }
+        
+        buttonViewController.setupBottomButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button") { [weak self] in
+            guard let self = self else {
+                return
+            }
+            
+            self.tracker.track(click: .continueWithWordPressCom)
+            self.continueWithDotCom()
+        }
+        
         if showCancel {
             let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
             buttonViewController.setupTertiaryButton(title: cancelTitle, isPrimary: false) { [weak self] in

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -195,66 +195,58 @@ class LoginPrologueViewController: LoginViewController {
     /// Displays the Unified prologue buttons.
     ///
     private func buildUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController) {
-        if configuration.continueWithSiteAddressFirst {
-            buildWooUnifiedPrologueButtons(buttonViewController)
-            return
-        }
-        
-        buildDefaultUnifiedPrologueButtons(buttonViewController)
-    }
-    
-    private func buildDefaultUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController) {
         let loginTitle = NSLocalizedString("Continue with WordPress.com",
                                            comment: "Button title. Takes the user to the login by email flow.")
         let siteAddressTitle = NSLocalizedString("Enter your site address",
                                                  comment: "Button title. Takes the user to the login by site address flow.")
-
-        setButtonViewMargins(forWidth: view.frame.width)
         
-        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button") { [weak self] in
-            guard let self = self else {
-                return
-            }
-            
-            self.tracker.track(click: .continueWithWordPressCom)
-            self.continueWithDotCom()
+        if configuration.continueWithSiteAddressFirst {
+            buildWooUnifiedPrologueButtons(buttonViewController, loginTitle: loginTitle, siteAddressTitle: siteAddressTitle)
+            return
         }
-
-        if configuration.enableUnifiedAuth {
-            buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Prologue Self Hosted Button") { [weak self] in
-                self?.siteAddressTapped()
-            }
-        }
-
-        if showCancel {
-            let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
-            buttonViewController.setupTertiaryButton(title: cancelTitle, isPrimary: false) { [weak self] in
-                self?.dismiss(animated: true, completion: nil)
-            }
-        }
-
-        // Set the button background color to clear so the blur effect blurs the Prologue background color.
-        buttonViewController.backgroundColor = .clear
-        buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
+        
+        buildDefaultUnifiedPrologueButtons(buttonViewController, loginTitle: loginTitle, siteAddressTitle: siteAddressTitle)
     }
     
-    private func buildWooUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController) {
+    private func buildDefaultUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController, loginTitle: String, siteAddressTitle: String) {
+
+        setButtonViewMargins(forWidth: view.frame.width)
+
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button", onTap: loginTapCallback())
+
+        if configuration.enableUnifiedAuth {
+            buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Prologue Self Hosted Button", onTap: siteAddressTapCallback()) 
+        }
+
+        showCancelIfNeccessary(buttonViewController)
+
+        setButtonViewControllerBackground(buttonViewController)
+    }
+    
+    private func buildWooUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController, loginTitle: String, siteAddressTitle: String) {
         guard configuration.enableUnifiedAuth == true else {
             return
         }
         
-        let loginTitle = NSLocalizedString("Continue with WordPress.com",
-                                           comment: "Button title. Takes the user to the login by email flow.")
-        let siteAddressTitle = NSLocalizedString("Enter your site address",
-                                                 comment: "Button title. Takes the user to the login by site address flow.")
-
         setButtonViewMargins(forWidth: view.frame.width)
+
+        buttonViewController.setupTopButton(title: siteAddressTitle, isPrimary: true, accessibilityIdentifier: "Prologue Self Hosted Button", onTap: siteAddressTapCallback())
         
-        buttonViewController.setupTopButton(title: siteAddressTitle, isPrimary: true, accessibilityIdentifier: "Prologue Self Hosted Button") { [weak self] in
+        buttonViewController.setupBottomButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Continue Button", onTap:loginTapCallback())
+        
+        showCancelIfNeccessary(buttonViewController)
+
+        setButtonViewControllerBackground(buttonViewController)
+    }
+    
+    private func siteAddressTapCallback() -> NUXButtonViewController.CallBackType {
+        return { [weak self] in
             self?.siteAddressTapped()
         }
-        
-        buttonViewController.setupBottomButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Continue Button") { [weak self] in
+    }
+
+    private func loginTapCallback() -> NUXButtonViewController.CallBackType {
+        return { [weak self] in
             guard let self = self else {
                 return
             }
@@ -262,15 +254,18 @@ class LoginPrologueViewController: LoginViewController {
             self.tracker.track(click: .continueWithWordPressCom)
             self.continueWithDotCom()
         }
-        
+    }
+    
+    private func showCancelIfNeccessary(_ buttonViewController: NUXButtonViewController) {
         if showCancel {
             let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
             buttonViewController.setupTertiaryButton(title: cancelTitle, isPrimary: false) { [weak self] in
                 self?.dismiss(animated: true, completion: nil)
             }
         }
-
-        // Set the button background color to clear so the blur effect blurs the Prologue background color.
+    }
+    
+    private func setButtonViewControllerBackground(_ buttonViewController: NUXButtonViewController) {
         buttonViewController.backgroundColor = .clear
         buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -250,11 +250,11 @@ class LoginPrologueViewController: LoginViewController {
 
         setButtonViewMargins(forWidth: view.frame.width)
         
-        buttonViewController.setupTopButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Prologue Self Hosted Button") { [weak self] in
+        buttonViewController.setupTopButton(title: siteAddressTitle, isPrimary: true, accessibilityIdentifier: "Prologue Self Hosted Button") { [weak self] in
             self?.siteAddressTapped()
         }
         
-        buttonViewController.setupBottomButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button") { [weak self] in
+        buttonViewController.setupBottomButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Continue Button") { [weak self] in
             guard let self = self else {
                 return
             }


### PR DESCRIPTION
Closes #513 

Ref: woocommerce/woocommerce-ios#3128

This PR:
* adds a flag to WordPressAuthenticatorConfiguration to signal if the login prologue should show the Continue With Site Address button first.
* add logic to LoginPrologueViewController to honor that flag.

How to test:
This PR should not introduce breaking changes to the API. 
* One way to confirm that's true would be pointing WordPress to this branch and test that WordPress-iOS builds and there are no behaviour changes.
* Another possible test would be checking out [this PR in WooCommerce](https://github.com/woocommerce/woocommerce-ios/pull/3166), which already points to this branch. 
