### PR TITLE
Push the podspec to our internal spec repo in addition to trunk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@dev:pod-repo-push
+  ios: wordpress-mobile/ios@1.0
 
 # YAML anchors for some common/repeated values
 x-common-params:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,22 @@ orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
   ios: wordpress-mobile/ios@dev:pod-repo-push
 
+# YAML anchors for some common/repeated values
+x-common-params:
+  - &xcode-version "12.2.0"
+  - &podspec "WordPressAuthenticator.podspec"
+  - &on-tags-only
+      tags:
+        only: /.*/
+      branches:
+        ignore: /.*/
+
 workflows:
   test_and_validate:
     jobs:
       - ios/test:
           name: Test
-          xcode-version: "12.2.0"
+          xcode-version: *xcode-version
           workspace: WordPressAuthenticator.xcworkspace
           scheme: WordPressAuthenticator
           device: iPhone 11
@@ -18,27 +28,21 @@ workflows:
           pod-install: true
       - ios/validate-podspec:
           name: Validate Podspec
-          xcode-version: "12.2.0"
-          podspec-path: WordPressAuthenticator.podspec
+          xcode-version: *xcode-version
+          podspec-path: *podspec
           bundle-install: true
       - ios/publish-podspec:
           name: Publish to a8c Spec Repo
-          xcode-version: "12.2.0"
-          podspec-path: WordPressAuthenticator.podspec
+          xcode-version: *xcode-version
+          podspec-path: *podspec
           spec-repo: https://github.com/wordpress-mobile/cocoapods-specs.git
           bundle-install: true
           post-to-slack: false
-          filters:
-            branches:
-              only: /test-spec-repo/
+          filters: *on-tags-only
       - ios/publish-podspec:
           name: Publish to Trunk
-          xcode-version: "12.2.0"
-          podspec-path: WordPressAuthenticator.podspec
+          xcode-version: *xcode-version
+          podspec-path: *podspec
           bundle-install: true
           post-to-slack: true
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+          filters: *on-tags-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0 
+  ios: wordpress-mobile/ios@dev:pod-repo-push
 
 workflows:
   test_and_validate:
@@ -21,6 +21,16 @@ workflows:
           xcode-version: "12.2.0"
           podspec-path: WordPressAuthenticator.podspec
           bundle-install: true
+      - ios/publish-podspec:
+          name: Publish to a8c Spec Repo
+          xcode-version: "12.2.0"
+          podspec-path: WordPressAuthenticator.podspec
+          spec-repo: https://github.com/wordpress-mobile/cocoapods-specs.git
+          bundle-install: true
+          post-to-slack: false
+          filters:
+            branches:
+              only: /test-spec-repo/
       - ios/publish-podspec:
           name: Publish to Trunk
           xcode-version: "12.2.0"


### PR DESCRIPTION
My HACK week project was about mirroring our internal pods to our new internal spec repo (to allow us to avoid waiting for the CDN sync).

This PR updates this pod's CircleCI config so that it we now push the podspec to the internal spec repo – in addition to still pushing it to trunk.

⚠️  This will first require us to merge wordpress-mobile/circleci-orbs#69 and make a new release of our orb before we can merge this. Please don't merge this PR before wordpress-mobile/circleci-orbs#69, but apart from this, this PR is ready for review.