### PR TITLE
Update pod version to 1.34.0-beta.3 per CR feedback.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.34.0-beta.1"
+  s.version       = "1.34.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
To pick up https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/561