### PR TITLE
Improves Jetpack Connect through Magic Links. 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -14,8 +14,7 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0-beta' # Don't change this until we hit 2.0 in Gridicons
   pod 'WordPressUI', '~> 1.7-beta' # Don't change this until we hit 2.0 in WordPressUI
-  #pod 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
-  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'e1a9734e86bc0eba95dfb9656221ded2401ace58'
+  pod 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
   pod 'WordPressShared', '~> 1.12-beta' # Don't change this until we hit 2.0 in WPShared
 
 

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,8 @@ def wordpress_authenticator_pods
   ##
   pod 'Gridicons', '~> 1.0-beta' # Don't change this until we hit 2.0 in Gridicons
   pod 'WordPressUI', '~> 1.7-beta' # Don't change this until we hit 2.0 in WordPressUI
-  pod 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
+  #pod 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
+  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'e1a9734e86bc0eba95dfb9656221ded2401ace58'
   pod 'WordPressShared', '~> 1.12-beta' # Don't change this until we hit 2.0 in WPShared
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.6.0)
-  - WordPressKit (4.24.0-beta.3):
+  - WordPressKit (4.24.0-beta.4):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -123,7 +123,7 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
-  WordPressKit: f1cf791ace51ca8c4b742225fed1d1458cb20f7d
+  WordPressKit: d084acd74bafd78d70ccb95686ceb927c825324e
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.6.0)
-  - WordPressKit (4.24.0-beta.2):
+  - WordPressKit (4.24.0-beta.3):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -75,7 +75,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `e1a9734e86bc0eba95dfb9656221ded2401ace58`)
+  - WordPressKit (~> 4.18-beta)
   - WordPressShared (~> 1.12-beta)
   - WordPressUI (~> 1.7-beta)
 
@@ -99,19 +99,10 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
-
-EXTERNAL SOURCES:
-  WordPressKit:
-    :commit: e1a9734e86bc0eba95dfb9656221ded2401ace58
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressKit:
-    :commit: e1a9734e86bc0eba95dfb9656221ded2401ace58
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -132,11 +123,11 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
-  WordPressKit: 453787f5a6deeb5bb6fad4ea39801fda5698877b
+  WordPressKit: f1cf791ace51ca8c4b742225fed1d1458cb20f7d
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
-PODFILE CHECKSUM: 0c8776d786aac49c67a884be75e795731aed4459
+PODFILE CHECKSUM: 02377777b693c2e84274e2a24ccfe6c9d5064b3c
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,14 +47,14 @@ PODS:
     - OHHTTPStubs/Default
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
-  - UIDeviceIdentifier (1.5.0)
-  - WordPressKit (4.18.0):
+  - UIDeviceIdentifier (1.6.0)
+  - WordPressKit (4.24.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
-    - UIDeviceIdentifier (~> 1)
+    - UIDeviceIdentifier (~> 1.4)
     - WordPressShared (~> 1.12)
-    - wpxmlrpc (~> 0.9.0)
+    - wpxmlrpc (~> 0.9)
   - WordPressShared (1.12.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
@@ -75,7 +75,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 8.0.0)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - WordPressKit (~> 4.18-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `e1a9734e86bc0eba95dfb9656221ded2401ace58`)
   - WordPressShared (~> 1.12-beta)
   - WordPressUI (~> 1.7-beta)
 
@@ -99,10 +99,19 @@ SPEC REPOS:
     - Specta
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
+
+EXTERNAL SOURCES:
+  WordPressKit:
+    :commit: e1a9734e86bc0eba95dfb9656221ded2401ace58
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: e1a9734e86bc0eba95dfb9656221ded2401ace58
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -122,12 +131,12 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 9cbce6364bec557cc3439aa6bb7514670d780881
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
-  WordPressKit: 1d10fa14ea185600472d31cf25e677c7d938b17d
+  UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
+  WordPressKit: 453787f5a6deeb5bb6fad4ea39801fda5698877b
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
-PODFILE CHECKSUM: 02377777b693c2e84274e2a24ccfe6c9d5064b3c
+PODFILE CHECKSUM: 0c8776d786aac49c67a884be75e795731aed4459
 
 COCOAPODS: 1.10.0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.32.0"
+  s.version       = "1.33.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		D881A311256B5B4700FE5605 /* NavigateToEnterSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */; };
 		D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
+		F11448EC258B827B0048203D /* URL+JetpackConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11448EB258B827B0048203D /* URL+JetpackConnect.swift */; };
 		F12F9FB424D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
 		F180B82424F59263000A01F5 /* StoredCredentialsPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */; };
