### PR TITLE
WordPressComSiteInfo: add properties and update parser

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.29.0"
+  s.version       = "1.30.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		CEDE0D93242011E000CB3345 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */; };
 		CEDE0D952420121D00CB3345 /* UIStoryboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */; };
 		CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */; };
+		D85C3882256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85C3881256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
 		F12F9FB424D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
@@ -353,6 +354,7 @@
 		CEDE0D92242011E000CB3345 /* NSObject+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D942420121D00CB3345 /* UIStoryboard+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Helpers.swift"; sourceTree = "<group>"; };
 		CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
+		D85C3881256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressComSiteInfoTests.swift; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
@@ -495,6 +497,7 @@
 			isa = PBXGroup;
 			children = (
 				B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */,
+				D85C3881256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1286,6 +1289,7 @@
 				BA53D64B24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift in Sources */,
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,
+				D85C3882256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift in Sources */,
 				F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */,
 				B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */,
 			);

--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -53,13 +53,13 @@ public class WordPressComSiteInfo {
         name                = remote["name"] as? String ?? ""
         tagline             = remote["description"] as? String ?? ""
         url                 = remote["urlAfterRedirects"] as? String ?? ""
-        hasJetpack          = remote["hasJetpack"] as? String == "1" ? true: false
-        isJetpackActive     = remote["isJetpackActive"] as? String == "1" ? true: false
-        isJetpackConnected  = remote["isJetpackConnected"] as? String == "1" ? true: false
+        hasJetpack          = remote["hasJetpack"] as? Int == 1 ? true: false
+        isJetpackActive     = remote["isJetpackActive"] as? Int == 1 ? true: false
+        isJetpackConnected  = remote["isJetpackConnected"] as? Int == 1 ? true: false
         icon                = remote["icon.img"] as? String ?? ""
-        isWPCom             = remote["isWordPressDotCom"] as? String == "1" ? true: false
-        isWP                = remote["isWordPress"] as? String == "1" ? true: false
-        exists              = remote["exists"] as? String == "1" ? true: false
+        isWPCom             = remote["isWordPressDotCom"] as? Int == 1 ? true: false
+        isWP                = remote["isWordPress"] as? Int == 1 ? true: false
+        exists              = remote["exists"] as? Int == 1 ? true: false
     }
 }
 

--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -50,15 +50,15 @@ public class WordPressComSiteInfo {
     /// Initializes the current SiteInfo instance with a raw dictionary.
     ///
     public init(remote: [AnyHashable: Any]) {
-        name                = remote["name"] as? String ?? ""
-        tagline             = remote["description"] as? String ?? ""
-        url                 = remote["urlAfterRedirects"] as? String ?? ""
-        hasJetpack          = remote["hasJetpack"] as? Int == 1 ? true: false
-        isJetpackActive     = remote["isJetpackActive"] as? Int == 1 ? true: false
-        isJetpackConnected  = remote["isJetpackConnected"] as? Int == 1 ? true: false
-        icon                = remote["icon.img"] as? String ?? ""
-        isWPCom             = remote["isWordPressDotCom"] as? Int == 1 ? true: false
-        isWP                = remote["isWordPress"] as? Int == 1 ? true: false
-        exists              = remote["exists"] as? Int == 1 ? true: false
+        name                = remote["name"] as? String                 ?? ""
+        tagline             = remote["description"] as? String          ?? ""
+        url                 = remote["urlAfterRedirects"] as? String    ?? ""
+        hasJetpack          = remote["hasJetpack"] as? Bool             ?? false
+        isJetpackActive     = remote["isJetpackActive"] as? Bool        ?? false
+        isJetpackConnected  = remote["isJetpackConnected"] as? Bool     ?? false
+        icon                = remote["icon.img"] as? String             ?? ""
+        isWPCom             = remote["isWordPressDotCom"] as? Bool      ?? false
+        isWP                = remote["isWordPress"] as? Bool            ?? false
+        exists              = remote["exists"] as? Bool                 ?? false
     }
 }

