### PR TITLE
Removes the calls to update SafariCredentials.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.33.0-beta.1"
+  s.version       = "1.33.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
@@ -52,8 +52,4 @@ class NUXLinkAuthViewController: LoginViewController {
     override func configureStatusLabel(_ message: String) {
         statusLabel?.text = message
     }
-
-    override func updateSafariCredentialsIfNeeded() {
-        // Noop
-    }
 }

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -226,13 +226,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
     // MARK: - Instance Methods
 
 
-    /// Noop.  Required by the SigninWPComSyncHandler protocol but the self-hosted
-    /// controller's implementation does not use safari saved credentials.
-    ///
-    override func updateSafariCredentialsIfNeeded() {
-    }
-
-
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action.
     ///

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -206,14 +206,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
 
     // MARK: - Instance Methods
 
-
-    /// Noop.  Required by the SigninWPComSyncHandler protocol but the self-hosted
-    /// controller's implementation does not use safari saved credentials.
-    ///
-    override func updateSafariCredentialsIfNeeded() {
-    }
-
-
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action.
     ///

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -220,12 +220,6 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         
         presentUnified2FA()
     }
-
-    // Update safari stored credentials. Call after a successful sign in.
-    ///
-    func updateSafariCredentialsIfNeeded() {
-        SafariCredentialsService.updateSafariCredentialsIfNeeded(with: loginFields)
-    }
     
     private enum LocalizedText {
         static let loginError = NSLocalizedString("Whoops, something went wrong and we couldn't log you in. Please try again!", comment: "An error message shown when a wpcom user provides the wrong password.")
@@ -261,8 +255,6 @@ extension LoginViewController {
     /// Signals the Main App to synchronize the specified WordPress.com account.
     ///
     private func syncWPCom(credentials: AuthenticatorCredentials, completion: (() -> ())? = nil) {
-        SafariCredentialsService.updateSafariCredentialsIfNeeded(with: loginFields)
-
         configureStatusLabel(LocalizedText.gettingAccountInfo)
 
         authenticationDelegate.sync(credentials: credentials) { [weak self] in

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -150,11 +150,6 @@ final class SiteCredentialsViewController: LoginViewController {
         }
     }
 
-    /// No-op. Required by the SigninWPComSyncHandler protocol but the self-hosted
-    /// controller's implementation does not use safari saved credentials.
-    ///
-    override func updateSafariCredentialsIfNeeded() {}
-
     /// No-op. Required by LoginFacade.
     func displayLoginMessage(_ message: String) {}
 }


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15554

Please refer to the WPiOS PR for details and testing instructions.