@@ -383,6 +384,7 @@
 		D881A310256B5B4700FE5605 /* NavigateToEnterSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterSite.swift; sourceTree = "<group>"; };
 		D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterAccount.swift; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
+		F11448EB258B827B0048203D /* URL+JetpackConnect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+JetpackConnect.swift"; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		F180B82324F59263000A01F5 /* StoredCredentialsPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsPicker.swift; sourceTree = "<group>"; };
@@ -690,6 +692,7 @@
 				CEDE0D962420126900CB3345 /* UIViewController+Helpers.swift */,
 				F1C96668250BF53400EB529D /* UIViewController+Dismissal.swift */,
 				CE9091FD249A720E00AB50BD /* UIView+AuthHelpers.swift */,
+				F11448EB258B827B0048203D /* URL+JetpackConnect.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1257,6 +1260,7 @@
 				D85C3653256DEDA900D56E34 /* WordPressAuthenticatorResult.swift in Sources */,
 				F1C96669250BF53400EB529D /* UIViewController+Dismissal.swift in Sources */,
 				CE811D6724EDC0FB00F4CCD6 /* LoginMagicLinkViewController.swift in Sources */,
+				F11448EC258B827B0048203D /* URL+JetpackConnect.swift in Sources */,
 				B56090E2208A4F9D00399AE4 /* WPNUXSecondaryButton.m in Sources */,
 				B56090E6208A4F9D00399AE4 /* WPNUXPrimaryButton.m in Sources */,
 				CE9091F72499549500AB50BD /* TextFieldTableViewCell.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -325,7 +325,7 @@ import AuthenticationServices
 
         let loginFields = retrieveLoginInfoForTokenAuth()
 
-        if url.isJetpackConnect() {
+        if url.isJetpackConnect {
             loginFields.meta.jetpackLogin = true
         }
 

--- a/WordPressAuthenticator/Extensions/URL+JetpackConnect.swift
+++ b/WordPressAuthenticator/Extensions/URL+JetpackConnect.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension URL {
+    public func isJetpackConnect() -> Bool {
+        query?.contains("&source=jetpack") ?? false
+    }
+}

--- a/WordPressAuthenticator/Extensions/URL+JetpackConnect.swift
+++ b/WordPressAuthenticator/Extensions/URL+JetpackConnect.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension URL {
-    public func isJetpackConnect() -> Bool {
+    public var isJetpackConnect: Bool {
         query?.contains("&source=jetpack") ?? false
     }
 }

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -82,17 +82,7 @@ public class LoginFieldsMeta: NSObject {
 
     /// Indicates whether a self-hosted user is attempting to log in to Jetpack
     ///
-    @objc public var jetpackLogin: Bool {
-        return jetpackBlogXMLRPC != nil && jetpackBlogUsername != nil
-    }
-
-    /// Username of the selfhosted site for which we're attempting to perform a Jetpack Connection.
-    ///
-    @objc public var jetpackBlogUsername: String?
-
-    /// XMLRPC of the selfhosted site for which we're attempting to perform a Jetpack Connection.
-    ///
-    @objc public var jetpackBlogXMLRPC: String?
+    @objc public var jetpackLogin = false
 
     /// Indicates whether a user is logging in via the wpcom flow or a self-hosted flow.  Used by the
     /// the LoginFacade in its branching logic.

--- a/WordPressAuthenticator/Services/WordPressComAccountService.swift
+++ b/WordPressAuthenticator/Services/WordPressComAccountService.swift
@@ -45,12 +45,13 @@ class WordPressComAccountService {
 
     /// Requests a WordPress.com Authentication Link to be sent to the specified email address.
     ///
-    func requestAuthenticationLink(for email: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    func requestAuthenticationLink(for email: String, jetpackLogin: Bool, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let remote = AccountServiceRemoteREST(wordPressComRestApi: anonymousAPI)
-
+        
         remote.requestWPComAuthLink(forEmail: email,
                                     clientID: configuration.wpcomClientId,
                                     clientSecret: configuration.wpcomSecret,
+                                    jetpackLogin: jetpackLogin,
                                     wpcomScheme: configuration.wpcomScheme,
                                     success: success,
                                     failure: { error in

--- a/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
@@ -110,6 +110,7 @@ class LoginLinkRequestViewController: LoginViewController {
         configureLoading(true)
         let service = WordPressComAccountService()
         service.requestAuthenticationLink(for: email,
+                                          jetpackLogin: loginFields.meta.jetpackLogin,
                                           success: { [weak self] in
                                             self?.didRequestAuthenticationLink()
                                             self?.configureLoading(false)

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -458,6 +458,7 @@ private extension GetStartedViewController {
         configureViewLoading(true)
         let service = WordPressComAccountService()
         service.requestAuthenticationLink(for: email,
+                                          jetpackLogin: loginFields.meta.jetpackLogin,
                                           success: { [weak self] in
                                             self?.didRequestAuthenticationLink()
                                             self?.configureViewLoading(false)

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -467,6 +467,7 @@ private extension PasswordViewController {
         configureViewLoading(true)
         let service = WordPressComAccountService()
         service.requestAuthenticationLink(for: email,
+                                          jetpackLogin: loginFields.meta.jetpackLogin,
                                           success: { [weak self] in
                                             self?.didRequestAuthenticationLink()
                                             self?.configureViewLoading(false)

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -136,8 +136,7 @@ class WordPressAuthenticatorTests: XCTestCase {
         }), object: .none)
 
         WordPressAuthenticator.showLoginForJustWPCom(from: presenterSpy,
-                                                     xmlrpc: "https://example.com/xmlrpc.php",
-                                                     username: "username",
+                                                     jetpackLogin: false,
                                                      connectedEmail: "email-address@example.com")
 
         let navController = try XCTUnwrap(presenterSpy.presentedVC as? LoginNavigationController)
@@ -146,8 +145,6 @@ class WordPressAuthenticatorTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
 
         XCTAssertEqual(controller.loginFields.restrictToWPCom, true)
-        XCTAssertEqual(controller.loginFields.meta.jetpackBlogXMLRPC, "https://example.com/xmlrpc.php")
-        XCTAssertEqual(controller.loginFields.meta.jetpackBlogUsername, "username")
         XCTAssertEqual(controller.loginFields.username, "email-address@example.com")
     }
 
@@ -205,26 +202,7 @@ class WordPressAuthenticatorTests: XCTestCase {
         let authenticator = WordpressAuthenticatorProvider.getWordpressAuthenticator()
         let url = URL(string: "https://wordpress.com/wp-login.php?token=1234567890%26action&magic-login&sr=1&signature=1234567890oienhdtsra")
 
-        XCTAssertTrue(authenticator.handleWordPressAuthUrl(url!, allowWordPressComAuth: true, rootViewController: UIViewController()))
-    }
-
-    func testOpenAuthenticationFailsWithoutQuery() {
-        let url = URL(string: "https://WordPress.com/")
-
-        let result = WordPressAuthenticator.openAuthenticationURL(url!, allowWordPressComAuth: false, fromRootViewController: UIViewController())
-
-        XCTAssertFalse(result)
-    }
-
-    func testOpenAuthenticationFailsWithoutWpcomAuth() {
-        let url = URL(string: "https://WordPress.com/?token=arstdhneio0987654321")
-        let loginFields = LoginFields()
-        loginFields.username = "user123"
-        loginFields.password = "knockknock"
-
-        let result = WordPressAuthenticator.openAuthenticationURL(url!, allowWordPressComAuth: false, fromRootViewController: UIViewController())
-
-        XCTAssertFalse(result)
+        XCTAssertTrue(authenticator.handleWordPressAuthUrl(url!, rootViewController: UIViewController()))
     }
 
     // MARK: WordPressAuthenticator OnePassword Tests


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15532
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/320

## Description

Improves the support for Jetpack connect so that we don't rely on locally-stored information for logging in using magic links.

Please refer to the WPiOS PR for details about the changes proposed here.

## Testing Details

Please refer to the WPiOS PR for testing instructions.