### PR TITLE
Assign Help button in custom UI injected by host apps

### DIFF
--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -480,7 +480,7 @@ private extension SiteAddressViewController {
                 
                 self.showWPUsernamePassword()
             case let .injectViewController(customUI):
-                /// Assign the help button of the newly injected UI to the same hep button we are currently displaying
+                /// Assign the help button of the newly injected UI to the same help button we are currently displaying
                 /// We are making a somewhat big assumption here: the chrome of the new UI we insert would look like the UI
                 /// WPAuthenticator is already displaying. Which is risky, but also kind of makes sense, considering
                 /// we are also pushing that injected UI to the current navigation controller.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -484,7 +484,9 @@ private extension SiteAddressViewController {
                 /// We are making a somewhat big assumption here: the chrome of the new UI we insert would look like the UI
                 /// WPAuthenticator is already displaying. Which is risky, but also kind of makes sense, considering
                 /// we are also pushing that injected UI to the current navigation controller.
-                customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
+                if WordPressAuthenticator.shared.delegate?.supportActionEnabled == true {
+                    customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
+                }
                 self.navigationController?.pushViewController(customUI, animated: true)
             }
         })

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -480,6 +480,11 @@ private extension SiteAddressViewController {
                 
                 self.showWPUsernamePassword()
             case let .injectViewController(customUI):
+                /// Assign the help button of the newly injected UI to the same hep button we are currently displaying
+                /// We are making a somewhat big assumption here: the chrome of the new UI we insert would look like the UI
+                /// WPAuthenticator is already displaying. Which is risky, but also kind of makes sense, considering
+                /// we are also pushing that injected UI to the current navigation controller.
+                customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
                 self.navigationController?.pushViewController(customUI, animated: true)
             }
         })


### PR DESCRIPTION
Closes #526 
Ref: woocommerce/woocommerce-ios#3225

Not the most modular solution ever, but I tried to break down what is happening in `NUXViewControllerBase` in a way where I could separate the creation of the help button to a separate protocol/protocol extension, so that host apps could implement that new protocol in any custom view controller and get the help button for free, but I couldn't find a way to make it work.

## Changes
* When a host app injects custom UI, assign the help button of the injected view controller in the navigation item, to the help button of the view controller currently on screen.

## How to test