### PR TITLE
Partially expose navigation logic to clients of WPAuthenticator

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.30.0-beta.1"
+  s.version       = "1.30.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -155,6 +155,9 @@
 		CEDE0D952420121D00CB3345 /* UIStoryboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */; };
 		CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */; };
 		D85C3653256DEDA900D56E34 /* WordPressAuthenticatorResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85C3652256DEDA900D56E34 /* WordPressAuthenticatorResult.swift */; };
+		D85C36E6256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85C36E5256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift */; };
+		D85C36EC256E10EA00D56E34 /* MockNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85C36EB256E10EA00D56E34 /* MockNavigationController.swift */; };
+		D85C36F0256E118D00D56E34 /* NavigationToEnterAccountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85C36EF256E118D00D56E34 /* NavigationToEnterAccountTests.swift */; };
 		D881A30D256B5A7900FE5605 /* NavigationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A30C256B5A7900FE5605 /* NavigationCommand.swift */; };
 		D881A311256B5B4700FE5605 /* NavigateToEnterSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */; };
 		D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */; };
@@ -358,6 +361,9 @@
 		CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
 		D85C3652256DEDA900D56E34 /* WordPressAuthenticatorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorResult.swift; sourceTree = "<group>"; };
+		D85C36E5256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationToEnterSiteTests.swift; sourceTree = "<group>"; };
+		D85C36EB256E10EA00D56E34 /* MockNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationController.swift; sourceTree = "<group>"; };
+		D85C36EF256E118D00D56E34 /* NavigationToEnterAccountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationToEnterAccountTests.swift; sourceTree = "<group>"; };
 		D881A30C256B5A7900FE5605 /* NavigationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCommand.swift; sourceTree = "<group>"; };
 		D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterSite.swift; sourceTree = "<group>"; };
 		D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterAccount.swift; sourceTree = "<group>"; };
@@ -741,6 +747,7 @@
 		B5ED7901207E976500A8FD8C /* WordPressAuthenticatorTests */ = {
 			isa = PBXGroup;
 			children = (
+				D85C36E4256E0DAF00D56E34 /* Navigation */,
 				F18DF0E32525009200D83AFE /* SupportingFiles */,
 				BA53D64924DFE06C001F1ABF /* Mocks */,
 				BA53D64424DFDE0B001F1ABF /* Credentials */,
@@ -793,6 +800,7 @@
 				BA53D64E24DFE981001F1ABF /* MockOnePasswordFacade.swift */,
 				BA53D64C24DFE4E6001F1ABF /* ModalViewControllerPresentingSpy.swift */,
 				BA53D64A24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift */,
+				D85C36EB256E10EA00D56E34 /* MockNavigationController.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -866,6 +874,15 @@
 				CE73475524B77A3800A22660 /* SiteCredentialsViewController.swift */,
 			);
 			path = "Site Address";
+			sourceTree = "<group>";
+		};
+		D85C36E4256E0DAF00D56E34 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				D85C36E5256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift */,
+				D85C36EF256E118D00D56E34 /* NavigationToEnterAccountTests.swift */,
+			);
+			path = Navigation;
 			sourceTree = "<group>";
 		};
 		D881A307256B5A6900FE5605 /* Navigation */ = {
@@ -1305,11 +1322,14 @@
 				BA53D64824DFDF97001F1ABF /* WordPressSourceTagTests.swift in Sources */,
 				BA53D64D24DFE4E6001F1ABF /* ModalViewControllerPresentingSpy.swift in Sources */,
 				BA53D64624DFDE1D001F1ABF /* CredentialsTests.swift in Sources */,
+				D85C36EC256E10EA00D56E34 /* MockNavigationController.swift in Sources */,
 				BA53D64F24DFE981001F1ABF /* MockOnePasswordFacade.swift in Sources */,
 				3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */,
 				BA53D64B24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift in Sources */,
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,
+				D85C36F0256E118D00D56E34 /* NavigationToEnterAccountTests.swift in Sources */,
+				D85C36E6256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift in Sources */,
 				F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */,
 				B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */,
 			);

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -154,6 +154,9 @@
 		CEDE0D93242011E000CB3345 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */; };
 		CEDE0D952420121D00CB3345 /* UIStoryboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */; };
 		CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */; };
