### PR TITLE
Separate login UI creation to its own function so that the host app can determine how it is displayed

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.34.0-beta.1"
+  s.version       = "1.34.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -174,7 +174,7 @@ import WordPressKit
     public class func loginUI(showCancel: Bool = false, restrictToWPCom: Bool = false, onLoginButtonTapped: (() -> Void)? = nil) -> UIViewController? {
         let storyboard = Storyboard.login.instance
         guard let controller = storyboard.instantiateInitialViewController() else {
-            assertionFailure("Cannot instantiate login root controller from Storyboard")
+            assertionFailure("Cannot instantiate initial login controller from Login.storyboard")
             return nil
         }
         if let childController = controller.children.first as? LoginPrologueViewController {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -156,20 +156,34 @@ import WordPressKit
     ///   - onLoginButtonTapped: Called when the login button on the prologue screen is tapped.
     ///   - onCompletion: Called when the login UI presentation completes.
     public class func showLogin(from presenter: UIViewController, animated: Bool, showCancel: Bool = false, restrictToWPCom: Bool = false, onLoginButtonTapped: (() -> Void)? = nil, onCompletion: (() -> Void)? = nil) {
-        defer {
-            trackOpenedLogin()
+        guard let loginViewController = loginUI(showCancel: showCancel, restrictToWPCom: restrictToWPCom, onLoginButtonTapped: onLoginButtonTapped) else {
+            return
         }
+        presenter.present(loginViewController, animated: animated, completion: onCompletion)
+        trackOpenedLogin()
+    }
 
+    /// Returns the view controller for the login flow.
+    /// The caller is responsible for tracking `.openedLogin` event when displaying the view controller as in `showLogin`.
+    ///
+    /// - Parameters:
+    ///   - showCancel: Whether a cancel CTA is shown on the login prologue screen.
+    ///   - restrictToWPCom: Whether only WordPress.com login is enabled.
+    ///   - onLoginButtonTapped: Called when the login button on the prologue screen is tapped.
+    /// - Returns: The root view controller for the login flow.
+    public class func loginUI(showCancel: Bool = false, restrictToWPCom: Bool = false, onLoginButtonTapped: (() -> Void)? = nil) -> UIViewController? {
         let storyboard = Storyboard.login.instance
-        if let controller = storyboard.instantiateInitialViewController() {
-            if let childController = controller.children.first as? LoginPrologueViewController {
-                childController.loginFields.restrictToWPCom = restrictToWPCom
-                childController.showCancel = showCancel
-                childController.onLoginButtonTapped = onLoginButtonTapped
-            }
-            controller.modalPresentationStyle = .fullScreen
-            presenter.present(controller, animated: animated, completion: onCompletion)
+        guard let controller = storyboard.instantiateInitialViewController() else {
+            assertionFailure("Cannot instantiate login root controller from Storyboard")
+            return nil
         }
+        if let childController = controller.children.first as? LoginPrologueViewController {
+            childController.loginFields.restrictToWPCom = restrictToWPCom
+            childController.showCancel = showCancel
+            childController.onLoginButtonTapped = onLoginButtonTapped
+        }
+        controller.modalPresentationStyle = .fullScreen
+        return controller
     }
 
     /// Used to present the new wpcom-only login flow from the app delegate


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/issues/3107 and https://github.com/woocommerce/woocommerce-ios/issues/3429

## Why

When launching the app in logged out state, we call `WordPressAuthenticator.showLogin` to show the login UI in both WPiOS and WCiOS apps. However, since iOS 14 we started seeing a delay presenting the login UI ([similar WPiOS issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/15399)). From my testing, it seems to be due to loading the view controller from **Login.storyboard** in the **authenticator pod** which is not easy to change. Because the app window's root view controller is the tab bar UI, the uninitialized tab bar UI is shown briefly before the login UI is presented.

In order to solve the glitch in WCiOS, we are setting the login view controller to the app window's root view controller instead of calling `WordPressAuthenticator.showLogin` to present the login UI from a source view controller. Therefore, this PR moved the login UI creation to a separate public function so that the host app can decide how it is displayed (set to the app window's root view controller in WCiOS' case).

## Changes

- Added a function `loginUI` with the same logic from how a login view controller is created and configured from the pre-existing `showLogin`.

## Testing

### WPiOS

Please review/test https://github.com/wordpress-mobile/WordPress-iOS/pull/15682 - I think we can merge it once it's approved so that we can also QA the authenticator change in case of regression

### WCiOS

Please see the testing section in https://github.com/woocommerce/woocommerce-ios/pull/3498