### PR TITLE
DRY two factor code handling in pasteboard, fix leading zero loss

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		020BE74A23B0BD2E007FE54C /* WordPressAuthenticatorDisplayImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE74923B0BD2E007FE54C /* WordPressAuthenticatorDisplayImages.swift */; };
 		1A21EE9822832BC300C940C6 /* WordPressComOAuthClientFacade+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A21EE9722832BC200C940C6 /* WordPressComOAuthClientFacade+Swift.swift */; };
 		1A4095182271AEFC009AA86D /* WPAuthenticator-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3108613125AFA4830022F75E /* PasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3108613025AFA4830022F75E /* PasteboardTests.swift */; };
 		3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */; };
 		3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */; };
 		3F550D5323DA4AC6007E5897 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5223DA4AC6007E5897 /* URLHandler.swift */; };
@@ -213,6 +214,7 @@
 		1A21EE9722832BC200C940C6 /* WordPressComOAuthClientFacade+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressComOAuthClientFacade+Swift.swift"; sourceTree = "<group>"; };
 		1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPAuthenticator-Swift.h"; sourceTree = "<group>"; };
 		276354F054C34AD36CA32AB6 /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		3108613025AFA4830022F75E /* PasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardTests.swift; sourceTree = "<group>"; };
 		33FEF45B466FF8EAAE5F3923 /* Pods-WordPressAuthenticator.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release.xcconfig"; sourceTree = "<group>"; };
 		37AFD4EF492B00CA7AEC11A3 /* Pods-WordPressAuthenticatorTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelectorTests.swift; sourceTree = "<group>"; };
@@ -535,6 +537,7 @@
 		B501C03D208FC52500D1E58F /* Authenticator */ = {
 			isa = PBXGroup;
 			children = (
+				3108613025AFA4830022F75E /* PasteboardTests.swift */,
 				B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */,
 				CE16177721B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift */,
 				BA53D64724DFDF97001F1ABF /* WordPressSourceTagTests.swift */,
@@ -1362,6 +1365,7 @@
 				BA53D64B24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift in Sources */,
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,
+				3108613125AFA4830022F75E /* PasteboardTests.swift in Sources */,
 				D85C36F0256E118D00D56E34 /* NavigationToEnterAccountTests.swift in Sources */,
 				D85C36E6256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift in Sources */,
 				D85C3882256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift in Sources */,

--- a/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
+++ b/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
@@ -25,4 +25,22 @@ extension UIPasteboard {
             }
         }
     }
+
+    /// Detects whether UIPasteboard.general contains a 2FA code.
+    /// - Parameters:
+    ///   - completion: Called with the 2FA code on success, or failure otherwise
+    @available(iOS 14.0, *)
+    func detectTwoFactorCode(completion: (Result<String, Error>) -> Void) {
+        UIPasteboard.general.detect(patterns: [.number]) { result in
+            switch result {
+                case .success(let detections):
+                    if let twoFactorCode = detections.first?.value as? String {
+                        completion(.success(twoFactorCode))
+                        return
+                    }
+            }
+        }
+
+        completion(.failure());
+    }
 }