+		D881A30D256B5A7900FE5605 /* NavigationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A30C256B5A7900FE5605 /* NavigationCommand.swift */; };
+		D881A311256B5B4700FE5605 /* NavigateToEnterSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */; };
+		D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
 		F12F9FB424D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
@@ -353,6 +356,9 @@
 		CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
+		D881A30C256B5A7900FE5605 /* NavigationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCommand.swift; sourceTree = "<group>"; };
+		D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterSite.swift; sourceTree = "<group>"; };
+		D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterAccount.swift; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
@@ -707,6 +713,7 @@
 		B5ED78F6207E976500A8FD8C /* WordPressAuthenticator */ = {
 			isa = PBXGroup;
 			children = (
+				D881A307256B5A6900FE5605 /* Navigation */,
 				F12F9FB624D8A7E800771BCE /* Analytics */,
 				CE1B18CA20EEC31000BECC3F /* Credentials */,
 				B5609099208A4EAF00399AE4 /* Authenticator */,
@@ -856,6 +863,16 @@
 				CE73475524B77A3800A22660 /* SiteCredentialsViewController.swift */,
 			);
 			path = "Site Address";
+			sourceTree = "<group>";
+		};
+		D881A307256B5A6900FE5605 /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				D881A30C256B5A7900FE5605 /* NavigationCommand.swift */,
+				D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */,
+				D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */,
+			);
+			path = Navigation;
 			sourceTree = "<group>";
 		};
 		F12F9FB524D8A7DB00771BCE /* Analytics */ = {
@@ -1231,6 +1248,7 @@
 				CE1B18CE20EEC3CB00BECC3F /* WordPressAuthenticatorDelegateProtocol.swift in Sources */,
 				B5609110208A54F800399AE4 /* OnePasswordFacade.swift in Sources */,
 				F180B82424F59263000A01F5 /* StoredCredentialsPicker.swift in Sources */,
+				D881A311256B5B4700FE5605 /* NavigateToEnterSite.swift in Sources */,
 				B5609109208A54F800399AE4 /* SignupService.swift in Sources */,
 				B560913D208A563800399AE4 /* LoginProloguePageViewController.swift in Sources */,
 				B5609117208A555600399AE4 /* SearchTableViewCell.swift in Sources */,
@@ -1239,6 +1257,7 @@
 				B56090F1208A527000399AE4 /* String+Underline.swift in Sources */,
 				B56052A42090B2ED001B91FD /* CircularImageView.swift in Sources */,
 				B5609141208A563800399AE4 /* LoginPrologueViewController.swift in Sources */,
+				D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */,
 				B56090EB208A51D000399AE4 /* LoginFields.swift in Sources */,
 				B56090FB208A533200399AE4 /* WordPressSupportSourceTag.swift in Sources */,
 				F1AF1BEF24E4A80F00BA453E /* LoginFacade.swift in Sources */,
@@ -1255,6 +1274,7 @@
 				B56090CB208A4F5400399AE4 /* NUXNavigationController.swift in Sources */,
 				B560911F208A555E00399AE4 /* SignupGoogleViewController.swift in Sources */,
 				B5609142208A563800399AE4 /* LoginNavigationController.swift in Sources */,
+				D881A30D256B5A7900FE5605 /* NavigationCommand.swift in Sources */,
 				CE9C5B4E24E31E03005A8BCF /* SignupMagicLinkViewController.swift in Sources */,
 				B56090E4208A4F9D00399AE4 /* WPNUXMainButton.m in Sources */,
 				3FFF2FC323D7F53200D38C77 /* AppSelector.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		CEDE0D93242011E000CB3345 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */; };
 		CEDE0D952420121D00CB3345 /* UIStoryboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */; };
 		CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */; };
+		D85C3653256DEDA900D56E34 /* WordPressAuthenticatorResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85C3652256DEDA900D56E34 /* WordPressAuthenticatorResult.swift */; };
 		D881A30D256B5A7900FE5605 /* NavigationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A30C256B5A7900FE5605 /* NavigationCommand.swift */; };
 		D881A311256B5B4700FE5605 /* NavigateToEnterSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */; };
 		D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */; };
@@ -356,6 +357,7 @@
 		CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
