### PR TITLE
Release 1.34.0 -> develop

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.34.0-beta.3"
+  s.version       = "1.34.0"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC


### PR DESCRIPTION
Release stable 1.34.0 in preparation for code freeze.

Note: Since this pod depends on WPKit, we should ideally merge wordpress-mobile/WordPressKit-iOS#334 first.