### PR TITLE
Changes reads to blogs

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.35.2"
+  s.version       = "1.36.0-beta.1"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
@@ -58,7 +58,7 @@ class LoginProloguePromoViewController: UIViewController {
             case .analytics:
                 return NSLocalizedString("Watch your audience grow with in-depth analytics.", comment: "Shown in the prologue carousel (promotional screens) during first launch.")
             case .discover:
-                return NSLocalizedString("Follow your favorite sites and discover new reads.", comment: "Shown in the prologue carousel (promotional screens) during first launch.")
+                return NSLocalizedString("Follow your favorite sites and discover new blogs.", comment: "Shown in the prologue carousel (promotional screens) during first launch.")
             }
         }
 


### PR DESCRIPTION
Related: https://github.com/wordpress-mobile/WordPress-iOS/pull/15999
Part of: https://github.com/wordpress-mobile/WordPress-iOS/issues/15807

### To test:
This feature is off by default and this string appears to not be used in the app as its overriden by 
[`UnifiedProloguePageType.swift`](https://github.com/wordpress-mobile/WordPress-iOS/pull/15999/files#diff-36f0ba12acfb2178808ce2fb0c35cbfdda6af231f20954a51ebea8db59f9a92a)