### PR TITLE
Stop tracking prologue step based on view presentation

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.35.1"
+  s.version       = "1.35.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -97,9 +97,10 @@ class LoginPrologueViewController: LoginViewController {
         WordPressAuthenticator.track(.loginPrologueViewed)
 
         tracker.set(flow: .prologue)
-        
-        if isBeingPresentedInAnyWay {
+
+        if !prologueFlowTracked {
             tracker.track(step: .prologue)
+            prologueFlowTracked = true
         } else {
             tracker.set(step: .prologue)
         }


### PR DESCRIPTION
This PR fixes an issue introduced when WordPress for iOS switched to displaying the authenticator as the window's root view controller instead of modally. That change meant that the previous check for `isBeingPresentedInAnyWay` always returned false, so we didn't track the prologue step.

This PR reverts to the previous method of tracking whether this is the first time the view controller has appeared, using a simple property.

Please test using the associated WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15967