### PR TITLE
Implement support for navigating to login with email address for self-hosted sites

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.33.0-beta.2"
+  s.version       = "1.33.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorResult.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorResult.swift
@@ -17,6 +17,11 @@ public enum WordPressAuthenticatorResult {
     ///
     case presentPasswordController(value: Bool)
 
+    /// Present the view controller requesting the email address
+    /// associated to the user's wordpress.com account
+    ///
+    case presentEmailController
+
     /// A view controller to be inserted into the navigation stack
     ///
     case injectViewController(value: UIViewController)

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -235,8 +235,10 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                     self.showSelfHostedUsernamePassword()
                 }
 
-                self.showWPUsernamePassword()
-
+                self.showWPUsernamePassword()                
+            case .presentEmailController:
+                // This case is only used for UL&S
+                break
             case .injectViewController(_):
                 // This case is only used for UL&S
                 break

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -513,6 +513,8 @@ private extension SiteAddressViewController {
                 }
                 
                 self.showWPUsernamePassword()
+            case .presentEmailController:
+                self.showGetStarted()
             case let .injectViewController(customUI):
                 self.pushCustomUI(customUI)
             }


### PR DESCRIPTION
Closes #554 
For context, see woocommerce/woocommerce-ios#3426

## Changes
* Add a new case to `WordPressAuthenticatorResult`. This new case signals that a host app wants to present the view controller that request the user's wp.com email address
* Update SiteAddressViewController to support the new case
* Bump the podspec

## How to test
* There is a draft PR to WordPress-iOS that pull this branch: wordpress-mobile/WordPress-iOS#15580 
* Testing the PR to WooCommerce-iOS that uses this new functionality: woocommerce/woocommerce-ios#3427