### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                     Plus: WordPress.com *signup* is supported.
                     DESC
 
-  s.homepage      = "http://apps.wordpress.com"
+  s.homepage      = "https://apps.wordpress.com"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
   s.author        = { "Automattic" => "mobile@automattic.com" }
   s.social_media_url = "https://twitter.com/automattic"

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressAuthenticator-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
+  s.author        = { "The WordPress Mobile Team" => "mobile@wordpress.org" }
 
   s.platform      = :ios, "11.0"
   s.swift_version = '4.2'

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -12,8 +12,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressAuthenticator-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = { "Automattic" => "mobile@automattic.com" }
-  s.social_media_url = "https://twitter.com/automattic"
+  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
 
   s.platform      = :ios, "11.0"
   s.swift_version = '4.2'

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,20 +1,23 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
   s.version       = "1.36.0-beta.2"
-  s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
 
+  s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC
                     This framework encapsulates everything required to display the Authentication UI
                     and perform authentication against WordPress.com and WordPress.org sites.
 
-                    Plus: WordPress.com *signup*  is supported.
+                    Plus: WordPress.com *signup* is supported.
                     DESC
 
-  s.homepage      = "https://github.com/wordpress-mobile/WordPressAuthenticator-iOS"
-  s.license       = "GPLv2"
-  s.author        = { "WordPress" => "mobile@automattic.com" }
+  s.homepage      = "http://apps.wordpress.com"
+  s.license       = { :type => "GPLv2", :file => "LICENSE" }
+  s.author        = { "Automattic" => "mobile@automattic.com" }
+  s.social_media_url = "http://twitter.com/WordPressiOS"
+
   s.platform      = :ios, "11.0"
   s.swift_version = '4.2'
+
   s.source        = { :git => "https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git", :tag => s.version.to_s }
   s.source_files  = 'WordPressAuthenticator/**/*.{h,m,swift}'
   s.private_header_files = "WordPressAuthenticator/Private/*.h"
@@ -26,7 +29,6 @@ Pod::Spec.new do |s|
       'WordPressAuthenticator/**/*.{storyboard,xib}'
     ]
   }
-  s.requires_arc  = true
   s.static_framework = true # This is needed because GoogleSignIn vendors a static framework
   s.header_dir    = 'WordPressAuthenticator'
 
@@ -36,7 +38,6 @@ Pod::Spec.new do |s|
   s.dependency 'lottie-ios', '~> 3.1.6'
   s.dependency 'NSURL+IDN', '0.4'
   s.dependency 'SVProgressHUD', '~> 2.2.5'
-
   s.dependency 'Gridicons', '~> 1.0'
   s.dependency 'GoogleSignIn', '~> 5.0.2'
 
@@ -49,5 +50,4 @@ Pod::Spec.new do |s|
   # Fixing arm64 issue with Xcode 12: https://github.com/CocoaPods/CocoaPods/issues/10104
   s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                     Plus: WordPress.com *signup* is supported.
                     DESC
 
-  s.homepage      = "https://apps.wordpress.com"
+  s.homepage      = "https://github.com/wordpress-mobile/WordPressAuthenticator-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
   s.author        = { "Automattic" => "mobile@automattic.com" }
   s.social_media_url = "https://twitter.com/automattic"

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.homepage      = "http://apps.wordpress.com"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
   s.author        = { "Automattic" => "mobile@automattic.com" }
-  s.social_media_url = "http://twitter.com/WordPressiOS"
+  s.social_media_url = "https://twitter.com/automattic"
 
   s.platform      = :ios, "11.0"
   s.swift_version = '4.2'

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                     and perform authentication against WordPress.com and WordPress.org sites.
 
                     Plus: WordPress.com *signup* is supported.
-                    DESC
+                  DESC
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressAuthenticator-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -32,6 +32,10 @@ Pod::Spec.new do |s|
   s.static_framework = true # This is needed because GoogleSignIn vendors a static framework
   s.header_dir    = 'WordPressAuthenticator'
 
+  # Fixing arm64 issue with Xcode 12: https://github.com/CocoaPods/CocoaPods/issues/10104
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }  
+
   s.dependency '1PasswordExtension', '~> 1.8.6'
   s.dependency 'Alamofire', '~> 4.8'
   s.dependency 'CocoaLumberjack', '~> 3.5'
@@ -46,8 +50,4 @@ Pod::Spec.new do |s|
   s.dependency 'WordPressUI', '~> 1.7-beta'
   s.dependency 'WordPressKit', '~> 4.18-beta' # Don't change this until we hit 5.0 in WPKit
   s.dependency 'WordPressShared', '~> 1.12-beta' # Don't change this until we hit 2.0 in WPShared
-
-  # Fixing arm64 issue with Xcode 12: https://github.com/CocoaPods/CocoaPods/issues/10104
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

## Format / Rules

This are the rules/format we'll try to use for all our podspecs (PRs pending for others)

* Update the values. This is debatable
  * Set the `homepage` ~to `http://apps.wordpress.com`~ to the GitHub repo's url
  * Use `:type` and `:file` keys for license to also provide a link to the full license text. Add `LICENSE` file if it doesn't yet exists.
  * Use `Automattic` as the sole author's name for consistency with all the pods
  * Set the `social_media_url` to the ~WordPressiOS~ Automattic twitter account
  * Remove the `requires_arc = true` key since this is the default since a long while now and is obsolete.
* Group the keys like the following, each section separated by a blank line for readability:
  1. Start with `name` and `version` of the pod at the very top
  2. Next is `summary` and `description`
  3. Next are metadata about the pod: `homepage`, `license`, `author` and `social_media_url`
  4. Then are compatibility version restrictions info: `platform` and `swift_version`
  5. Then are all the keys about the pod's source and how to compile it (`source`, `source_files`, and any key related to instructions for CocoaPods on how to build and assemble the pod)
  6. Finally are the list of `dependency` entries.

## How to Review

I will use this `WordPressAuthenticator` PR to collect feedback on the format standardization, but I will open draft PRs on a couple of our other pods to show how the application of those consistency/standard affect them, so feel free to look at those drafts too, to compare the effect those rules will have on them.

* https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/291
* https://github.com/wordpress-mobile/WordPressKit-iOS/pull/376
* https://github.com/wordpress-mobile/WordPressUI-iOS/pull/84
* https://github.com/wordpress-mobile/wpxmlrpc/pull/56

_Once this PR is approved and we agree on the common values and structure, I'll apply any feedback to the other PRs and un-draft them all._

## How to test

* Mainly check the PR diff for the new copies and content of metadata fields.
* To ensure there are no syntax errors after those changes, you can run `pod lib lint *.podspec` from the repo's root.