### PR TITLE
Shorter sign up - remove Send Link by email screen

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.35.0"
+  s.version       = "1.35.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -17,6 +17,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let openMailSignupInstructions: String
     public let openMailLoginInstructions: String
     public let checkSpamInstructions: String
+    public let oopsInstructions: String
     public let googleSignupInstructions: String
     public let googlePasswordInstructions: String
     public let applePasswordInstructions: String
@@ -67,6 +68,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 openMailSignupInstructions: String = defaultStrings.openMailSignupInstructions,
                 openMailLoginInstructions: String = defaultStrings.openMailLoginInstructions,
                 checkSpamInstructions: String = defaultStrings.checkSpamInstructions,
+                oopsInstructions: String = defaultStrings.oopsInstructions,
                 googleSignupInstructions: String = defaultStrings.googleSignupInstructions,
                 googlePasswordInstructions: String = defaultStrings.googlePasswordInstructions,
                 applePasswordInstructions: String = defaultStrings.applePasswordInstructions,
@@ -102,6 +104,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.openMailSignupInstructions = openMailSignupInstructions
         self.openMailLoginInstructions = openMailLoginInstructions
         self.checkSpamInstructions = checkSpamInstructions
+        self.oopsInstructions = oopsInstructions
         self.googleSignupInstructions = googleSignupInstructions
         self.googlePasswordInstructions = googlePasswordInstructions
         self.applePasswordInstructions = applePasswordInstructions
@@ -153,6 +156,7 @@ public extension WordPressAuthenticatorDisplayStrings {
             openMailLoginInstructions: NSLocalizedString("Check your email on this device, and tap the link in the email you receive from WordPress.com.",
                                                          comment: "Instruction text after a login Magic Link was requested."),
             checkSpamInstructions: NSLocalizedString("Not seeing the email? Check your Spam or Junk Mail folder.", comment: "Instructions after a Magic Link was sent, but the email can't be found in their inbox."),
+            oopsInstructions: NSLocalizedString("Didn't mean to create a new account? Go back to re-enter your email address.", comment: "Instructions after a Magic Link was sent, but email is incorrect."),
             googleSignupInstructions: NSLocalizedString("We'll use this email address to create your new WordPress.com account.", comment: "Text confirming email address to be used for new account."),
             googlePasswordInstructions: NSLocalizedString("To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once.",
                                                           comment: "Instructional text shown when requesting the user's password for Google login."),

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -401,7 +401,7 @@ private extension GetStartedViewController {
         let errorCode = userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
 
         if errorCode == "unknown_user" {
-            self.showSignupViewIfNecessary(error)
+            self.sendEmail()
         } else if errorCode == "email_login_not_allowed" {
                 // If we get this error, we know we have a WordPress.com user but their
                 // email address is flagged as suspicious.  They need to login via their
@@ -411,36 +411,45 @@ private extension GetStartedViewController {
             self.displayError(error as NSError, sourceTag: self.sourceTag)
         }
     }
-
-    /// Offer host apps the opportunity to decide if they want to allow signups
-    ///
-    func showSignupViewIfNecessary(_ error: Error) {
-        guard let authenticationDelegate = WordPressAuthenticator.shared.delegate, authenticationDelegate.shouldHandleError(error) else {
-            showSignupView()
-            return
-        }
-
-        /// Hand over control to the host app.
-        authenticationDelegate.handleError(error) { customUI in
-            // Setting the rightBarButtonItems of the custom UI before pushing the view controller
-            // and resetting the navigationController's navigationItem after the push seems to be the
-            // only combination that gets the Help button to show up.
-            customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
-            self.navigationController?.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
-
-            self.navigationController?.pushViewController(customUI, animated: true)
-        }
-    }
     
-    /// Show the Sign Up view.
+    // MARK: - Send email
+
+    /// Makes the call to request a magic signup link be emailed to the user.
     ///
-    func showSignupView() {
-        guard let vc = UnifiedSignupViewController.instantiate(from: .unifiedSignup) else {
-            DDLogError("Failed to navigate to UnifiedSignupViewController from GetStartedViewController")
+    private func sendEmail() {
+        tracker.set(flow: .signup)
+        loginFields.meta.emailMagicLinkSource = .signup
+
+        configureSubmitButton(animating: true)
+
+        let service = WordPressComAccountService()
+        service.requestSignupLink(for: loginFields.username,
+                                  success: { [weak self] in
+                                    self?.didRequestSignupLink()
+                                    self?.configureSubmitButton(animating: false)
+
+            }, failure: { [weak self] (error: Error) in
+                DDLogError("Request for signup link email failed.")
+                
+                guard let self = self else {
+                    return
+                }
+                
+                self.tracker.track(failure: error.localizedDescription)
+                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                self.configureSubmitButton(animating: false)
+        })
+    }
+
+    private func didRequestSignupLink() {
+        guard let vc = SignupMagicLinkViewController.instantiate(from: .unifiedSignup) else {
+            DDLogError("Failed to navigate from UnifiedSignupViewController to SignupMagicLinkViewController")
             return
         }
-        
+
         vc.loginFields = loginFields
+        vc.loginFields.restrictToWPCom = true
+
         navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
@@ -132,7 +132,7 @@ private extension SignupMagicLinkViewController {
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
-        rows = [.persona, .instructions, .checkSpam]
+        rows = [.persona, .instructions, .checkSpam, .oops]
     }
 
     /// Configure cells.
@@ -145,6 +145,8 @@ private extension SignupMagicLinkViewController {
             configureInstructionLabel(cell)
         case let cell as TextLabelTableViewCell where row == .checkSpam:
             configureCheckSpamLabel(cell)
+        case let cell as TextLabelTableViewCell where row == .oops:
+            configureoopsLabel(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -167,6 +169,12 @@ private extension SignupMagicLinkViewController {
     func configureCheckSpamLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.checkSpamInstructions, style: .body)
     }
+    
+    /// Configure the "Check spam" cell.
+    ///
+    func configureoopsLabel(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.oopsInstructions, style: .body)
+    }
 
     // MARK: - Private Constants
 
@@ -176,12 +184,13 @@ private extension SignupMagicLinkViewController {
         case persona
         case instructions
         case checkSpam
+        case oops
 
         var reuseIdentifier: String {
             switch self {
             case .persona:
                 return GravatarEmailTableViewCell.reuseIdentifier
-            case .instructions, .checkSpam:
+            case .instructions, .checkSpam, .oops:
                 return TextLabelTableViewCell.reuseIdentifier
             }
         }


### PR DESCRIPTION
After talking this over with design (@mattmiklic ) we decided to remove this screen:
<img src="https://user-images.githubusercontent.com/1335657/106846256-6c506100-6661-11eb-8412-1800da561a0c.png" width="270" alt="Simulator Screen Shot - iPhone 12 Pro - 2021-02-02 at 13 00 39">

Instead, we will be sending the email immediately after the user entered their email : 

https://user-images.githubusercontent.com/1335657/106846364-96098800-6661-11eb-812e-c80a3ae1cdc2.MP4

To test:
1. copy this branch to pod file in WPiOS 
2.  pod install
3. Test login and signup work as expected with no issues
4. Check tracking is as expected 