### PR TITLE
Allow host apps to customize the background of the login prologue

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -196,6 +196,9 @@ public struct WordPressAuthenticatorUnifiedStyle {
     /// Style: Auth Prologue buttons background color
     public let prologueButtonsBackgroundColor: UIColor
 
+    /// Style: Auth Prologue view background color
+    public let prologueViewBackgroundColor: UIColor
+
     /// Style: Status bar style. Defaults to `default`.
     ///
     public let statusBarStyle: UIStatusBarStyle
@@ -216,6 +219,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
                 textButtonHighlightColor: UIColor,
                 viewControllerBackgroundColor: UIColor,
                 prologueButtonsBackgroundColor: UIColor = .clear,
+                prologueViewBackgroundColor: UIColor? = nil,
                 statusBarStyle: UIStatusBarStyle = .default,
                 navBarBackgroundColor: UIColor,
                 navButtonTextColor: UIColor,
@@ -228,6 +232,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
         self.textButtonHighlightColor = textButtonHighlightColor
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
         self.prologueButtonsBackgroundColor = prologueButtonsBackgroundColor
+        self.prologueViewBackgroundColor = prologueViewBackgroundColor ?? viewControllerBackgroundColor
         self.statusBarStyle = statusBarStyle
         self.navBarBackgroundColor = navBarBackgroundColor
         self.navButtonTextColor = navButtonTextColor

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -266,9 +266,21 @@ class LoginPrologueViewController: LoginViewController {
     
     private func setButtonViewControllerBackground(_ buttonViewController: NUXButtonViewController) {
         // Fallback to setting the button background color to clear so the blur effect blurs the Prologue background color.
-        let backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.prologueButtonsBackgroundColor ?? .clear
-        buttonViewController.backgroundColor = backgroundColor
-        buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
+        let buttonsBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.prologueButtonsBackgroundColor ?? .clear
+        buttonViewController.backgroundColor = buttonsBackgroundColor
+
+        /// If host apps provide a background color for the prologue buttons:
+        /// 1. Hide the blur effect
+        /// 2. Set the background color of the view controller to prologueViewBackgroundColor
+        let prologueViewBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.prologueViewBackgroundColor ?? .clear
+
+        guard prologueViewBackgroundColor == buttonsBackgroundColor else {
+            buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
+            return
+        }
+
+        buttonBlurEffectView.isHidden = true
+        view.backgroundColor = prologueViewBackgroundColor
     }
 
     // MARK: - Actions


### PR DESCRIPTION
Closes #538 
Ref: woocommerce/woocommerce-ios#3319

LoginPrologueViewController sets its background color to `WordPressAuthenticatorUnifiedStyle.unifiedBackgroundColor`. 

For WooCommerce, we would need to be able to set the background color of the area where the action buttons sit extend to be as wide as the screen.

## Changes
* Added a new parameter to WordPressAuthenticatorUnifiedStyle with a value that defaults to `viewControllerBackgroundColor`.
* Add some logic to LoginPrologueViewController to assign this new color and hide the blurred view. I don't love how this is implemented, but I am not sure there is a much better way to do it. 

## How to test
There are no changes to the API, but just in case I submitted a draft PR to WordPress that should prove that nothing breaks: wordpress-mobile/WordPress-iOS#15464 The best way to test this is:
* Checkout the PR in WooCommerce that uses these changes: woocommerce/woocommerce-ios#3320
* Checkout also the PR in WordPress that proves that these changes do not break anything: wordpress-mobile/WordPress-iOS#15464