--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -21,6 +21,14 @@ public class WordPressComSiteInfo {
     ///
     public let hasJetpack: Bool
 
+    /// Indicates if Jetpack is active, or not.
+    ///
+    public let isJetpackActive: Bool
+
+    /// Indicates if Jetpack is connected, or not.
+    ///
+    public let isJetpackConnected: Bool
+
     /// URL of the Site's Blavatar.
     ///
     public let icon: String
@@ -29,17 +37,33 @@ public class WordPressComSiteInfo {
     ///
     public let isWPCom: Bool
 
+    /// Inidcates wheter the site is WordPress, or not.
+    ///
+    public let isWP: Bool
+
+    /// Inidcates whether the site exists, or not.
+    ///
+    public let exists: Bool
+
 
 
     /// Initializes the current SiteInfo instance with a raw dictionary.
     ///
     public init(remote: [AnyHashable: Any]) {
-        name        = remote["name"] as? String         ?? ""
-        tagline     = remote["description"] as? String  ?? ""
-        url         = remote["URL"] as? String          ?? ""
-        hasJetpack  = remote["hasJetpack"] as? Bool     ?? false
-        icon        = remote["icon.img"] as? String     ?? ""
-        isWPCom     = remote["isWordPressDotCom"] as? Bool ?? false
-        
+        name                = remote["name"] as? String ?? ""
+        tagline             = remote["description"] as? String ?? ""
+        url                 = remote["urlAfterRedirects"] as? String ?? ""
+        hasJetpack          = remote["hasJetpack"] as? String == "1" ? true: false
+        isJetpackActive     = remote["isJetpackActive"] as? String == "1" ? true: false
+        isJetpackConnected  = remote["isJetpackConnected"] as? String == "1" ? true: false
+        icon                = remote["icon.img"] as? String ?? ""
+        isWPCom             = remote["isWordPressDotCom"] as? String == "1" ? true: false
+        isWP                = remote["isWordPress"] as? String == "1" ? true: false
+        exists              = remote["exists"] as? String == "1" ? true: false
     }
+}
+
+
+extension Int {
+    var boolValue: Bool { return self != 0 }
 }

--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -62,8 +62,3 @@ public class WordPressComSiteInfo {
         exists              = remote["exists"] as? Int == 1 ? true: false
     }
 }
-
-
-extension Int {
-    var boolValue: Bool { return self != 0 }
-}

--- a/WordPressAuthenticatorTests/Model/WordPressComSiteInfoTests.swift
+++ b/WordPressAuthenticatorTests/Model/WordPressComSiteInfoTests.swift
@@ -38,13 +38,13 @@ final class WordPressComSiteInfoTests: XCTestCase {
 private extension WordPressComSiteInfoTests {
     func mock() -> [AnyHashable: Any] {
         return [
-            "isJetpackActive": "1",
-            "jetpackVersion": "0",
-            "isWordPressDotCom": "0",
+            "isJetpackActive": true,
+            "jetpackVersion": false,
+            "isWordPressDotCom": false,
             "urlAfterRedirects": "https://somewhere.com",
-            "hasJetpack": "1",
-            "isWordPress": "1",
-            "isJetpackConnected": "1"
+            "hasJetpack": true,
+            "isWordPress": true,
+            "isJetpackConnected": true
         ] as [AnyHashable: Any]
     }
 }

--- a/WordPressAuthenticatorTests/Model/WordPressComSiteInfoTests.swift
+++ b/WordPressAuthenticatorTests/Model/WordPressComSiteInfoTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import WordPressAuthenticator
+
+final class WordPressComSiteInfoTests: XCTestCase {
+    private var subject: WordPressComSiteInfo!
+
+    override func setUp() {
+        subject = WordPressComSiteInfo(remote: mock())
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    func testJetpackActiveMatchesExpectation() {
+        XCTAssertTrue(subject.isJetpackActive)
+    }
+
+    func testHasJetpackMatchesExpectation() {
+        XCTAssertTrue(subject.hasJetpack)
+    }
+
+    func testJetpackConnectedMatchesExpectation() {
+        XCTAssertTrue(subject.isJetpackConnected)
+    }
+
+    func testWPComMatchesExpectation() {
+        XCTAssertFalse(subject.isWPCom)
+    }
+
+    func testWPMatchesExpectation() {
+        XCTAssertTrue(subject.isWP)
+    }
+}
+
+private extension WordPressComSiteInfoTests {
+    func mock() -> [AnyHashable: Any] {
+        return [
+            "isJetpackActive": "1",
+            "jetpackVersion": "0",
+            "isWordPressDotCom": "0",
+            "urlAfterRedirects": "https://somewhere.com",
+            "hasJetpack": "1",
+            "isWordPress": "1",
+            "isJetpackConnected": "1"
+        ] as [AnyHashable: Any]
+    }
+}


### PR DESCRIPTION
Closes #521 

## Changes
* Add some properties to WordPressComSiteInfo to provide more information related to the state of the Jetpack installation. This will be very helpful for WooCommerce
* Update parser. It seems like the payload key mapping  to url is `urlAfterRedirects`
* Add tests to cover the parser

## Testing
* 👀  on the code
* If CI is ✅  we should we good to go. This should not introduce any breaking changes to WP