### PR TITLE
Update prologue site address button title

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.31.0-beta.4"
+  s.version       = "1.31.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -85,7 +85,7 @@ public struct WordPressAuthenticatorConfiguration {
     
     /// Flag for the unified login/signup flows.
     /// If disabled, the "Continue With WordPress" button in the login prologue is shown first.
-    /// If enabled, the "Enter your site Address" button in the login prologue is shown first.
+    /// If enabled, the "Enter your existing site address" button in the login prologue is shown first.
     /// Default value is disabled
     let continueWithSiteAddressFirst: Bool
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -168,7 +168,7 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                         comment: "The button title text for creating a new account."),
             continueWithWPButtonTitle: NSLocalizedString("Continue with WordPress.com",
                                                comment: "Button title. Takes the user to the login by email flow."),
-            enterYourSiteAddressButtonTitle: NSLocalizedString("Enter your site address",
+            enterYourSiteAddressButtonTitle: NSLocalizedString("Enter your existing site address",
                                                                comment: "Button title. Takes the user to the login by site address flow."),
             findSiteButtonTitle: NSLocalizedString("Find your site address",
                                                    comment: "The hint button's title text to help users find their site address."),

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -403,7 +403,7 @@ class LoginPrologueViewController: LoginViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    /// Unified "Enter your site address" prologue button action.
+    /// Unified "Enter your existing site address" prologue button action.
     ///
     private func siteAddressTapped() {
         tracker.track(click: .loginWithSiteAddress)


### PR DESCRIPTION
Fixes #540 

WPiOS testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15481
WCiOS testing PR: https://github.com/woocommerce/woocommerce-ios/pull/3338

This PR updates the prologue button string to "Enter your **existing** site address". Please visit the testing PR(s) to validate the changes.

### Screenshot of bug
<a href="https://user-images.githubusercontent.com/1062444/101955602-bec25380-3bc3-11eb-9f0c-e116c59e5cff.png"><img src="https://user-images.githubusercontent.com/1062444/101955602-bec25380-3bc3-11eb-9f0c-e116c59e5cff.png" width="350" /></a>