### PR TITLE
Bump podspec to 1.33.0-beta.5

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.33.0-beta.3"
+  s.version       = "1.33.0-beta.4"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.33.0-beta.4"
+  s.version       = "1.33.0-beta.5"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
We pushed a [commit](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/commit/f3ec73993dd73757f6b923e1b087bd085bc24eaa) to develop by accident (oops) so it's time to bump the podspec.

The change pushed to develop directly is innocuous so I don't think it's necessary to revert it and go through a formal PR review. We can consider this PR as the 👍  associated to that diff. 😊 

## Changes
* Bumped the podspec version to 1.33.0-beta.4

## How to test
* Check that CI is ✅ 