### PR TITLE
Update login / signup buttons copy and font

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -166,7 +166,7 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                    comment: "The button title text for opening the user's preferred email app."),
             createAccountButtonTitle: NSLocalizedString("Create Account",
                                                         comment: "The button title text for creating a new account."),
-            continueWithWPButtonTitle: NSLocalizedString("Continue with WordPress.com",
+            continueWithWPButtonTitle: NSLocalizedString("Log in or sign up with WordPress.com",
                                                comment: "Button title. Takes the user to the login by email flow."),
             enterYourSiteAddressButtonTitle: NSLocalizedString("Enter your existing site address",
                                                                comment: "Button title. Takes the user to the login by site address flow."),

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -184,7 +184,8 @@ extension WPStyleGuide {
             return NSAttributedString(attachment: googleAttachment)
         } else {
             // Create an attributed string that contains the Google icon + button text.
-            googleAttachment.bounds = CGRect(x: 0, y: (NUXButton.titleFont.capHeight - Constants.googleIconButtonSize) / 2,
+            let nuxButtonTitleFont = WPStyleGuide.mediumWeightFont(forStyle: .title3)
+            googleAttachment.bounds = CGRect(x: 0, y: (nuxButtonTitleFont.capHeight - Constants.googleIconButtonSize) / 2,
                                              width: Constants.googleIconButtonSize, height: Constants.googleIconButtonSize)
 
             let buttonString = NSMutableAttributedString(attachment: googleAttachment)

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -29,7 +29,7 @@ import WordPressKit
         return indicator
     }()
 
-    static let titleFont = WPStyleGuide.mediumWeightFont(forStyle: .title3)
+    var titleFont = WPStyleGuide.mediumWeightFont(forStyle: .title3)
     
     override open func layoutSubviews() {
         super.layoutSubviews()
@@ -75,6 +75,10 @@ import WordPressKit
 
     func didChangePreferredContentSize() {
         titleLabel?.adjustsFontForContentSizeCategory = true
+    }
+    
+    func customizeFont(_ font: UIFont) {
+        titleFont = font
     }
 
     /// Indicates if the current instance should be rendered with the "Primary" Style.
@@ -158,7 +162,7 @@ import WordPressKit
     /// Setup: TitleLabel
     ///
     private func configureTitleLabel() {
-        titleLabel?.font = NUXButton.titleFont
+        titleLabel?.font = self.titleFont
         titleLabel?.adjustsFontForContentSizeCategory = true
         titleLabel?.textAlignment = .center
     }

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -14,14 +14,16 @@ private struct NUXButtonConfig {
     let attributedTitle: NSAttributedString?
     let socialService: SocialServiceName?
     let isPrimary: Bool
+    let configureBodyFontForTitle: Bool?
     let accessibilityIdentifier: String?
     let callback: CallBackType?
 
-    init(title: String? = nil, attributedTitle: NSAttributedString? = nil, socialService: SocialServiceName? = nil, isPrimary: Bool, accessibilityIdentifier: String? = nil, callback: CallBackType?) {
+    init(title: String? = nil, attributedTitle: NSAttributedString? = nil, socialService: SocialServiceName? = nil, isPrimary: Bool, configureBodyFontForTitle: Bool? = nil, accessibilityIdentifier: String? = nil, callback: CallBackType?) {
         self.title = title
         self.attributedTitle = attributedTitle
         self.socialService = socialService
         self.isPrimary = isPrimary
+        self.configureBodyFontForTitle = configureBodyFontForTitle
         self.accessibilityIdentifier = accessibilityIdentifier
         self.callback = callback
     }
@@ -79,6 +81,10 @@ open class NUXButtonViewController: UIViewController {
 
             button.accessibilityIdentifier = buttonConfig.accessibilityIdentifier ?? accessibilityIdentifier(for: buttonConfig.title)
             button.isPrimary = buttonConfig.isPrimary
+            if buttonConfig.configureBodyFontForTitle == true {
+                button.customizeFont(WPStyleGuide.mediumWeightFont(forStyle: .body))
+            }
+
             button.isHidden = false
         } else {
             button?.isHidden = true
@@ -107,16 +113,16 @@ open class NUXButtonViewController: UIViewController {
         }
     }
 
-    func setupTopButton(title: String, isPrimary: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {
-        topButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
+    func setupTopButton(title: String, isPrimary: Bool = false, configureBodyFontForTitle: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {
+        topButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, configureBodyFontForTitle: configureBodyFontForTitle, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
     }
 
     func setupTopButtonFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) {
         topButtonConfig = buttonConfigFor(socialService: socialService, onTap: callback)
     }
     
-    func setupBottomButton(title: String, isPrimary: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {
-        bottomButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
+    func setupBottomButton(title: String, isPrimary: Bool = false, configureBodyFontForTitle: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {
+        bottomButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, configureBodyFontForTitle: configureBodyFontForTitle, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
     }
 
     func setupButtomButtonFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) {
@@ -135,7 +141,7 @@ open class NUXButtonViewController: UIViewController {
     func hideShadowView() {
         shadowView?.isHidden = true
     }
-    
+
     // MARK: - Helpers
 
     private func buttonConfigFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) -> NUXButtonConfig {

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -49,7 +49,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
             return
         }
         
-        let wordpressTitle = NSLocalizedString("Continue with WordPress.com", comment: "Button title. Tapping begins our normal log in process.")
+        let wordpressTitle = NSLocalizedString("Log in or sign up with WordPress.com", comment: "Button title. Tapping begins our normal log in process.")
         buttonViewController.setupTopButton(title: wordpressTitle, isPrimary: false, accessibilityIdentifier: "Log in with Email Button") { [weak self] in
             
             guard let self = self else {
@@ -60,7 +60,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
             self.dismiss(animated: true)
             self.emailTapped?()
         }
-        
+
         buttonViewController.setupButtomButtonFor(socialService: .google, onTap: handleGoogleButtonTapped)
 
         if !LoginFields().restrictToWPCom && selfHostedTapped != nil {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -211,10 +211,10 @@ class LoginPrologueViewController: LoginViewController {
 
         setButtonViewMargins(forWidth: view.frame.width)
 
-        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button", onTap: loginTapCallback())
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, configureBodyFontForTitle: true, accessibilityIdentifier: "Prologue Continue Button", onTap: loginTapCallback())
 
         if configuration.enableUnifiedAuth {
-            buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, accessibilityIdentifier: "Prologue Self Hosted Button", onTap: siteAddressTapCallback()) 
+            buttonViewController.setupBottomButton(title: siteAddressTitle, isPrimary: false, configureBodyFontForTitle: true, accessibilityIdentifier: "Prologue Self Hosted Button", onTap: siteAddressTapCallback())
         }
 
         showCancelIfNeccessary(buttonViewController)


### PR DESCRIPTION
WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/15703
This PR updates the copy on the login / signup button from "Welcome to WordPress.com" to "Log in or sign up with WordPress.com"

Since the title is more lengthy, this PR also updates the title label font of both buttons from `title3` to `body` per design

![Simulator Screen Shot - iPhone 12 Pro - 2021-02-01 at 19 44 51](https://user-images.githubusercontent.com/1335657/106550289-b56cad80-64c7-11eb-83ee-771f964b6892.png)

To Test:
1. Update the WordPressAuthenticator path in WPiOS to this branch
2. Be signed out 
3. See copy as described 
4. See font is body as described 
5. Continue to next screen and see button title fonts are unchanged (title3)
 