### PR TITLE
Allow host apps to insert custom UI instead of WP.com account creation flow

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.31.0-beta.2"
+  s.version       = "1.31.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -410,7 +410,12 @@ private extension GetStartedViewController {
 
         /// Hand over control to the host app.
         authenticationDelegate.handleError(error) { customUI in
+            // Setting the rightBarButtonItems of the custom UI before pushing the view controller
+            // and resetting the navigationController's navigationItem after the push seems to be the
+            // only combination that gets the Help button to show up.
             customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
+            self.navigationController?.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
+
             self.navigationController?.pushViewController(customUI, animated: true)
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -410,6 +410,7 @@ private extension GetStartedViewController {
 
         /// Hand over control to the host app.
         authenticationDelegate.handleError(error) { customUI in
+            customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
             self.navigationController?.pushViewController(customUI, animated: true)
         }
     }


### PR DESCRIPTION
Closes #533 
Ref: woocommerce/woocommerce-ios#3146

## Changes
Building up upon the functionality implemented in PR #525 , this PR touches GetStartedViewController, so that:
* When we detect an error after a user attempts log in with an email address, we would ask the host app if it wants to handle this error and intercept the navigation flow
* If the host app wants to handle the error, we would insert the UI that the host app provides. 
* If the host app does not want to handle the error, we continue forward without changes in behaviour.
* Bumped the version in the podspec

## How to test
This PR does not break the public API, but it has the potential to introduce a bug in WordPress. There are two ways I would suggest to test the functionality:
1. Test the corresponding PR in WooCommerce (woocommerce/woocommerce-ios#3286). When users try to log in with a WordPress account and enter an email address that does not match a WP.com account, WooCommerce should insert custom UI. 
2. Test the same flow with WordPress. No behaviour should change and it should still be possible to sign up for a WP.com account. The easiest way to test this is testing the draft PR wordpress-mobile/WordPress-iOS#15435
