### PR TITLE
Adjust the WordPressUI Dependency definition

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 5.0.2'
-  s.dependency 'WordPressUI', '~> 1.7.0'
+  s.dependency 'WordPressUI', '~> 1.7-beta'
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.


### PR DESCRIPTION
Right now it’ll only accept `1.7.x` versions, and we want to accept anything between 1.x.x and 2.0, including betas.