### PR TITLE
Display a spacer cell instead of TOS when host apps remove the link to WP.com terms of service.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.31.0-beta.5"
+  s.version       = "1.31.0-beta.6"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		D8610CEC2570A60C00A5DF27 /* NavigationToRootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8610CEB2570A60C00A5DF27 /* NavigationToRootTests.swift */; };
 		D8611A63257622ED00A5DF27 /* NavigateBack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8611A62257622ED00A5DF27 /* NavigateBack.swift */; };
 		D8611A672576236800A5DF27 /* NavigateBackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8611A662576236800A5DF27 /* NavigateBackTests.swift */; };
+		D87F120B2586DA26005675C5 /* SpacerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F12092586DA26005675C5 /* SpacerTableViewCell.swift */; };
+		D87F120C2586DA26005675C5 /* SpacerTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D87F120A2586DA26005675C5 /* SpacerTableViewCell.xib */; };
 		D881A30D256B5A7900FE5605 /* NavigationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A30C256B5A7900FE5605 /* NavigationCommand.swift */; };
 		D881A311256B5B4700FE5605 /* NavigateToEnterSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */; };
 		D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */; };
@@ -375,6 +377,8 @@
 		D8610CEB2570A60C00A5DF27 /* NavigationToRootTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationToRootTests.swift; sourceTree = "<group>"; };
 		D8611A62257622ED00A5DF27 /* NavigateBack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateBack.swift; sourceTree = "<group>"; };
 		D8611A662576236800A5DF27 /* NavigateBackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateBackTests.swift; sourceTree = "<group>"; };
+		D87F12092586DA26005675C5 /* SpacerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacerTableViewCell.swift; sourceTree = "<group>"; };
+		D87F120A2586DA26005675C5 /* SpacerTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SpacerTableViewCell.xib; sourceTree = "<group>"; };
 		D881A30C256B5A7900FE5605 /* NavigationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCommand.swift; sourceTree = "<group>"; };
 		D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterSite.swift; sourceTree = "<group>"; };
 		D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterAccount.swift; sourceTree = "<group>"; };
@@ -876,6 +880,8 @@
 				CE6BCD3724A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib */,
 				98F40AEF24F5E13200A72911 /* TextWithLinkTableViewCell.swift */,
 				98F40AEE24F5E13200A72911 /* TextWithLinkTableViewCell.xib */,
+				D87F12092586DA26005675C5 /* SpacerTableViewCell.swift */,
+				D87F120A2586DA26005675C5 /* SpacerTableViewCell.xib */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -1065,6 +1071,7 @@
 				CE1BBF8D24D48580001D2E3E /* GravatarEmailTableViewCell.xib in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
 				CE6BCD3924A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib in Resources */,
+				D87F120C2586DA26005675C5 /* SpacerTableViewCell.xib in Resources */,
 				CE6BCD2F24A3A235001BCDC5 /* TextLabelTableViewCell.xib in Resources */,
 				98CF18F9248725620047B66C /* GoogleSignupConfirmation.storyboard in Resources */,
 				B5609137208A563800399AE4 /* EmailMagicLink.storyboard in Resources */,
@@ -1262,6 +1269,7 @@
 				98CF18F7248725370047B66C /* GoogleSignupConfirmationViewController.swift in Sources */,
 				BA53D65324DFEA58001F1ABF /* OnePasswordResultsFetcher.swift in Sources */,
 				1A21EE9822832BC300C940C6 /* WordPressComOAuthClientFacade+Swift.swift in Sources */,
+				D87F120B2586DA26005675C5 /* SpacerTableViewCell.swift in Sources */,
 				CEC77C6624854F2E00FB9050 /* SiteAddressViewController.swift in Sources */,
 				CEDE0D952420121D00CB3345 /* UIStoryboard+Helpers.swift in Sources */,
 				B5ED7920207E993E00A8FD8C /* WPAuthenticatorLogging.m in Sources */,

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -206,12 +206,8 @@ private extension GetStartedViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.instructions, .email]
+        rows = [.instructions, .email, .tos]
 
-        if let authenticationDelegate = WordPressAuthenticator.shared.delegate, authenticationDelegate.wpcomTermsOfServiceEnabled {
-            rows.append(.tos)
-        }
-        
         if let errorText = errorMessage, !errorText.isEmpty {
             rows.append(.errorMessage)
         }