+		D85C3652256DEDA900D56E34 /* WordPressAuthenticatorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorResult.swift; sourceTree = "<group>"; };
 		D881A30C256B5A7900FE5605 /* NavigationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCommand.swift; sourceTree = "<group>"; };
 		D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterSite.swift; sourceTree = "<group>"; };
 		D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterAccount.swift; sourceTree = "<group>"; };
@@ -625,6 +627,7 @@
 				CE1B18D120EEC44400BECC3F /* WordPressAuthenticatorStyles.swift */,
 				020BE74923B0BD2E007FE54C /* WordPressAuthenticatorDisplayImages.swift */,
 				CE16177421B6D82200B82A47 /* WordPressAuthenticatorDisplayStrings.swift */,
+				D85C3652256DEDA900D56E34 /* WordPressAuthenticatorResult.swift */,
 			);
 			path = Authenticator;
 			sourceTree = "<group>";
@@ -1207,6 +1210,7 @@
 				B560910F208A54F800399AE4 /* SafariCredentialsService.swift in Sources */,
 				B5CDBED420B4714500BC1EF2 /* UIImage+Assets.swift in Sources */,
 				B5609116208A555600399AE4 /* LoginTextField.swift in Sources */,
+				D85C3653256DEDA900D56E34 /* WordPressAuthenticatorResult.swift in Sources */,
 				F1C96669250BF53400EB529D /* UIViewController+Dismissal.swift in Sources */,
 				CE811D6724EDC0FB00F4CCD6 /* LoginMagicLinkViewController.swift in Sources */,
 				B56090E2208A4F9D00399AE4 /* WPNUXSecondaryButton.m in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -48,7 +48,7 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///     - site: passes in the site information to the delegate method.
     ///     - onCompletion: Closure to be executed on completion.
     ///
-    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, from: UIViewController?, onCompletion: @escaping (Error?, Bool) -> Void)
+    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (Error?, Bool, UIViewController?) -> Void)
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -48,7 +48,7 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///     - site: passes in the site information to the delegate method.
     ///     - onCompletion: Closure to be executed on completion.
     ///
-    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (Error?, Bool, UIViewController?) -> Void)
+    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void)
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -48,7 +48,7 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///     - site: passes in the site information to the delegate method.
     ///     - onCompletion: Closure to be executed on completion.
     ///
-    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, navigationController: UINavigationController?, onCompletion: @escaping (Error?, Bool) -> Void)
+    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, from: UIViewController?, onCompletion: @escaping (Error?, Bool) -> Void)
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -48,7 +48,7 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///     - site: passes in the site information to the delegate method.
     ///     - onCompletion: Closure to be executed on completion.
     ///
-    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (Error?, Bool) -> Void)
+    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, navigationController: UINavigationController?, onCompletion: @escaping (Error?, Bool) -> Void)
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorResult.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorResult.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+
+/// Provides options for clients of WordPressAuthenticator
+/// to signal what they expect WPAuthenticator to do in response to
+/// `shouldPresentUsernamePasswordController`
+///
+/// @see WordPressAuthenticatorDelegate.shouldPresentUsernamePasswordController
+public enum WordPressAuthenticatorResult {
+
+    /// An error
+    ///
+    case error(value: Error)
+
+    /// Boolean flag to indicate if UI providing entry for username and passsword
+    /// should be presented
+    ///
+    case presentPasswordController(value: Bool)
+
+    /// A view controller to be inserted into the navigation stack
+    ///
+    case injectViewController(value: UIViewController)
+}

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -2,9 +2,8 @@ import Foundation
 
 public struct NavigateToEnterAccount: NavigationCommand {
     public init() {}
-    public func execute(with: UINavigationController?) {
-        print("Off we go to Enter a New WordPress.com account")
-        continueWithDotCom(navigationController: with)
+    public func execute(from: UIViewController?) {
+        continueWithDotCom(navigationController: from?.navigationController)
     }
 }
 

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -4,5 +4,20 @@ public struct NavigateToEnterAccount: NavigationCommand {
     public init() {}
     public func execute(with: UINavigationController?) {
         print("Off we go to Enter a New WordPress.com account")
+        continueWithDotCom(navigationController: with)
+    }
+}
+
+
+private extension NavigateToEnterAccount {
+    /// Unified "Continue with WordPress.com" prologue button action.
+    ///
+    private func continueWithDotCom(navigationController: UINavigationController?) {
+        guard let vc = GetStartedViewController.instantiate(from: .getStarted) else {
+            DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
+            return
+        }
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct NavigateToEnterAccount: NavigationCommand {
+    func execute(with: UINavigationController) {
+        print("Off we go to Enter a New WordPress.com account")
+    }
+}

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Navigates to the unified "Continue with WordPress.com" flow.
+///
 public struct NavigateToEnterAccount: NavigationCommand {
     public init() {}
     public func execute(from: UIViewController?) {
@@ -9,8 +11,6 @@ public struct NavigateToEnterAccount: NavigationCommand {
 
 
 private extension NavigateToEnterAccount {
-    /// Unified "Continue with WordPress.com" prologue button action.
-    ///
     private func continueWithDotCom(navigationController: UINavigationController?) {
         guard let vc = GetStartedViewController.instantiate(from: .getStarted) else {
             DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 public struct NavigateToEnterAccount: NavigationCommand {
-    func execute(with: UINavigationController) {
+    public init() {}
+    public func execute(with: UINavigationController?) {
         print("Off we go to Enter a New WordPress.com account")
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
@@ -2,7 +2,8 @@
 import Foundation
 
 public struct NavigateToEnterSite: NavigationCommand {
-    func execute(with: UINavigationController) {
+    public init() {}
+    public func execute(with: UINavigationController?) {
         print("Off we go to Enter a New Site Address")
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
@@ -1,0 +1,8 @@
+
+import Foundation
+
+public struct NavigateToEnterSite: NavigationCommand {
+    func execute(with: UINavigationController) {
+        print("Off we go to Enter a New Site Address")
+    }
+}

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
@@ -3,10 +3,8 @@ import Foundation
 
 public struct NavigateToEnterSite: NavigationCommand {
     public init() {}
-    public func execute(with: UINavigationController?) {
-        print("Off we go to Enter a New Site Address")
-
-        presentUnifiedSiteAddressView(navigationController: with)
+    public func execute(from: UIViewController?) {
+        presentUnifiedSiteAddressView(navigationController: from?.navigationController)
     }
 }
 

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
@@ -1,6 +1,9 @@
 
 import Foundation
 
+
+/// Navigates to the unified site address login flow.
+///
 public struct NavigateToEnterSite: NavigationCommand {
     public init() {}
     public func execute(from: UIViewController?) {
@@ -9,8 +12,6 @@ public struct NavigateToEnterSite: NavigationCommand {
 }
 
 private extension NavigateToEnterSite {
-    /// Navigates to the unified site address login flow.
-    ///
     func presentUnifiedSiteAddressView(navigationController: UINavigationController?) {
         guard let vc = SiteAddressViewController.instantiate(from: .siteAddress) else {
             DDLogError("Failed to navigate from LoginViewController to SiteAddressViewController")

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
@@ -5,5 +5,20 @@ public struct NavigateToEnterSite: NavigationCommand {
     public init() {}
     public func execute(with: UINavigationController?) {
         print("Off we go to Enter a New Site Address")
+
+        presentUnifiedSiteAddressView(navigationController: with)
+    }
+}
+
+private extension NavigateToEnterSite {
+    /// Navigates to the unified site address login flow.
+    ///
+    func presentUnifiedSiteAddressView(navigationController: UINavigationController?) {
+        guard let vc = SiteAddressViewController.instantiate(from: .siteAddress) else {
+            DDLogError("Failed to navigate from LoginViewController to SiteAddressViewController")
+            return
+        }
+
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigationCommand.swift
+++ b/WordPressAuthenticator/Navigation/NavigationCommand.swift
@@ -7,5 +7,5 @@ import Foundation
 /// Concrete implementations of this protocol will decide what that means
 ///
 public protocol NavigationCommand {
-    func execute(with: UINavigationController?)
+    func execute(from: UIViewController?)
 }

--- a/WordPressAuthenticator/Navigation/NavigationCommand.swift
+++ b/WordPressAuthenticator/Navigation/NavigationCommand.swift
@@ -6,6 +6,6 @@ import Foundation
 /// 
 /// Concrete implementations of this protocol will decide what that means
 ///
-protocol NavigationCommand {
+public protocol NavigationCommand {
     func execute(with: UINavigationController)
 }

--- a/WordPressAuthenticator/Navigation/NavigationCommand.swift
+++ b/WordPressAuthenticator/Navigation/NavigationCommand.swift
@@ -7,5 +7,5 @@ import Foundation
 /// Concrete implementations of this protocol will decide what that means
 ///
 public protocol NavigationCommand {
-    func execute(with: UINavigationController)
+    func execute(with: UINavigationController?)
 }

--- a/WordPressAuthenticator/Navigation/NavigationCommand.swift
+++ b/WordPressAuthenticator/Navigation/NavigationCommand.swift
@@ -1,0 +1,11 @@
+
+import Foundation
+
+/// NavigationCommand abstracts logic necessary provide clients of this library
+/// with a way to navigate to a particular location in the UL navigation flow.
+/// 
+/// Concrete implementations of this protocol will decide what that means
+///
+protocol NavigationCommand {
+    func execute(with: UINavigationController)
+}

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -226,7 +226,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 
     func presentNextControllerIfPossible(siteInfo: WordPressComSiteInfo?) {
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, from: navigationController, onCompletion: { (error, isSelfHosted) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (error, isSelfHosted, injectedViewController) in
             guard let originalError = error else {
                 
                 if isSelfHosted {

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -226,19 +226,21 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 
     func presentNextControllerIfPossible(siteInfo: WordPressComSiteInfo?) {
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (error, isSelfHosted, injectedViewController) in
-            guard let originalError = error else {
-                
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (result) in
+            switch result {
+            case let .error(error):
+                self.displayError(message: error.localizedDescription)
+            case let .presentPasswordController(isSelfHosted):
                 if isSelfHosted {
                     self.showSelfHostedUsernamePassword()
-                    return
                 }
 
                 self.showWPUsernamePassword()
-                return
-            }
 
-            self.displayError(message: originalError.localizedDescription)
+            case .injectViewController(_):
+                // This case is only used for UL&S
+                break
+            }
         })
     }
 

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -226,7 +226,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 
     func presentNextControllerIfPossible(siteInfo: WordPressComSiteInfo?) {
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, navigationController: navigationController, onCompletion: { (error, isSelfHosted) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, from: navigationController, onCompletion: { (error, isSelfHosted) in
             guard let originalError = error else {
                 
                 if isSelfHosted {

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -226,7 +226,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 
     func presentNextControllerIfPossible(siteInfo: WordPressComSiteInfo?) {
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (error, isSelfHosted) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, navigationController: navigationController, onCompletion: { (error, isSelfHosted) in
             guard let originalError = error else {
                 
                 if isSelfHosted {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -468,7 +468,7 @@ private extension SiteAddressViewController {
             return
         }
         
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (error, isSelfHosted) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, navigationController: navigationController, onCompletion: { (error, isSelfHosted) in
             guard let originalError = error else {
 
                 if isSelfHosted {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -468,7 +468,7 @@ private extension SiteAddressViewController {
             return
         }
         
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, navigationController: navigationController, onCompletion: { (error, isSelfHosted) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, from: navigationController, onCompletion: { (error, isSelfHosted) in
             guard let originalError = error else {
 
                 if isSelfHosted {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -468,25 +468,21 @@ private extension SiteAddressViewController {
             return
         }
         
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (error, isSelfHosted, injectedViewController) in
-            // Shortcircuit if clients provide a view controller to be inserted in the stack
-            if let customUI = injectedViewController {
-                self.navigationController?.pushViewController(customUI, animated: true)
-                return
-            }
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (result) in
 
-            guard let originalError = error else {
-
+            switch result {
+            case let .error(error):
+                self.displayError(message: error.localizedDescription)
+            case let .presentPasswordController(isSelfHosted):
                 if isSelfHosted {
                     self.showSelfHostedUsernamePassword()
                     return
                 }
-
+                
                 self.showWPUsernamePassword()
-                return
+            case let .injectViewController(customUI):
+                self.navigationController?.pushViewController(customUI, animated: true)
             }
-
-            self.displayError(message: originalError.localizedDescription)
         })
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -468,7 +468,13 @@ private extension SiteAddressViewController {
             return
         }
         
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, from: navigationController, onCompletion: { (error, isSelfHosted) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (error, isSelfHosted, injectedViewController) in
+            // Shortcircuit if clients provide a view controller to be inserted in the stack
+            if let customUI = injectedViewController {
+                self.navigationController?.pushViewController(customUI, animated: true)
+                return
+            }
+
             guard let originalError = error else {
 
                 if isSelfHosted {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -469,7 +469,6 @@ private extension SiteAddressViewController {
         }
         
         WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (result) in
-
             switch result {
             case let .error(error):
                 self.displayError(message: error.localizedDescription)

--- a/WordPressAuthenticatorTests/Mocks/MockNavigationController.swift
+++ b/WordPressAuthenticatorTests/Mocks/MockNavigationController.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+final class MockNavigationController: UINavigationController {
+    var pushedViewController: UIViewController?
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+       pushedViewController = viewController
+       super.pushViewController(viewController, animated: true)
+     }
+}

--- a/WordPressAuthenticatorTests/Navigation/NavigationToEnterAccountTests.swift
+++ b/WordPressAuthenticatorTests/Navigation/NavigationToEnterAccountTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import WordPressAuthenticator
+
+final class NavigationToAccountTests: XCTestCase {
+    func testNavigationCommandNavigatesToExpectedDestination() {
+        let origin = UIViewController()
+        let navigationController = MockNavigationController(rootViewController: origin)
+
+        let command = NavigateToEnterAccount()
+        command.execute(from: origin)
+
+        let pushedViewController = navigationController.pushedViewController
+
+        XCTAssertNotNil(pushedViewController)
+        XCTAssertTrue(pushedViewController is GetStartedViewController)
+    }
+}

--- a/WordPressAuthenticatorTests/Navigation/NavigationToEnterSiteTests.swift
+++ b/WordPressAuthenticatorTests/Navigation/NavigationToEnterSiteTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import WordPressAuthenticator
+
+final class NavigationToEnterSiteTests: XCTestCase {
+    func testNavigationCommandNavigatesToExpectedDestination() {
+        let origin = UIViewController()
+        let navigationController = MockNavigationController(rootViewController: origin)
+
+        let command = NavigateToEnterSite()
+        command.execute(from: origin)
+
+        let pushedViewController = navigationController.pushedViewController
+
+        XCTAssertNotNil(pushedViewController)
+        XCTAssertTrue(pushedViewController is SiteAddressViewController)
+    }
+}


### PR DESCRIPTION
Closes #515 

Ref: woocommerce/woocommerce-ios#3161
Ref: p91TBi-3ON-p2

This PR provides a way for clients of WPAuthenticator to insert custom UI into WPAuthenticator's navigation flow in a way that:
* Hands over control to client apps, so those client apps can pass UI back to WPAuthenticator.
* Does not require modifications to the current implementation of WPAuthenticator, but only adds new code to it
* Leaves the responsibility of navigating out of the custom UI to WPAuthenticator
* Does not break much of the existing API.

## Changes
A simple implementation of the [command pattern](https://en.wikipedia.org/wiki/Command_pattern): 
* `NavigationCommand` is the actual command, and it is modeled as a protocol
* Two implementations of NavigationCommand: `NavigateToEnterSite` and `NavigateToEnterAccount`. These two structs lift and duplicate some of the existing code in `SiteAddressViewController`, to navigate, respectively, to the root of the navigation flow that allows logging in with a site address and a wordpress.com account.
* Modifies the signature of the method `shouldPresentUsernamePasswordController` in `WordPressAuthenticatorDelegate`. This modification breaks backwards compatibility. (see more about it in a comment to the PR)

## Testing
Changes break the API of WPAuthenticatorDelegate so this is a bit tricky to test in isolation.

I have submitted a draft PR to WordPress-iOS that integrates with the breaking changes in this PR, and provides a way to test that the changes I am submitting now do not break the existing login flow: wordpress-mobile/WordPress-iOS#15385

* Checkout WordPress-iOS branch `try/ctarda/auth`
* Run `bundle exec pod install`. That will point WPAuthenticator to this branch
* Build and run WordPress-iOS. 
* Log out if necessary.
* Attempt to login with both a WordPress.com account and a self-hosted site. Check that logging in is not broken.

