### PR TITLE
Bump pod version for PR that missed the latest pod version in `develop`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.34.0-beta.2"
+  s.version       = "1.34.0-beta.3"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
## Why

My bad for forgetting to check the latest pod version on `develop` before merging https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/564 so that it didn't update the pod version. This PR bumped the pod version for the PR to `1.34.0-beta.3`!

## Changes

Bumped the pod version from `1.34.0-beta.2` to `1.34.0-beta.3`.

## Testing

Just CI!
