### PR TITLE
Add a new style parameter for spinner color when NUXButton is disabled

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.33.1-beta.1"
+  s.version       = "1.34.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.33.0"
+  s.version       = "1.33.1-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -39,6 +39,9 @@ public struct WordPressAuthenticatorStyle {
 
     public let disabledTitleColor: UIColor
 
+    /// Color of the spinner that is shown when a button is disabled.
+    public let disabledButtonActivityIndicatorColor: UIColor
+
     /// Style: Text Buttons
     ///
     public let textButtonColor: UIColor
@@ -109,6 +112,7 @@ public struct WordPressAuthenticatorStyle {
                 primaryTitleColor: UIColor,
                 secondaryTitleColor: UIColor,
                 disabledTitleColor: UIColor,
+                disabledButtonActivityIndicatorColor: UIColor,
                 textButtonColor: UIColor,
                 textButtonHighlightColor: UIColor,
                 instructionColor: UIColor,
@@ -139,6 +143,7 @@ public struct WordPressAuthenticatorStyle {
         self.primaryTitleColor = primaryTitleColor
         self.secondaryTitleColor = secondaryTitleColor
         self.disabledTitleColor = disabledTitleColor
+        self.disabledButtonActivityIndicatorColor = disabledButtonActivityIndicatorColor
         self.textButtonColor = textButtonColor
         self.textButtonHighlightColor = textButtonHighlightColor
         self.instructionColor = instructionColor

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -12,7 +12,7 @@ import WordPressKit
     open override var isEnabled: Bool {
         didSet {
             if #available(iOS 13, *) {
-                activityIndicator.color = isEnabled ? style.primaryTitleColor : style.secondaryTitleColor
+                activityIndicator.color = isEnabled ? style.primaryTitleColor : style.disabledTitleColor
             }
         }
     }

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -12,7 +12,7 @@ import WordPressKit
     open override var isEnabled: Bool {
         didSet {
             if #available(iOS 13, *) {
-                activityIndicator.color = isEnabled ? style.primaryTitleColor : style.disabledTitleColor
+                activityIndicator.color = isEnabled ? style.primaryTitleColor : style.disabledButtonActivityIndicatorColor
             }
         }
     }

--- a/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
+++ b/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
@@ -32,6 +32,7 @@ public class WordpressAuthenticatorProvider: NSObject {
                 primaryTitleColor: UIColor.random(),
                 secondaryTitleColor: UIColor.random(),
                 disabledTitleColor: UIColor.random(),
+                disabledButtonActivityIndicatorColor: UIColor.random(),
                 textButtonColor: UIColor.random(),
                 textButtonHighlightColor: UIColor.random(),
                 instructionColor: UIColor.random(),


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/2716 and https://github.com/woocommerce/woocommerce-ios/issues/3386

## Why

In `NUXButton`, the spinner color is set to `style.secondaryTitleColor` when the button is disabled. The same `style.secondaryTitleColor` is also used as the button title color when the button is secondary style and disabled - this usage fits its name "secondaryTitleColor" the most. Because of this parameter reuse and the design in WCiOS, the same color `secondaryTitleColor` results in the spinner color not visible at all in WCiOS ([example screenshot](https://user-images.githubusercontent.com/1945542/104574223-be204f80-5690-11eb-8280-a1ec1304becd.png)).

## Changes

This PR added a new parameter `WordPressAuthenticatorStyle.disabledButtonActivityIndicatorColor` for the spinner color when the button is disabled in `NUXButton`.

## Testing

### WPiOS

Please check out this PR https://github.com/wordpress-mobile/WordPress-iOS/pull/15639 - feel free to merge it later, or just test the changes and add the parameter the next time WPiOS updates the authenticator pod

### WCiOS

Please check out this PR: https://github.com/woocommerce/woocommerce-ios/pull/3472

## Example screenshots

### WPiOS

\ | before | after
-- | -- | --
log in with email | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 17 06 36](https://user-images.githubusercontent.com/1945542/104574088-9cbf6380-5690-11eb-9ece-f45f06c94cd1.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 17 31 07](https://user-images.githubusercontent.com/1945542/104574105-9fba5400-5690-11eb-896a-7acb573cb4d0.png)
log in with site address | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 17 07 07](https://user-images.githubusercontent.com/1945542/104574141-a943bc00-5690-11eb-95f6-ab31e4c2b573.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 17 31 18](https://user-images.githubusercontent.com/1945542/104574147-acd74300-5690-11eb-90ec-781c064ed46b.png)

### WCiOS

\ | before | after
-- | -- | --
log in with email | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 16 50 04](https://user-images.githubusercontent.com/1945542/104574223-be204f80-5690-11eb-8280-a1ec1304becd.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 17 30 06](https://user-images.githubusercontent.com/1945542/104574236-c1b3d680-5690-11eb-9deb-50a250d5b2c4.png)
log in with site address | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 16 51 14](https://user-images.githubusercontent.com/1945542/104574266-c9737b00-5690-11eb-980d-2f09d0675f1c.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2021-01-14 at 17 30 37](https://user-images.githubusercontent.com/1945542/104574286-cc6e6b80-5690-11eb-905a-3febd37615a0.png)