@@ -277,6 +273,11 @@ private extension GetStartedViewController {
     /// Configure the link cell.
     ///
     func configureTextWithLink(_ cell: TextWithLinkTableViewCell) {
+        guard let authenticationDelegate = WordPressAuthenticator.shared.delegate, authenticationDelegate.wpcomTermsOfServiceEnabled else {
+            cell.hideButton()
+            return
+        }
+
         cell.configureButton(markedText: WordPressAuthenticator.shared.displayStrings.loginTermsOfService)
         
         cell.actionHandler = { [weak self] in

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -195,7 +195,8 @@ private extension GetStartedViewController {
         let cells = [
             TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
             TextFieldTableViewCell.reuseIdentifier: TextFieldTableViewCell.loadNib(),
-            TextWithLinkTableViewCell.reuseIdentifier: TextWithLinkTableViewCell.loadNib()
+            TextWithLinkTableViewCell.reuseIdentifier: TextWithLinkTableViewCell.loadNib(),
+            SpacerTableViewCell.reuseIdentifier: SpacerTableViewCell.loadNib()
         ]
         
         for (reuseIdentifier, nib) in cells {
@@ -206,7 +207,13 @@ private extension GetStartedViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.instructions, .email, .tos]
+        rows = [.instructions, .email]
+
+        if let authenticationDelegate = WordPressAuthenticator.shared.delegate, authenticationDelegate.wpcomTermsOfServiceEnabled {
+            rows.append(.tos)
+        } else {
+            rows.append(.spacer)
+        }
 
         if let errorText = errorMessage, !errorText.isEmpty {
             rows.append(.errorMessage)
@@ -223,6 +230,8 @@ private extension GetStartedViewController {
             configureEmailField(cell)
         case let cell as TextWithLinkTableViewCell:
             configureTextWithLink(cell)
+        case cell as SpacerTableViewCell:
+            break
         case let cell as TextLabelTableViewCell where row == .errorMessage:
             configureErrorLabel(cell)
         default:
@@ -273,11 +282,6 @@ private extension GetStartedViewController {
     /// Configure the link cell.
     ///
     func configureTextWithLink(_ cell: TextWithLinkTableViewCell) {
-        guard let authenticationDelegate = WordPressAuthenticator.shared.delegate, authenticationDelegate.wpcomTermsOfServiceEnabled else {
-            cell.hideButton()
-            return
-        }
-
         cell.configureButton(markedText: WordPressAuthenticator.shared.displayStrings.loginTermsOfService)
         
         cell.actionHandler = { [weak self] in
@@ -301,6 +305,7 @@ private extension GetStartedViewController {
         case instructions
         case email
         case tos
+        case spacer
         case errorMessage
         
         var reuseIdentifier: String {
@@ -311,6 +316,8 @@ private extension GetStartedViewController {
                 return TextFieldTableViewCell.reuseIdentifier
             case .tos:
                 return TextWithLinkTableViewCell.reuseIdentifier
+            case .spacer:
+                return SpacerTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/SpacerTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/SpacerTableViewCell.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+/// SpacerTableViewCell: an empty cell, used as separator and to introduce padding.
+///
+final class SpacerTableViewCell: UITableViewCell {
+    static let reuseIdentifier = "SpacerTableViewCell"
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/SpacerTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/SpacerTableViewCell.xib
@@ -18,6 +18,9 @@
                 <autoresizingMask key="autoresizingMask"/>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <accessibility key="accessibilityConfiguration">
+                <accessibilityTraits key="traits" notEnabled="YES"/>
+            </accessibility>
             <point key="canvasLocation" x="-83" y="95"/>
         </tableViewCell>
     </objects>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/SpacerTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/SpacerTableViewCell.xib
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="16" id="KGk-i7-Jjw" customClass="SpacerTableViewCell" customModule="WordPressAuthenticator" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="-83" y="95"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
@@ -42,4 +42,8 @@ class TextWithLinkTableViewCell: UITableViewCell {
         button.accessibilityTraits = accessibilityTrait
     }
 
+    func hideButton() {
+        button.isHidden = true
+    }
+
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
@@ -41,9 +41,4 @@ class TextWithLinkTableViewCell: UITableViewCell {
         button.setAttributedTitle(highlightAttributedString, for: .highlighted)
         button.accessibilityTraits = accessibilityTrait
     }
-
-    func hideButton() {
-        button.isHidden = true
-    }
-
 }


### PR DESCRIPTION
Closes #543 
Ref: woocommerce/woocommerce-ios#3309
Ref: woocommerce/woocommerce-ios#3330
PR in WooCommerce: woocommerce/woocommerce-ios#3339

The way I implemented the removal of the TOS was by just removing the cell from the table view. That makes the bottom hairline in the email textfield cell to sit right above the top margin of the Continue button. 

I considered just hiding the TOS button instead of removing the cell completely (you can see that if you look at this very PR history) but in the end I thought a Spacer cell (a completely empty one) might be a better way to handle this.

## Changes
* Add a spacer cell
* Declare a new section in GetStartedViewController to model the spacer
* Check if the host app wants to display TOS or not. If it doesn't, add a spacer.

## How to test
* Look at the code. Does the change make sense?
* Check that the corresponding PRs in WooCommerce and WordPress work as expected.
- WooCommerce: woocommerce/woocommerce-ios#3339
- WordPress: wordpress-mobile/WordPress-iOS#15486