### PR TITLE
Allow host apps to remove the link to the WP.com Terms Of Service

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.31.0-beta.3"
+  s.version       = "1.31.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -12,6 +12,10 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///
     var supportActionEnabled: Bool { get }
 
+    /// Indicates if the WordPress.com's Terms of Service should be enabled, or not.
+    ///
+    var wpcomTermsOfServiceEnabled: Bool { get }
+
     /// Indicates if the Support notification indicator should be displayed.
     ///
     var showSupportNotificationIndicator: Bool { get }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -206,7 +206,11 @@ private extension GetStartedViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.instructions, .email, .tos]
+        rows = [.instructions, .email]
+
+        if let authenticationDelegate = WordPressAuthenticator.shared.delegate, authenticationDelegate.wpcomTermsOfServiceEnabled {
+            rows.append(.tos)
+        }
         
         if let errorText = errorMessage, !errorText.isEmpty {
             rows.append(.errorMessage)


### PR DESCRIPTION
Closes: #535 
Ref: woocommerce/woocommerce-ios#3145

This PR introduces a new change to the library's public API.

## Changes
* Added a new method to WPAuthenticatorDelegate to allow host apps to declare if they want to allow a link to WP.com Terms Of Service
* Update `GetStartedViewController` to build the list of rows depending on that value.
* Bump the podspec to 1.31.0-beta.4

## Testing
* CI giving the ✅ 
* This PR in WordPress-iOS implements support for the changes introduced now. It contains testing instructions: wordpress-mobile/WordPress-iOS#15451