--- a/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
+++ b/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
@@ -30,7 +30,7 @@ extension UIPasteboard {
     /// - Parameters:
     ///   - completion: Called with the 2FA code on success, or failure otherwise
     @available(iOS 14.0, *)
-    func detectTwoFactorCode(completion: (Result<String, Error>) -> Void) {
+    func detectTwoFactorCode(completion: @escaping (Result<String, Error>) -> Void) {
         UIPasteboard.general.detect(patterns: [.number]) { result in
             switch result {
                 case .success(let detections):
@@ -38,9 +38,9 @@ extension UIPasteboard {
                         completion(.success(twoFactorCode))
                         return
                     }
+                case .failure(let error):
+                    completion(.failure(error))
             }
         }
-
-        completion(.failure());
     }
 }

--- a/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
+++ b/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
@@ -31,7 +31,7 @@ extension UIPasteboard {
     /// - Parameters:
     ///   - completion: Called with a six digit authentication code on success
     @available(iOS 14.0, *)
-    func detectAuthenticatorCode(completion: @escaping (Result<String, Error>) -> Void) {
+    public func detectAuthenticatorCode(completion: @escaping (Result<String, Error>) -> Void) {
         UIPasteboard.general.detect(patterns: [.number]) { result in
             switch result {
                 case .success(let detections):

--- a/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
+++ b/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
@@ -59,9 +59,9 @@ extension UIPasteboard {
                         return
                     }
 
-                    while authenticationCode.count < 6 {
-                        authenticationCode = "0" + authenticationCode
-                    }
+                    let missingDigits = 6 - authenticationCode.count
+                    let paddingZeros = String(repeating: "0", count: missing)
+                    let paddedAuthenticationCode = paddingZeros + authenticationCode
 
                     completion(.success(authenticationCode))
                     return

--- a/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
+++ b/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
@@ -29,9 +29,9 @@ extension UIPasteboard {
     /// Attempts to detect and return a authenticator code from the pasteboard.
     /// Expects to run on main thread.
     /// - Parameters:
-    ///   - completion: Called with a six digit authentication code on success
+    ///   - completion: Called with a length digit authentication code on success
     @available(iOS 14.0, *)
-    public func detectAuthenticatorCode(completion: @escaping (Result<String, Error>) -> Void) {
+    public func detectAuthenticatorCode(length: Int = 6, completion: @escaping (Result<String, Error>) -> Void) {
         UIPasteboard.general.detect(patterns: [.number]) { result in
             switch result {
                 case .success(let detections):
@@ -44,7 +44,7 @@ extension UIPasteboard {
                         return
                     }
 
-                    var authenticationCode = matchedNumber.stringValue
+                    let authenticationCode = matchedNumber.stringValue
 
                     /// Reject numbers with decimal points or signs in them
                     let codeCharacterSet = CharacterSet(charactersIn: authenticationCode)
@@ -53,17 +53,20 @@ extension UIPasteboard {
                         return
                     }
 
-                    /// We need 6 digits. No more, no less.
-                    if authenticationCode.count > 6 {
+                    /// We need length digits. No more, no less.
+                    if authenticationCode.count > length {
                         completion(.success(""))
+                        return
+                    } else if authenticationCode.count == length {
+                        completion(.success(authenticationCode))
                         return
                     }
 
                     let missingDigits = 6 - authenticationCode.count
-                    let paddingZeros = String(repeating: "0", count: missing)
+                    let paddingZeros = String(repeating: "0", count: missingDigits)
                     let paddedAuthenticationCode = paddingZeros + authenticationCode
 
-                    completion(.success(authenticationCode))
+                    completion(.success(paddedAuthenticationCode))
                     return
                 case .failure(let error):
                     completion(.failure(error))

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -296,14 +296,12 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         }
 
         if #available(iOS 14.0, *) {
-            UIPasteboard.general.detect(patterns: [.number]) { [weak self] result in
+            UIPasteboard.general.detectTwoFactorCode() { [weak self] result in
                 switch result {
-                case .success(let detections):
-                    if let pasteString = detections.first?.value as? String {
-                        self?.handle(code: pasteString)
-                    }
-                case .failure:
-                    break
+                    case .success(let twoFactorCode):
+                        self?.handle(code: twoFactorCode)
+                    case .failure:
+                        break
                 }
             }
         } else {

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -296,10 +296,10 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         }
 
         if #available(iOS 14.0, *) {
-            UIPasteboard.general.detectTwoFactorCode() { [weak self] result in
+            UIPasteboard.general.detectAuthenticatorCode() { [weak self] result in
                 switch result {
-                    case .success(let twoFactorCode):
-                        self?.handle(code: twoFactorCode)
+                    case .success(let authenticatorCode):
+                        self?.handle(code: authenticatorCode)
                     case .failure:
                         break
                 }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -318,10 +318,10 @@ private extension TwoFAViewController {
         }
 
         if #available(iOS 14.0, *) {
-            UIPasteboard.general.detectTwoFactorCode() { [weak self] result in
+            UIPasteboard.general.detectAuthenticatorCode() { [weak self] result in
                 switch result {
-                    case .success(let twoFactorCode):
-                        self?.handle(code: twoFactorCode, textField: codeField)
+                    case .success(let authenticatorCode):
+                        self?.handle(code: authenticatorCode, textField: codeField)
                     case .failure:
                         break
                 }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -318,13 +318,10 @@ private extension TwoFAViewController {
         }
 
         if #available(iOS 14.0, *) {
-            UIPasteboard.general.detect(patterns: [.number]) { [weak self] result in
+            UIPasteboard.general.detectTwoFactorCode() { [weak self] result in
                 switch result {
-                    case .success(let detections):
-                        if let pasteCode = detections.first?.value as? Int {
-                            let pasteString = String(pasteCode)
-                            self?.handle(code: pasteString, textField: codeField)
-                        }
+                    case .success(let twoFactorCode):
+                        self?.handle(code: twoFactorCode, textField: codeField)
                     case .failure:
                         break
                 }

--- a/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
@@ -1,11 +1,3 @@
-//
-//  PasteboardTests.swift
-//  WordPressAuthenticatorTests
-//
-//  Created by Allen Snook on 1/13/21.
-//  Copyright © 2021 Automattic. All rights reserved.
-//
-
 import XCTest
 
 class PasteboardTests: XCTestCase {

--- a/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
@@ -1,0 +1,62 @@
+//
+//  PasteboardTests.swift
+//  WordPressAuthenticatorTests
+//
+//  Created by Allen Snook on 1/13/21.
+//  Copyright © 2021 Automattic. All rights reserved.
+//
+
+import XCTest
+
+class PasteboardTests: XCTestCase {
+    let timeout = TimeInterval(3)
+
+    override class func tearDown() {
+        super.tearDown()
+        let pasteboard = UIPasteboard.general
+        pasteboard.string = ""
+    }
+
+    func testNominalAuthCode() throws {
+        guard #available(iOS 14.0, *) else {
+            throw XCTSkip("Unsupported iOS version")
+        }
+
+        let expect = expectation(description: "Could read nominal auth code from pasteboard")
+        let pasteboard = UIPasteboard.general
+        pasteboard.string = "123456"
+
+        UIPasteboard.general.detectAuthenticatorCode() { result in
+            switch result {
+                case .success(let authenticationCode):
+                    XCTAssertEqual(authenticationCode, "123456")
+                case .failure(_):
+                    XCTAssert(false)
+            }
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testLeadingZeroInAuthCodePreserved() throws {
+        guard #available(iOS 14.0, *) else {
+            throw XCTSkip("Unsupported iOS version")
+        }
+
+        let expect = expectation(description: "Could read leading zero auth code from pasteboard")
+        let pasteboard = UIPasteboard.general
+        pasteboard.string = "012345"
+
+        UIPasteboard.general.detectAuthenticatorCode() { result in
+            switch result {
+                case .success(let authenticationCode):
+                    XCTAssertEqual(authenticationCode, "012345")
+                case .failure(_):
+                    XCTAssert(false)
+            }
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }}


### PR DESCRIPTION
Fixes #557 

To test, e.g. with WooCommerce iOS
- Build
- Ensure all unit tests pass, including the two new tests added for this under PasteboardTests
- Update WooCommerce iOS' Podfile to point at a local clone of this branch
- Build WooCommerce iOS with this pod
- Launch
- Sign in to WordPress.com using an account with 2FA enabled
- At the 2FA code prompt, swipe back to the home screen and open your authenticator app
- Select a 2FA code with a leading zero and tap it to copy it
- Swipe back into the WooCommerce iOS app
- Ensure the 2FA code (all six digits) is automatically pasted for you
- Don't actually complete login. Instead, return to the authenticator app and grab a 2FA code without a leading zero.
- Swipe back into the WooCommerce iOS app
- Ensure the 2FA code (all six digits) is automatically pasted for you
- Lastly, do it again but this time grab the code for your actual login and ensure you can complete login with it.