### PR TITLE
Fix the prologue buttons background color when using a dynamic color

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.36.0-beta.1"
+  s.version       = "1.36.0-beta.2"
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -275,7 +275,7 @@ class LoginPrologueViewController: LoginViewController {
         /// 2. Set the background color of the view controller to prologueViewBackgroundColor
         let prologueViewBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.prologueViewBackgroundColor ?? .clear
 
-        guard prologueViewBackgroundColor == buttonsBackgroundColor else {
+        guard prologueViewBackgroundColor.cgColor == buttonsBackgroundColor.cgColor else {
             buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
             return
         }


### PR DESCRIPTION
Part of: https://github.com/woocommerce/woocommerce-ios/issues/3824

## Description

In LoginPrologueViewController, we have the option to provide a background color for the prologue buttons and have that background color extend the full width of the screen (when `buttonsBackgroundColor` and `prologueViewBackgroundColor` are the same color).

However, setting that background color to a dynamic color breaks the behavior in the same way as in the original issue https://github.com/woocommerce/woocommerce-ios/issues/3319.

## Changes

In https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/539, the fix for https://github.com/woocommerce/woocommerce-ios/issues/3319 includes a check to compare `prologueViewBackgroundColor` and `buttonsBackgroundColor`, to determine if the blur effect should be applied or if the view's background color should be set.

However, that compares the UIColor objects, which may be different even if their color values are the same. This PR compares the CGColor value instead, to ensure we're doing a valid comparison of the color data.

/|Before|After
-|-|-
Light|![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-03-18 at 17 30 45](https://user-images.githubusercontent.com/8658164/111670805-26fe8200-8810-11eb-83ab-80586ba8f0ec.png)|![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-03-18 at 17 40 31](https://user-images.githubusercontent.com/8658164/111671648-113d8c80-8811-11eb-8d74-06d4fe64c163.png)
Dark|![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-03-18 at 16 05 27](https://user-images.githubusercontent.com/8658164/111658523-53ac9c80-8804-11eb-9fbf-ca9468233a89.png)|![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-03-18 at 16 03 24](https://user-images.githubusercontent.com/8658164/111658537-55766000-8804-11eb-9136-003f80796d42.png)


## Testing

Build and run the app from the branch in WooCommerce that uses these changes, to confirm the background looks as expected in light and dark mode: https://github.com/woocommerce/woocommerce-ios/tree/issue/3824-prologue-carousel
