### PR TITLE
Site address login: correctly remove `wp-admin` from the url string

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.36.0-beta.2"
+  s.version       = "1.36.0-beta.3"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -3,21 +3,21 @@ import Foundation
 /// Implements the analytics tracking logic for our sign in flow.
 ///
 public class AuthenticatorAnalyticsTracker {
-    
+
     private static let defaultSource: Source = .default
     private static let defaultFlow: Flow = .prologue
     private static let defaultStep: Step = .prologue
-    
+
     /// The method used for analytics tracking.  Useful for overriding in automated tests.
     ///
-    typealias TrackerMethod = (_ event: AnalyticsEvent) -> ()
+    typealias TrackerMethod = (_ event: AnalyticsEvent) -> Void
 
     public enum EventType: String {
         case step = "unified_login_step"
         case interaction = "unified_login_interaction"
         case failure = "unified_login_failure"
     }
-    
+
     public enum Property: String {
         case failure
         case flow
@@ -25,240 +25,240 @@ public class AuthenticatorAnalyticsTracker {
         case source
         case step
     }
-    
+
     public enum Source: String {
         /// Starts when the user logs in / sign up from the prologue screen
         ///
         case `default`
-        
+
         case jetpack
         case share
         case deeplink
         case reauthentication
-        
+
         /// Starts when the used adds a site from the site picker
         ///
         case selfHosted = "self_hosted"
     }
-    
+
     public enum Flow: String {
         /// The initial flow before we decide whether the user is logging in or signing up
         ///
         case wpCom = "wordpress_com"
-        
+
         /// Flow for Google login
         ///
         case loginWithGoogle = "google_login"
-        
+
         /// Flow for Google  signup
         ///
         case signupWithGoogle = "google_signup"
-        
+
         /// Flow for Apple login
         ///
         case loginWithApple = "siwa_login"
-        
+
         /// Flow for Apple signup
         ///
         case signupWithApple = "siwa_signup"
-        
+
         /// Flow for iCloud Keychain login
         ///
         case loginWithiCloudKeychain = "icloud_keychain_login"
-        
+
         /// The flow that starts when we offer the user the magic link login
         ///
         case loginWithMagicLink = "login_magic_link"
-        
+
         /// This flow starts when the user decides to login with a password instead
         ///
         case loginWithPassword = "login_password"
-        
+
         /// This flow starts when the user decides to log in with their site address
         ///
         case loginWithSiteAddress = "login_site_address"
-        
+
         /// This flow represents the signup (when the user inputs an email that’s not registered with a .com account)
         ///
         case signup
-        
+
         /// This flow represents the prologue screen.
         ///
         case prologue
     }
-    
+
     public enum Step: String {
         /// Gets shown on the Prologue screen
         ///
         case prologue
-        
+
         /// Triggered when a flow is started
         ///
         case start
-        
+
         /// Triggered when a user requests a magic link and sees the screen with the “Open mail” button
         ///
         case magicLinkRequested = "magic_link_requested"
-        
+
         /// This represents the user opening their mail. It’s not strictly speaking an in-app screen but for the user it is part of the flow.
         case emailOpened = "email_opened"
-        
+
         /// The screen with a username and password visible
         ///
         case usernamePassword = "username_password"
-        
+
         /// The screen that requests the password
         ///
         case passwordChallenge = "password_challenge"
-        
+
         /// Triggered on the epilogue screen
         ///
         case success
-        
+
         /// Triggered on the help screen
         ///
         case help
-        
+
         /// When we ask user to input the code from the 2 factor authentication
         case twoFactorAuthentication = "2fa"
     }
-    
+
     public enum ClickTarget: String {
         /// Tracked when submitting the email form, the email & password form, site address form,
         /// username & password form and signup email form
         ///
         case submit
-        
+
         /// Tracked when the user clicks on continue in the login/signup epilogue
         ///
         case `continue`
-        
+
         /// Tracked when the post signup interstitial screen is dismissed, when the
         /// login signup help dialog is dismissed and when the email hint dialog is dismissed
         ///
         case dismiss
-        
+
         /// Tracked when the user clicks “Continue with WordPress.com” on the Prologue screen
         ///
         case continueWithWordPressCom = "continue_with_wordpress_com"
-        
+
         /// Tracked when the user clicks “Login with site address” on the Prologue screen
         ///
         case loginWithSiteAddress = "login_with_site_address"
-        
+
         /// When the user tries to login with Apple from the confirmation screen
         ///
         case loginWithApple = "login_with_apple"
-        
+
         /// Tracked when the user clicks “Login with Google” on the WordPress.com flow screen
         ///
         case loginWithGoogle = "login_with_google"
-        
+
         /// When the user clicks on “Forgotten password” on one of the screens that show the password field
         ///
         case forgottenPassword = "forgotten_password"
-        
+
         /// When the user clicks on terms of service anywhere
         ///
         case termsOfService = "terms_of_service_clicked"
-        
+
         /// When the user tries to sign up with email from the confirmation screen
         ///
         case signupWithEmail = "signup_with_email"
-        
+
         /// When the user tries to sign up with Apple from the confirmation screen
         ///
         case signupWithApple = "signup_with_apple"
-        
+
         /// When the user tries to sign up with Google from the confirmation screen
         ///
         case signupWithGoogle = "signup_with_google"
-        
+
         /// When the user opens the email client from the magic link screen
         ///
         case openEmailClient = "open_email_client"
-        
+
         /// Any time the user clicks on the help icon in the login flow
         ///
         case showHelp = "show_help"
-        
+
         /// Used on the 2FA screen to send code with a text instead of using the authenticator app
         ///
         case sendCodeWithText = "send_code_with_text"
-        
+
         /// Used on the 2FA screen to submit authentication code
         ///
         case submitTwoFactorCode = "submit_2fa_code"
-        
+
         /// When the user requests a magic link after filling in email address
         ///
         case requestMagicLink = "request_magic_link"
-        
+
         /// Click on “Create new site” button after a successful signup
         ///
         case createNewSite = "create_new_site"
-        
+
         /// Adding a self-hosted site from the epilogue
         ///
         case addSelfHostedSite = "add_self_hosted_site"
-        
+
         /// Connecting a site from the epilogue
         ///
         case connectSite = "connect_site"
-        
+
         /// Picking an avatar from the epilogue after a successful signup
         ///
         case selectAvatar = "select_avatar"
-        
+
         /// Editing the username from the epilogue after a successful signup
         ///
         case editUsername = "edit_username"
-        
+
         /// Clicking on “Need help finding site address” from a dialog
         ///
         case helpFindingSiteAddress = "help_finding_site_address"
-        
+
         /// When the user clicks on the email field to log in, this triggers the hint dialog to show up
         ///
         case selectEmailField = "select_email_field"
-        
+
         /// When the user selects an email from the hint dialog
         ///
         case pickEmailFromHint = "pick_email_from_hint"
-        
+
         /// When the user clicks on “Create account” on the signup confirmation screen
         ///
         case createAccount = "create_account"
     }
-    
+
     /// Shared Instance.
     ///
     public static var shared: AuthenticatorAnalyticsTracker = {
         return AuthenticatorAnalyticsTracker()
     }()
-    
+
     /// State for the analytics tracker.
     ///
     public class State {
         internal(set) public var lastFlow: Flow
         internal(set) public var lastSource: Source
         internal(set) public var lastStep: Step
-        
+
         init(lastFlow: Flow = AuthenticatorAnalyticsTracker.defaultFlow, lastSource: Source = AuthenticatorAnalyticsTracker.defaultSource, lastStep: Step = AuthenticatorAnalyticsTracker.defaultStep) {
             self.lastFlow = lastFlow
             self.lastSource = lastSource
             self.lastStep = lastStep
         }
     }
-    
+
     /// The state of this tracker.
     ///
     public let state = State()
-    
+
     /// The backing analytics tracking method.  Can be overridden for testing purposes.
     ///
     let track: TrackerMethod
-    
+
     /// Whether tracking is enabled or not.  This is just a convenience configuration to enable this tracker to be turned on and off
     /// using a feature flag.  It should go away once we remove the legacy tracking.
     ///
@@ -270,16 +270,16 @@ public class AuthenticatorAnalyticsTracker {
         self.enabled = enabled
         self.track = track
     }
-    
+
     /// Resets the flow and step to the defaults.  The source is left untouched, and should only be set explicitely.
     ///
     func resetState() {
         set(flow: Self.defaultFlow)
         set(step: Self.defaultStep)
     }
-    
+
     // MARK: - Legacy vs Unified tracking
-    
+
     /// This method will reply whether, for the current flow in the state, tracking is enabled.
     ///
     /// It's the responsibility of the class calling the tracking methods to check this before attempting to actually do the tracking.
@@ -289,7 +289,7 @@ public class AuthenticatorAnalyticsTracker {
     public func canTrack() -> Bool {
         return enabled
     }
-    
+
     /// This is a convenience method, that's useful for cases where we simply want to check if the legacy tracking should be
     /// enabled.  It can be particularly useful in cases where we don't have a matching tracking call in the new flow.
     ///
@@ -298,45 +298,45 @@ public class AuthenticatorAnalyticsTracker {
     public func shouldUseLegacyTracker() -> Bool {
         return !canTrack()
     }
-    
+
     // MARK: - Tracking
-    
+
     /// Track a step within a flow.
     ///
     public func track(step: Step) {
         guard canTrack() else {
             return
         }
-        
+
         track(event(step: step))
     }
-    
+
     /// Track a click interaction.
     ///
     public func track(click: ClickTarget) {
         guard canTrack() else {
             return
         }
-        
+
         track(event(click: click))
     }
-    
+
     /// Track a failure.
     ///
     public func track(failure: String) {
         guard canTrack() else {
             return
         }
-        
+
         track(event(failure: failure))
     }
-    
+
     // MARK: - Tracking: Legacy Tracking Support
-    
+
     /// Tracks a step within a flow if tracking is enabled for that flow, or executes the specified block if tracking is not enabled
     /// for the flow.
     ///
-    public func track(step: Step, ifTrackingNotEnabled legacyTracking: () -> ()) {
+    public func track(step: Step, ifTrackingNotEnabled legacyTracking: () -> Void) {
         guard canTrack() else {
             legacyTracking()
             return
@@ -344,11 +344,11 @@ public class AuthenticatorAnalyticsTracker {
 
         track(step: step)
     }
-    
+
     /// Track a click interaction if tracking is enabled for that flow, or executes the specified block if tracking is not enabled
     /// for the flow.
     ///
-    public func track(click: ClickTarget, ifTrackingNotEnabled legacyTracking: () -> ()) {
+    public func track(click: ClickTarget, ifTrackingNotEnabled legacyTracking: () -> Void) {
         guard canTrack() else {
             legacyTracking()
             return
@@ -356,11 +356,11 @@ public class AuthenticatorAnalyticsTracker {
 
         track(event(click: click))
     }
-    
+
     /// Track a failure if tracking is enabled for that flow, or executes the specified block if tracking is not enabled
     /// for the flow.
     ///
-    public func track(failure: String, ifTrackingNotEnabled legacyTracking: () -> ()) {
+    public func track(failure: String, ifTrackingNotEnabled legacyTracking: () -> Void) {
         guard canTrack() else {
             legacyTracking()
             return
@@ -368,9 +368,9 @@ public class AuthenticatorAnalyticsTracker {
 
         track(event(failure: failure))
     }
-    
+
     // MARK: - Event Construction & Context Updating
-    
+
     /// Creates an event for a step.  Updates the state machine.
     ///
     /// - Parameters:
@@ -383,9 +383,9 @@ public class AuthenticatorAnalyticsTracker {
         let event = AnalyticsEvent(
             name: EventType.step.rawValue,
             properties: properties(step: step))
-        
+
         state.lastStep = step
-        
+
         return event
     }
 
@@ -399,12 +399,12 @@ public class AuthenticatorAnalyticsTracker {
     private func event(failure: String) -> AnalyticsEvent {
         var properties = lastProperties()
         properties[Property.failure.rawValue] = failure
-        
+
         return AnalyticsEvent(
             name: EventType.failure.rawValue,
             properties: properties)
     }
-    
+
     /// Creates an event for a click interaction.  Loads the properties from the state machine.
     ///
     /// - Parameters:
@@ -420,41 +420,41 @@ public class AuthenticatorAnalyticsTracker {
             name: EventType.interaction.rawValue,
             properties: properties)
     }
-    
+
     // MARK: - Source & Flow
-    
+
     /// Allows the caller to set the flow without tracking.
     ///
     public func set(flow: Flow) {
         state.lastFlow = flow
     }
-    
+
     /// Allows the caller to set the source without tracking.
     ///
     public func set(source: Source) {
         state.lastSource = source
     }
-    
+
     /// Allows the caller to set the step without tracking.
     ///
     public func set(step: Step) {
         state.lastStep = step
     }
-    
+
     // MARK: - Properties
-    
+
     private func properties(step: Step) -> [String: String] {
         return properties(step: step, flow: state.lastFlow, source: state.lastSource)
     }
-    
+
     private func properties(step: Step, flow: Flow, source: Source) -> [String: String] {
         return [
             Property.flow.rawValue: flow.rawValue,
             Property.source.rawValue: source.rawValue,
-            Property.step.rawValue: step.rawValue,
+            Property.step.rawValue: step.rawValue
         ]
     }
-    
+
     /// Retrieve the last step, flow and source stored in the state machine.
     ///
     private func lastProperties() -> [String: String] {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Errors.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Errors.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 // MARK: - WordPressAuthenticator Error Constants. Once the entire code is Swifted, let's *PLEASE* have a
 //          beautiful Error `Swift Enum`.
 //

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Notifications.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Notifications.swift
@@ -12,7 +12,7 @@ extension NSNotification.Name {
     /// Posted whenever a Support notification is received.
     ///
     public static let wordpressSupportNotificationReceived = NSNotification.Name(rawValue: "WordPressSupportNotificationReceived")
-    
+
     /// Posted whenever a Support notification has been viewed.
     ///
     public static let wordpressSupportNotificationCleared = NSNotification.Name(rawValue: "WordPressSupportNotificationCleared")

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -418,32 +418,32 @@ import WordPressKit
     /// - Returns: The base URL or an empty string.
     ///
     class func baseSiteURL(string: String) -> String {
-        guard let siteURL = NSURL(string: NSURL.idnEncodedURL(string)), string.count > 0 else {
+
+        guard !string.isEmpty,
+              let siteURL = NSURL(string: NSURL.idnEncodedURL(string)),
+              var path = siteURL.absoluteString else {
             return ""
         }
 
-        var path = siteURL.absoluteString!
         let isSiteURLSchemeEmpty = siteURL.scheme == nil || siteURL.scheme!.isEmpty
 
-        if path.isWordPressComPath() {
-            if isSiteURLSchemeEmpty {
-                path = "https://\(path)"
-            } else if path.range(of: "http://") != nil {
-                path = path.replacingOccurrences(of: "http://", with: "https://")
-            }
-        } else if isSiteURLSchemeEmpty {
+        if isSiteURLSchemeEmpty {
             path = "https://\(path)"
+        } else if path.isWordPressComPath() && path.range(of: "http://") != nil {
+            path = path.replacingOccurrences(of: "http://", with: "https://")
         }
 
         path.removeSuffix("/wp-login.php")
-        try? path.removeSuffix(pattern: "/wp-admin/?")
+
+        // Remove wp-admin and everything after it.
+        try? path.removeSuffix(pattern: "/wp-admin(.*)")
+
         path.removeSuffix("/")
 
         return path
     }
 
     // MARK: - Other Helpers
-
 
     /// Opens Safari to display the forgot password page for a wpcom or self-hosted
     /// based on the passed LoginFields instance.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -44,7 +44,7 @@ import WordPressKit
     /// Authenticator's Styles for unified flows.
     ///
     public let unifiedStyle: WordPressAuthenticatorUnifiedStyle?
-    
+
     /// Authenticator's Display Images.
     ///
     public let displayImages: WordPressAuthenticatorDisplayImages
@@ -52,7 +52,7 @@ import WordPressKit
     /// Authenticator's Display Texts.
     ///
     public let displayStrings: WordPressAuthenticatorDisplayStrings
-    
+
     /// Notification to be posted whenever the signing flow completes.
     ///
     @objc public static let WPSigninDidFinishNotification = "WPSigninDidFinishNotification"
@@ -90,15 +90,15 @@ import WordPressKit
                                                  displayImages: displayImages,
                                                  displayStrings: displayStrings)
     }
-    
+
     // MARK: - Testing Support
-    
+
     class func isInitialized() -> Bool {
         return privateInstance != nil
     }
 
     // MARK: - Public Methods
-    
+
     public func supportPushNotificationReceived() {
         NotificationCenter.default.post(name: .wordpressSupportNotificationReceived, object: nil)
     }
@@ -106,10 +106,10 @@ import WordPressKit
     public func supportPushNotificationCleared() {
         NotificationCenter.default.post(name: .wordpressSupportNotificationCleared, object: nil)
     }
-    
+
     /// Indicates if the specified ViewController belongs to the Authentication Flow, or not.
     ///
-    public class func isAuthenticationViewController(_ viewController: UIViewController) ->  Bool {
+    public class func isAuthenticationViewController(_ viewController: UIViewController) -> Bool {
         return viewController is LoginPrologueViewController || viewController is NUXViewControllerBase
     }
 
@@ -137,7 +137,6 @@ import WordPressKit
     @objc public func handleWordPressAuthUrl(_ url: URL, rootViewController: UIViewController, automatedTesting: Bool = false) -> Bool {
         return WordPressAuthenticator.openAuthenticationURL(url, fromRootViewController: rootViewController, automatedTesting: automatedTesting)
     }
-
 
     // MARK: - Helpers for presenting the login flow
 
@@ -196,7 +195,7 @@ import WordPressKit
             showEmailLogin(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail)
             return
         }
-        
+
         showGetStarted(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail)
     }
 
@@ -207,16 +206,16 @@ import WordPressKit
             DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
             return
         }
-        
+
         controller.loginFields.restrictToWPCom = true
         controller.loginFields.username = connectedEmail ?? String()
         controller.loginFields.meta.jetpackLogin = jetpackLogin
-        
+
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen
         presenter.present(navController, animated: true, completion: nil)
     }
-    
+
     /// Shows the Email Login view with Signup option.
     ///
     private class func showEmailLogin(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil) {
@@ -243,29 +242,29 @@ import WordPressKit
         defer {
             trackOpenedLogin()
         }
-        
+
         AuthenticatorAnalyticsTracker.shared.set(source: .selfHosted)
-        
+
         guard let controller = signinForWPOrg() else {
             DDLogError("WordPressAuthenticator: Failed to instantiate Site Address view controller.")
             return
         }
-        
+
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen
         presenter.present(navController, animated: true, completion: nil)
     }
-    
+
     /// Returns a Site Address view controller: allows the user to log into a WordPress.org website.
     ///
     @objc public class func signinForWPOrg() -> UIViewController? {
         guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             return LoginSiteAddressViewController.instantiate(from: .login)
         }
-        
+
         return SiteAddressViewController.instantiate(from: .siteAddress)
     }
-    
+
     // Helper used by WPAuthTokenIssueSolver
     @objc
     public class func signinForWPCom(dotcomEmailAddress: String?, dotcomUsername: String?, onDismissed: ((_ cancelled: Bool) -> Void)? = nil) -> UIViewController {
@@ -278,25 +277,25 @@ import WordPressKit
                 DDLogError("WordPressAuthenticator: Failed to instantiate LoginWPComViewController")
                 return UIViewController()
             }
-            
+
             controller.loginFields = loginFields
             controller.dismissBlock = onDismissed
-            
+
             return NUXNavigationController(rootViewController: controller)
         }
-        
+
         AuthenticatorAnalyticsTracker.shared.set(source: .reauthentication)
         AuthenticatorAnalyticsTracker.shared.set(flow: .loginWithPassword)
-        
+
         guard let controller = PasswordViewController.instantiate(from: .password) else {
             DDLogError("WordPressAuthenticator: Failed to instantiate PasswordViewController")
             return UIViewController()
         }
-        
+
         controller.loginFields = loginFields
         controller.dismissBlock = onDismissed
         controller.trackAsPasswordChallenge = false
-        
+
         return NUXNavigationController(rootViewController: controller)
     }
 
@@ -311,11 +310,9 @@ import WordPressKit
         return controller
     }
 
-
     private class func trackOpenedLogin() {
         WordPressAuthenticator.track(.openedLogin)
     }
-
 
     // MARK: - Authentication Link Helpers
 
@@ -335,27 +332,27 @@ import WordPressKit
             DDLogError("Magic link error: we couldn't retrieve the query dictionary from the sign-in URL.")
             return false
         }
-        
+
         guard let authToken = queryDictionary.string(forKey: "token") else {
             DDLogError("Magic link error: we couldn't retrieve the authentication token from the sign-in URL.")
             return false
         }
-        
+
         guard let flowRawValue = queryDictionary.string(forKey: "flow") else {
             DDLogError("Magic link error: we couldn't retrieve the flow from the sign-in URL.")
             return false
         }
-        
+
         let loginFields = LoginFields()
-        
+
         if url.isJetpackConnect {
             loginFields.meta.jetpackLogin = true
         }
-        
+
         // We could just use the flow, but since `MagicLinkFlow` is an ObjC enum, it always
         // allows a `default` value.  By mapping the ObjC enum to a Swift enum we can avoid that afterwards.
         let flow: NUXLinkAuthViewController.Flow
-        
+
         switch MagicLinkFlow(rawValue: flowRawValue) {
         case .signup:
             flow = .signup
@@ -369,7 +366,7 @@ import WordPressKit
             DDLogError("Magic link error: the flow should be either `signup` or `login`. We can't handle an unsupported flow.")
             return false
         }
-        
+
         if !automatedTesting {
             let storyboard = Storyboard.emailMagicLink.instance
             guard let loginVC = storyboard.instantiateViewController(withIdentifier: "LinkAuthView") as? NUXLinkAuthViewController else {
@@ -377,10 +374,10 @@ import WordPressKit
                 return false
             }
             loginVC.loginFields = loginFields
-            
+
             let navController = LoginNavigationController(rootViewController: loginVC)
             navController.modalPresentationStyle = .fullScreen
-            
+
             // The way the magic link flow works some view controller might
             // still be presented when the app is resumed by tapping on the auth link.
             // We need to do a little work to present the SigninLinkAuth controller
@@ -400,16 +397,14 @@ import WordPressKit
             } else {
                 presenter.present(navController, animated: false, completion: nil)
             }
-            
+
             loginVC.syncAndContinue(authToken: authToken, flow: flow, isJetpackConnect: url.isJetpackConnect)
         }
-        
+
         return true
     }
 
-
     // MARK: - Site URL helper
-
 
     /// The base site URL path derived from `loginFields.siteUrl`
     ///
@@ -473,7 +468,6 @@ import WordPressKit
 
     // MARK: - 1Password Helper
 
-
     /// Request credentails from 1Password (if supported)
     ///
     /// - Parameter sender: A UIView. Typically the button the user tapped on.
@@ -491,7 +485,7 @@ import WordPressKit
             if allowUsernameChange {
                 loginFields.username = username
             }
-            
+
             loginFields.password = password
             loginFields.multifactorCode = otp ?? String()
 
@@ -520,11 +514,11 @@ public extension WordPressAuthenticator {
     }
 
     func startObservingAppleIDCredentialRevoked(completion:  @escaping () -> Void) {
-        appleIDCredentialObserver = NotificationCenter.default.addObserver(forName: AppleAuthenticator.credentialRevokedNotification, object: nil, queue: nil) { (notification) in
+        appleIDCredentialObserver = NotificationCenter.default.addObserver(forName: AppleAuthenticator.credentialRevokedNotification, object: nil, queue: nil) { (_) in
             completion()
         }
     }
-    
+
     func stopObservingAppleIDCredentialRevoked() {
         if let observer = appleIDCredentialObserver {
             NotificationCenter.default.removeObserver(observer)

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -20,11 +20,11 @@ public struct WordPressAuthenticatorConfiguration {
     /// WordPress.com Terms of Service URL
     ///
     let wpcomTermsOfServiceURL: String
-    
+
     /// WordPress.com Base URL for OAuth
     ///
     let wpcomBaseURL: String
-    
+
     /// WordPress.com API Base URL
     ///
     let wpcomAPIBaseURL: String
@@ -59,7 +59,7 @@ public struct WordPressAuthenticatorConfiguration {
     /// If enabled, "Find your site address", "Reset your password", and others will be displayed.
     /// If disabled, none of the hint buttons will appear on the unified auth flows.
     let displayHintButtons: Bool
-    
+
     /// Flag indicating if the Sign In With Apple option should be displayed.
     ///
     let enableSignInWithApple: Bool
@@ -71,7 +71,7 @@ public struct WordPressAuthenticatorConfiguration {
     ///     If disabled, a view is displayed providing the user with other options.
     ///
     let enableSignupWithGoogle: Bool
-    
+
     /// Flag for the unified login/signup flows.
     /// If disabled, none of the unified flows will display.
     /// If enabled, all unified flows will display.
@@ -82,7 +82,7 @@ public struct WordPressAuthenticatorConfiguration {
     /// If disabled, displays the old carousel.
     /// If enabled, displays the new carousel.
     let enableUnifiedCarousel: Bool
-    
+
     /// Flag for the unified login/signup flows.
     /// If disabled, the "Continue With WordPress" button in the login prologue is shown first.
     /// If enabled, the "Enter your existing site address" button in the login prologue is shown first.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -1,5 +1,3 @@
-
-
 // MARK: - WordPressAuthenticator Delegate Protocol
 //
 public protocol WordPressAuthenticatorDelegate: class {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 // MARK: - WordPress Authenticator Display Strings
 //
 public struct WordPressAuthenticatorDisplayStrings {
@@ -30,7 +29,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let createAccountButtonTitle: String
     public let continueWithWPButtonTitle: String
     public let enterYourSiteAddressButtonTitle: String
-    
+
     /// Large titles displayed in unified auth flows.
     ///
     public let getStartedTitle: String
@@ -182,7 +181,7 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                        comment: "The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password."),
             textCodeButtonTitle: NSLocalizedString("Text me a code instead",
                                                    comment: "The button's title text to send a 2FA code via SMS text message."),
-            loginTermsOfService:NSLocalizedString("By continuing, you agree to our _Terms of Service_.", comment: "Legal disclaimer for logging in. The underscores _..._ denote underline."),
+            loginTermsOfService: NSLocalizedString("By continuing, you agree to our _Terms of Service_.", comment: "Legal disclaimer for logging in. The underscores _..._ denote underline."),
             signupTermsOfService: NSLocalizedString("If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_.", comment: "Legal disclaimer for signing up. The underscores _..._ denote underline."),
             getStartedTitle: NSLocalizedString("Get Started",
                                                comment: "View title for initial auth views."),

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorResult.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorResult.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Provides options for clients of WordPressAuthenticator
 /// to signal what they expect WPAuthenticator to do in response to
 /// `shouldPresentUsernamePasswordController`

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -77,7 +77,7 @@ public struct WordPressAuthenticatorStyle {
     public let navBarBadgeColor: UIColor
 
     public let navBarBackgroundColor: UIColor
-    
+
     public let navButtonTextColor: UIColor
 
     /// Style: prologue background colors
@@ -96,7 +96,7 @@ public struct WordPressAuthenticatorStyle {
     /// Style: status bar style
     ///
     public let statusBarStyle: UIStatusBarStyle
-    
+
     /// Designated initializer
     ///
     public init(primaryNormalBackgroundColor: UIColor,
@@ -197,7 +197,7 @@ public struct WordPressAuthenticatorUnifiedStyle {
     /// Style: Auth view background colors
     ///
     public let viewControllerBackgroundColor: UIColor
-    
+
     /// Style: Auth Prologue buttons background color
     public let prologueButtonsBackgroundColor: UIColor
 
@@ -207,13 +207,13 @@ public struct WordPressAuthenticatorUnifiedStyle {
     /// Style: Status bar style. Defaults to `default`.
     ///
     public let statusBarStyle: UIStatusBarStyle
-    
+
     /// Style: Navigation bar.
     ///
     public let navBarBackgroundColor: UIColor
     public let navButtonTextColor: UIColor
     public let navTitleTextColor: UIColor
-    
+
     /// Designated initializer
     ///
     public init(borderColor: UIColor,

--- a/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
@@ -1,12 +1,11 @@
 import Foundation
 
-
 // MARK: - Authentication Flow Event. Useful to relay internal Auth events over to activity trackers.
 //
 public struct WordPressSupportSourceTag {
     public let name: String
     public let origin: String?
-    
+
     public init(name: String, origin: String? = nil) {
         self.name = name
         self.origin = origin

--- a/WordPressAuthenticator/Credentials/WordPressComCredentials.swift
+++ b/WordPressAuthenticator/Credentials/WordPressComCredentials.swift
@@ -19,9 +19,9 @@ public struct WordPressComCredentials: Equatable {
     /// The site address used during login
     ///
     public var siteURL: String
-    
+
     private let wpComURL = "https://wordpress.com"
-    
+
     /// Legacy  initializer, for backwards compatibility
     ///
     public init(authToken: String,
@@ -34,7 +34,6 @@ public struct WordPressComCredentials: Equatable {
         self.siteURL = !siteURL.isEmpty ? siteURL : wpComURL
     }
 }
-
 
 // MARK: - Equatable Conformance
 //

--- a/WordPressAuthenticator/Credentials/WordPressOrgCredentials.swift
+++ b/WordPressAuthenticator/Credentials/WordPressOrgCredentials.swift
@@ -32,7 +32,6 @@ public struct WordPressOrgCredentials: Equatable {
     }
 }
 
-
 // MARK: - Equatable Conformance
 //
 public func ==(lhs: WordPressOrgCredentials, rhs: WordPressOrgCredentials) -> Bool {

--- a/WordPressAuthenticator/Email Client Picker/AppSelector.swift
+++ b/WordPressAuthenticator/Email Client Picker/AppSelector.swift
@@ -28,7 +28,7 @@ class AppSelector {
                 guard let url = URL(string: urlString), urlHandler.canOpenURL(url) else {
                     continue
                 }
-                actions.append(UIAlertAction(title: AppSelectorTitles(rawValue: name)?.localized ?? name, style: .default) { action in
+                actions.append(UIAlertAction(title: AppSelectorTitles(rawValue: name)?.localized ?? name, style: .default) { _ in
                     urlHandler.open(url, options: [:], completionHandler: nil)
                 })
             }
@@ -36,7 +36,7 @@ class AppSelector {
             guard !actions.isEmpty else {
                 return nil
             }
-            //sort the apps alphabetically
+            // sort the apps alphabetically
             actions = actions.sorted { $0.title ?? "" < $1.title ?? "" }
             actions.append(UIAlertAction(title: AppSelectorTitles.cancel.localized, style: .cancel, handler: nil))
 
@@ -58,7 +58,6 @@ class AppSelector {
         }
     }
 }
-
 
 /// Initializers for Email Picker
 extension AppSelector {
@@ -90,7 +89,7 @@ extension AppSelector {
 
         // if available, prepend apple mail
         if MFMailComposeViewController.canSendMail(), let url = URL(string: "message://") {
-            defaultAction = UIAlertAction(title: AppSelectorTitles.appleMail.localized, style: .default) { action in
+            defaultAction = UIAlertAction(title: AppSelectorTitles.appleMail.localized, style: .default) { _ in
                 UIApplication.shared.open(url)
             }
         }
@@ -100,7 +99,6 @@ extension AppSelector {
                   sourceView: sourceView)
     }
 }
-
 
 /// Localizable app selector titles
 enum AppSelectorTitles: String {

--- a/WordPressAuthenticator/Email Client Picker/LinkMailPresenter.swift
+++ b/WordPressAuthenticator/Email Client Picker/LinkMailPresenter.swift
@@ -1,6 +1,5 @@
 import MessageUI
 
-
 /// Email picker presenter
 class LinkMailPresenter {
 

--- a/WordPressAuthenticator/Email Client Picker/URLHandler.swift
+++ b/WordPressAuthenticator/Email Client Picker/URLHandler.swift
@@ -4,10 +4,9 @@ protocol URLHandler {
     func canOpenURL(_ url: URL) -> Bool
     /// opens the specified URL
     func open(_ url: URL,
-              options: [UIApplication.OpenExternalURLOptionsKey : Any],
+              options: [UIApplication.OpenExternalURLOptionsKey: Any],
               completionHandler completion: ((Bool) -> Void)?)
 }
 
 /// conforms UIApplication to URLHandler to allow dependency injection
 extension UIApplication: URLHandler {}
-

--- a/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -3,7 +3,6 @@ import wpxmlrpc
 import SafariServices
 import WordPressUI
 
-
 extension FancyAlertViewController {
     private struct Strings {
         static let titleText = NSLocalizedString("What's my site address?", comment: "Title of alert helping users understand their site address")
@@ -25,7 +24,7 @@ extension FancyAlertViewController {
         sourceTag: WordPressSupportSourceTag,
         moreHelpTapped: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil) -> FancyAlertViewController {
-        
+
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
             controller.dismiss(animated: true) {
                 // Find the topmost view controller that we can present from
@@ -46,7 +45,7 @@ extension FancyAlertViewController {
             onDismiss?()
             controller.dismiss(animated: true, completion: nil)
         }
-        
+
         let config = FancyAlertViewController.Config(titleText: Strings.titleText,
                                                      bodyText: Strings.bodyText,
                                                      headerImage: image,
@@ -61,9 +60,7 @@ extension FancyAlertViewController {
         return controller
     }
 
-
     // MARK: - Error Handling
-
 
     /// Get an alert for the specified error.
     /// The view is configured differently depending on the kind of error.
@@ -111,7 +108,6 @@ extension FancyAlertViewController {
         return alertForGenericErrorMessage(message, loginFields: loginFields, sourceTag: sourceTag)
     }
 
-
     /// Shows a generic error message.
     ///
     /// - Parameter message: The error message to show.
@@ -141,7 +137,6 @@ extension FancyAlertViewController {
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
     }
 
-
     /// Shows a generic error message.
     /// If Support is enabled, the view is configured so the user can open Support for assistance.
     ///
@@ -151,7 +146,7 @@ extension FancyAlertViewController {
     static func alertForGenericErrorMessageWithHelpButton(_ message: String, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
 
         // If support is not enabled, don't add a Help Button since it won't do anything.
-        var moreHelpButton: ButtonConfig? = nil
+        var moreHelpButton: ButtonConfig?
 
         if WordPressAuthenticator.shared.delegate?.supportEnabled == false {
             DDLogInfo("Error Alert: Support not enabled. Hiding Help button.")
@@ -166,7 +161,7 @@ extension FancyAlertViewController {
                         else {
                             return
                     }
-                    
+
                     WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag)
                 }
             }
@@ -184,7 +179,6 @@ extension FancyAlertViewController {
 
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
     }
-
 
     /// Shows a WPWalkthroughOverlayView for a bad url error message.
     ///

--- a/WordPressAuthenticator/Extensions/NSObject+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/NSObject+Helpers.swift
@@ -1,8 +1,6 @@
-
 import Foundation
 
-
-// MARK - NSObject Helper Methods
+// MARK: - NSObject Helper Methods
 //
 extension NSObject {
 

--- a/WordPressAuthenticator/Extensions/UIImage+Assets.swift
+++ b/WordPressAuthenticator/Extensions/UIImage+Assets.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 // MARK: - Named Assets
 //
 extension UIImage {

--- a/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
+++ b/WordPressAuthenticator/Extensions/UIPasteboard+Detect.swift
@@ -11,7 +11,7 @@ extension UIPasteboard {
             case .success(let detections):
                 guard detections.isEmpty == false else {
                     DispatchQueue.main.async {
-                        completion(.success([UIPasteboard.DetectionPattern : Any]()))
+                        completion(.success([UIPasteboard.DetectionPattern: Any]()))
                     }
                     return
                 }

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -1,13 +1,12 @@
 import Foundation
 
-
-// MARK - Storyboard enum
+// MARK: - Storyboard enum
 enum Storyboard: String {
     case login = "Login"
     case signup = "Signup"
     case getStarted = "GetStarted"
     case unifiedSignup = "UnifiedSignup"
-    case unifiedLoginMagicLink = "LoginMagicLink" 
+    case unifiedLoginMagicLink = "LoginMagicLink"
     case emailMagicLink = "EmailMagicLink"
     case siteAddress = "SiteAddress"
     case googleAuth = "GoogleAuth"

--- a/WordPressAuthenticator/Extensions/UIView+AuthHelpers.swift
+++ b/WordPressAuthenticator/Extensions/UIView+AuthHelpers.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// UIView class methods
 ///
 extension UIView {

--- a/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
+++ b/WordPressAuthenticator/Extensions/UIViewController+Dismissal.swift
@@ -10,7 +10,7 @@ extension UIViewController {
     var isBeingDismissedInAnyWay: Bool {
         isMovingFromParent || isBeingDismissed || (navigationController?.isBeingDismissed ?? false)
     }
-    
+
     /// Depending on how a VC is presented we need to check different things to know whether it's being presented or not.
     /// A VC presented as the first VC in a navigation controller needs to check if the navigation controller is being presented.
     /// A VC added to an existing navigation controller is presented when `isMovingToParent` is `true`.

--- a/WordPressAuthenticator/Extensions/UIViewController+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIViewController+Helpers.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-
-// MARK - UIViewController Helpers
+// MARK: - UIViewController Helpers
 extension UIViewController {
 
     /// Convenience method to instantiate a view controller from a storyboard.

--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -30,7 +30,7 @@ extension WPStyleGuide {
     class var hairlineBorderWidth: CGFloat {
         return 1.0 / UIScreen.main.scale
     }
-    
+
     /// Common view style for signin view controllers.
     ///
     /// - Parameters:
@@ -76,7 +76,7 @@ extension WPStyleGuide {
         onePasswordButton.sizeToFit()
         onePasswordButton.setContentHuggingPriority(.required, for: .horizontal)
         onePasswordButton.setContentCompressionResistancePriority(.required, for: .horizontal)
-        
+
         onePasswordButton.accessibilityTraits = .button
         onePasswordButton.accessibilityLabel = NSLocalizedString("One Password button", comment: "Accessibility label for 1 password button")
         onePasswordButton.accessibilityHint = NSLocalizedString("Opens One Password manager", comment: "Accessibility hint for 1 password button")
@@ -168,11 +168,11 @@ extension WPStyleGuide {
     /// - Returns: A properly styled NSAttributedString
     ///
     class func formattedGoogleString(forHyperlink: Bool = false) -> NSAttributedString {
-        
+
         let googleAttachment = NSTextAttachment()
         let googleIcon = UIImage.googleIcon
         googleAttachment.image = googleIcon
-        
+
         if forHyperlink {
             // Create an attributed string that contains the Google icon.
             let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
@@ -196,7 +196,7 @@ extension WPStyleGuide {
             return buttonString
         }
     }
-    
+
     /// Creates an attributed string that includes the Apple logo.
     ///
     /// - Returns: A properly styled NSAttributedString to be displayed on a NUXButton.
@@ -219,37 +219,37 @@ extension WPStyleGuide {
 
         return NSAttributedString(attributedString: attributedString)
     }
-    
+
     /// Creates a button for Self-hosted Login
     ///
     /// - Returns: A properly styled UIButton
     ///
     class func selfHostedLoginButton(alignment: UIControl.NaturalContentHorizontalAlignment = .leading) -> UIButton {
-        
+
         let style = WordPressAuthenticator.shared.style
-        
+
         let button: UIButton
 
         if WordPressAuthenticator.shared.configuration.showLoginOptions {
             let baseString =  NSLocalizedString("Or log in by _entering your site address_.", comment: "Label for button to log in using site address. Underscores _..._ denote underline.")
-            
+
             let attrStrNormal = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonColor)
             let attrStrHighlight = baseString.underlined(color: style.subheadlineColor, underlineColor: style.textButtonHighlightColor)
             let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
-            
+
             button = textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font, alignment: alignment)
         } else {
             let baseString = NSLocalizedString("Enter the address of the WordPress site you'd like to connect.", comment: "Label for button to log in using your site address.")
-            
-            let attrStrNormal = selfHostedButtonString(baseString, linkColor:  style.textButtonColor)
+
+            let attrStrNormal = selfHostedButtonString(baseString, linkColor: style.textButtonColor)
             let attrStrHighlight = selfHostedButtonString(baseString, linkColor: style.textButtonHighlightColor)
             let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
-            
+
             button = textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font)
         }
-        
+
         button.accessibilityIdentifier = "Self Hosted Login Button"
-        
+
         return button
     }
 
@@ -294,7 +294,7 @@ extension WPStyleGuide {
         let baseString = WordPressAuthenticator.shared.displayStrings.signupTermsOfService
         let textColor = unifiedStyle?.textSubtleColor ?? originalStyle.subheadlineColor
         let linkColor = unifiedStyle?.textButtonColor ?? originalStyle.textButtonColor
-        
+
         let attrStrNormal = baseString.underlined(color: textColor, underlineColor: linkColor)
         let attrStrHighlight = baseString.underlined(color: textColor, underlineColor: linkColor)
         let font = WPStyleGuide.mediumWeightFont(forStyle: .footnote)
@@ -303,7 +303,7 @@ extension WPStyleGuide {
         button.titleLabel?.textAlignment = .center
         return button
     }
-    
+
     private class func textButton(normal normalString: NSAttributedString, highlighted highlightString: NSAttributedString, font: UIFont, alignment: UIControl.NaturalContentHorizontalAlignment = .leading, forUnified: Bool = false) -> UIButton {
         let button = SubheadlineButton()
         button.clipsToBounds = true
@@ -318,7 +318,7 @@ extension WPStyleGuide {
         // These constraints work around some issues with multiline buttons and
         // vertical layout.  Without them the button's height may not account
         // for the titleLabel's height.
-        
+
         let verticalLabelSpacing = forUnified ? 0 : Constants.verticalLabelSpacing
         button.titleLabel?.topAnchor.constraint(equalTo: button.topAnchor, constant: verticalLabelSpacing).isActive = true
         button.titleLabel?.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -verticalLabelSpacing).isActive = true

--- a/WordPressAuthenticator/Logging/CocoaLumberjack.swift
+++ b/WordPressAuthenticator/Logging/CocoaLumberjack.swift
@@ -31,7 +31,7 @@ extension DDLogFlag {
         self = DDLogFlag(rawValue: logLevel.rawValue)
     }
 
-    ///returns the log level, or the lowest equivalant.
+    /// returns the log level, or the lowest equivalant.
     public func toLogLevel() -> DDLogLevel {
         if let ourValid = DDLogLevel(rawValue: rawValue) {
             return ourValid

--- a/WordPressAuthenticator/Model/LoginFields+Validation.swift
+++ b/WordPressAuthenticator/Model/LoginFields+Validation.swift
@@ -17,7 +17,7 @@ extension LoginFields {
         guard let url = URL(string: NSURL.idnEncodedURL(siteAddress)) else {
             return false
         }
-        
+
         return !url.absoluteString.isEmpty
     }
 

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -2,7 +2,6 @@ import Foundation
 import GoogleSignIn
 import WordPressKit
 
-
 /// LoginFields is a state container for user textfield input on the login screens
 /// as well as other meta data regarding the nature of a login attempt.
 ///
@@ -48,13 +47,13 @@ public class LoginFields: NSObject {
         storedCredentials?.storedUserameHash = usernameHash
         storedCredentials?.storedPasswordHash = passwordHash
     }
-    
+
     class func makeForWPCom(username: String, password: String) -> LoginFields {
         let loginFields = LoginFields()
-        
+
         loginFields.username = username
         loginFields.password = password
-        
+
         return loginFields
     }
 }

--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 // MARK: - WordPress.com Site Info
 //
 public class WordPressComSiteInfo {
@@ -32,7 +31,7 @@ public class WordPressComSiteInfo {
     /// URL of the Site's Blavatar.
     ///
     public let icon: String
-    
+
     /// Indicates whether the site is WordPressDotCom, or not.
     ///
     public let isWPCom: Bool
@@ -44,8 +43,6 @@ public class WordPressComSiteInfo {
     /// Inidcates whether the site exists, or not.
     ///
     public let exists: Bool
-
-
 
     /// Initializes the current SiteInfo instance with a raw dictionary.
     ///

--- a/WordPressAuthenticator/NUX/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/NUXButton.swift
@@ -30,7 +30,7 @@ import WordPressKit
     }()
 
     var titleFont = WPStyleGuide.mediumWeightFont(forStyle: .title3)
-    
+
     override open func layoutSubviews() {
         super.layoutSubviews()
 
@@ -49,15 +49,13 @@ import WordPressKit
         super.tintColorDidChange()
         configureBackgrounds()
         configureTitleColors()
-        
+
         if socialService == .apple {
             setAttributedTitle(WPStyleGuide.formattedAppleString(), for: .normal)
         }
     }
 
-
     // MARK: - Instance Methods
-
 
     /// Toggles the visibility of the activity indicator.  When visible the button
     /// title is hidden.
@@ -76,7 +74,7 @@ import WordPressKit
     func didChangePreferredContentSize() {
         titleLabel?.adjustsFontForContentSizeCategory = true
     }
-    
+
     func customizeFont(_ font: UIFont) {
         titleFont = font
     }

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -41,7 +41,7 @@ open class NUXButtonViewController: UIViewController {
     @IBOutlet var tertiaryButton: NUXButton?
     @IBOutlet var buttonHolder: UIView?
 
-    open var delegate: NUXButtonViewControllerDelegate?
+    open weak var delegate: NUXButtonViewControllerDelegate?
     open var backgroundColor: UIColor?
 
     private var topButtonConfig: NUXButtonConfig?
@@ -65,13 +65,13 @@ open class NUXButtonViewController: UIViewController {
         configure(button: bottomButton, withConfig: bottomButtonConfig)
         configure(button: topButton, withConfig: topButtonConfig)
         configure(button: tertiaryButton, withConfig: tertiaryButtonConfig)
-        
+
         buttonHolder?.backgroundColor = backgroundColor
     }
 
     private func configure(button: NUXButton?, withConfig buttonConfig: NUXButtonConfig?) {
         if let buttonConfig = buttonConfig, let button = button {
-            
+
             if let attributedTitle = buttonConfig.attributedTitle {
                 button.setAttributedTitle(attributedTitle, for: .normal)
                 button.socialService = buttonConfig.socialService
@@ -120,7 +120,7 @@ open class NUXButtonViewController: UIViewController {
     func setupTopButtonFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) {
         topButtonConfig = buttonConfigFor(socialService: socialService, onTap: callback)
     }
-    
+
     func setupBottomButton(title: String, isPrimary: Bool = false, configureBodyFontForTitle: Bool = false, accessibilityIdentifier: String? = nil, onTap callback: @escaping CallBackType) {
         bottomButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, configureBodyFontForTitle: configureBodyFontForTitle, accessibilityIdentifier: accessibilityIdentifier, callback: callback)
     }

--- a/WordPressAuthenticator/NUX/NUXKeyboardResponder.swift
+++ b/WordPressAuthenticator/NUX/NUXKeyboardResponder.swift
@@ -34,14 +34,12 @@ public extension NUXKeyboardResponder where Self: NUXViewController {
         NotificationCenter.default.addObserver(self, selector: keyboardWillHideAction, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
-
     /// Unregisters the receiver from keyboard events.
     ///
     func unregisterForKeyboardEvents() {
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
-
 
     /// Returns the vertical offset to apply to the sign in form.
     ///
@@ -50,7 +48,6 @@ public extension NUXKeyboardResponder where Self: NUXViewController {
     func signinFormVerticalOffset() -> CGFloat {
         return NUXKeyboardDefaultFormVerticalOffset
     }
-
 
     /// Adjusts constraint constants to adapt the view for a visible keyboard.
     ///
@@ -65,7 +62,6 @@ public extension NUXKeyboardResponder where Self: NUXViewController {
             verticalCenterConstraint?.constant = signinFormVerticalOffset()
         }
     }
-
 
     /// Process the passed NSNotification from a UIKeyboardWillShowNotification.
     ///
@@ -93,7 +89,6 @@ public extension NUXKeyboardResponder where Self: NUXViewController {
                        completion: nil)
     }
 
-
     /// Process the passed NSNotification from a UIKeyboardWillHideNotification.
     ///
     /// - Parameter notification: the NSNotification object from a UIKeyboardWillHideNotification.
@@ -119,7 +114,6 @@ public extension NUXKeyboardResponder where Self: NUXViewController {
                        completion: nil)
     }
 
-
     /// Retrieves the keyboard frame and the animation duration from a keyboard
     /// notificaiton.
     ///
@@ -137,7 +131,6 @@ public extension NUXKeyboardResponder where Self: NUXViewController {
         }
         return (keyboardFrame: frame, animationDuration: duration)
     }
-
 
     func heightDeltaFromKeyboardFrame(_ keyboardFrame: CGRect) -> CGFloat {
         // If an external keyboard is connected, the ending keyboard frame's maxY

--- a/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
@@ -9,7 +9,7 @@ import WordPressShared
 ///
 class NUXLinkAuthViewController: LoginViewController {
     @IBOutlet weak var statusLabel: UILabel?
-    
+
     enum Flow {
         case signup
         case login
@@ -22,14 +22,14 @@ class NUXLinkAuthViewController: LoginViewController {
     override func configureStatusLabel(_ message: String) {
         statusLabel?.text = message
     }
-    
+
     func syncAndContinue(authToken: String, flow: Flow, isJetpackConnect: Bool) {
         let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackConnect, multifactor: false, siteURL: "https://wordpress.com")
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
-        
+
         syncWPComAndPresentEpilogue(credentials: credentials) {
             self.tracker.track(step: .success)
-            
+
             switch flow {
             case .signup:
                 // This stat is part of a funnel that provides critical information.  Before

--- a/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import WordPressShared
 
-
 /// Step two in the auth link flow. This VC prompts the user to open their email
 /// app to look for the emailed authentication link.
 ///
@@ -20,8 +19,6 @@ class NUXLinkMailViewController: LoginViewController {
             return .loginMagicLink
         }
     }
-
-
 
     // MARK: - Lifecycle Methods
 

--- a/WordPressAuthenticator/NUX/NUXNavigationController.swift
+++ b/WordPressAuthenticator/NUX/NUXNavigationController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import WordPressUI
 
-
 /// Simple subclass of UINavigationController to facilitate a customized
 /// appearance as part of the sign in flow.
 ///

--- a/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -1,6 +1,5 @@
 import WordPressUI
 
-
 // MARK: - NUXViewController
 /// Base class to use for NUX view controllers that aren't a table view
 /// Note: shares most of its code with NUXTableViewController. Look to make
@@ -46,7 +45,7 @@ open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewCon
         submitButton?.setTitle(primaryTitle, for: .highlighted)
         submitButton?.accessibilityIdentifier = "Continue Button"
     }
-    
+
     open func enableSubmit(animating: Bool) -> Bool {
         return !animating
     }

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -3,7 +3,7 @@ import WordPressUI
 
 private enum Constants {
     static let helpButtonInsets = UIEdgeInsets(top: 0.0, left: 5.0, bottom: 0.0, right: 5.0)
-    //Button Item: Custom view wrapping the Help UIbutton
+    // Button Item: Custom view wrapping the Help UIbutton
     static let helpButtonItemMarginSpace = CGFloat(-8)
     static let helpButtonItemMinimumSize = CGSize(width: 44.0, height: 44.0)
 
@@ -54,7 +54,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         }
 
         let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: nil, action: nil)
-        cancelButton.on() { [weak self] (control: UIBarButtonItem) in
+        cancelButton.on { [weak self] (_: UIBarButtonItem) in
             self?.handleCancelButtonTapped()
         }
         navigationItem.leftBarButtonItem = cancelButton
@@ -120,7 +120,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
     func setupBackgroundTapGestureRecognizer() {
         let tgr = UITapGestureRecognizer()
-        tgr.on() { [weak self] gestureRecognizer in
+        tgr.on { [weak self] _ in
             self?.handleBackgroundTapGesture()
         }
         view.addGestureRecognizer(tgr)
@@ -135,10 +135,9 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
     //
     func handleHelpButtonTapped(_ sender: AnyObject) {
         AuthenticatorAnalyticsTracker.shared.track(click: .showHelp)
-        
+
         displaySupportViewController(from: sourceTag)
     }
-
 
     // MARK: - Navbar Help and App Logo methods
 
@@ -147,7 +146,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         var buttonTextColor: UIColor
         var titleTextColor: UIColor
         var hideBottomBorder: Bool
-        
+
         if forUnified {
             // Unified nav bar style
             backgroundColor = WordPressAuthenticator.shared.unifiedStyle?.navBarBackgroundColor ??
@@ -167,17 +166,17 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
         setupNavBarIcon(showIcon: !forUnified)
         setHelpButtonTextColor(forUnified: forUnified)
-        
+
         let buttonItemAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [LoginNavigationController.self])
         buttonItemAppearance.tintColor = buttonTextColor
         buttonItemAppearance.setTitleTextAttributes([.foregroundColor: buttonTextColor], for: .normal)
-        
+
         if #available(iOS 13.0, *) {
             let appearance = UINavigationBarAppearance()
             appearance.shadowColor = hideBottomBorder ? .clear : .separator
             appearance.backgroundColor = backgroundColor
             appearance.titleTextAttributes = [.foregroundColor: titleTextColor]
-            
+
             UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).standardAppearance = appearance
             UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).compactAppearance = appearance
             UINavigationBar.appearance(whenContainedInInstancesOf: [LoginNavigationController.self]).scrollEdgeAppearance = appearance
@@ -187,13 +186,13 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             appearance.titleTextAttributes = [.foregroundColor: titleTextColor]
         }
     }
-    
+
     /// Add/remove the nav bar app logo.
     ///
     func setupNavBarIcon(showIcon: Bool = true) {
         showIcon ? addAppLogoToNavController() : removeAppLogoFromNavController()
     }
-    
+
     /// Adds the app logo to the nav controller
     ///
     public func addAppLogoToNavController() {
@@ -207,7 +206,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
     public func removeAppLogoFromNavController() {
         navigationItem.titleView = nil
     }
-    
+
     /// Whenever the WordPressAuthenticator Delegate returns true, when `shouldDisplayHelpButton` is queried, we'll proceed
     /// and attach the Help Button to the navigationController.
     ///
@@ -232,7 +231,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             }
             return WordPressAuthenticator.shared.style.navButtonTextColor
         }()
-        
+
         helpButton.setTitleColor(navButtonTextColor, for: .normal)
         helpButton.setTitleColor(navButtonTextColor.withAlphaComponent(0.4), for: .highlighted)
     }
@@ -268,7 +267,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
     private func addHelpButton(to superView: UIView) {
         helpButton.setTitle(NSLocalizedString("Help", comment: "Help button"), for: .normal)
         setHelpButtonTextColor(forUnified: false)
-        
+
         helpButton.on(.touchUpInside) { [weak self] control in
             self?.handleHelpButtonTapped(control)
         }
@@ -315,7 +314,6 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             view.heightAnchor.constraint(equalToConstant: Constants.notificationIndicatorSize.height)
             ])
     }
-
 
     // MARK: - UIViewControllerTransitioningDelegate
 

--- a/WordPressAuthenticator/NUX/WPHelpIndicatorView.swift
+++ b/WordPressAuthenticator/NUX/WPHelpIndicatorView.swift
@@ -7,22 +7,22 @@ open class WPHelpIndicatorView: UIView {
         static let defaultInsets = UIEdgeInsets.zero
         static let defaultBackgroundColor = WordPressAuthenticator.shared.style.navBarBadgeColor
     }
-    
+
     var insets: UIEdgeInsets = Constants.defaultInsets {
         didSet {
             setNeedsDisplay()
         }
     }
-    
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
         commonSetup()
     }
-    
+
     public required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func commonSetup() {
         layer.masksToBounds = true
         layer.cornerRadius = 6.0

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -9,7 +9,6 @@ public struct NavigateToEnterAccount: NavigationCommand {
     }
 }
 
-
 private extension NavigateToEnterAccount {
     private func continueWithDotCom(navigationController: UINavigationController?) {
         guard let vc = GetStartedViewController.instantiate(from: .getStarted) else {

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
@@ -1,6 +1,4 @@
-
 import Foundation
-
 
 /// Navigates to the unified site address login flow.
 ///

--- a/WordPressAuthenticator/Navigation/NavigateToRoot.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToRoot.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Navigates to the root of the unified login flow.
 ///
 public struct NavigateToRoot: NavigationCommand {

--- a/WordPressAuthenticator/Navigation/NavigationCommand.swift
+++ b/WordPressAuthenticator/Navigation/NavigationCommand.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 /// NavigationCommand abstracts logic necessary provide clients of this library

--- a/WordPressAuthenticator/Services/LoginFacade.swift
+++ b/WordPressAuthenticator/Services/LoginFacade.swift
@@ -4,16 +4,16 @@ extension LoginFacade {
     private var tracker: AuthenticatorAnalyticsTracker {
         AuthenticatorAnalyticsTracker.shared
     }
-    
+
     func requestOneTimeCode(with loginFields: LoginFields) {
         wordpressComOAuthClientFacade.requestOneTimeCode(
-            withUsername: loginFields.username, 
+            withUsername: loginFields.username,
             password: loginFields.password,
             success: { [weak self] in
                 guard let self = self else {
                     return
                 }
-                
+
                 if self.tracker.shouldUseLegacyTracker() {
                     WordPressAuthenticator.track(.twoFactorSentSMS)
                 }
@@ -26,7 +26,7 @@ extension LoginFacade {
         guard let nonce = loginFields.nonceInfo?.nonceSMS else {
             return
         }
-        
+
         wordpressComOAuthClientFacade.requestSocial2FACode(
             withUserID: loginFields.nonceUserID,
             nonce: nonce,
@@ -34,22 +34,22 @@ extension LoginFacade {
                 guard let self = self else {
                     return
                 }
-                
+
                 if let newNonce = newNonce {
                     loginFields.nonceInfo?.nonceSMS = newNonce
                 }
-            
+
                 if self.tracker.shouldUseLegacyTracker() {
                     WordPressAuthenticator.track(.twoFactorSentSMS)
                 }
-        }) { (error, newNonce) in
+        }) { (_, newNonce) in
             if let newNonce = newNonce {
                 loginFields.nonceInfo?.nonceSMS = newNonce
             }
-            DDLogError("Failed to request one time code");
+            DDLogError("Failed to request one time code")
         }
     }
-    
+
     @objc
     public func trackSuccess() {
         tracker.track(step: .success)

--- a/WordPressAuthenticator/Services/OnePasswordFacade.swift
+++ b/WordPressAuthenticator/Services/OnePasswordFacade.swift
@@ -2,8 +2,6 @@ import Foundation
 import UIKit
 import OnePasswordExtension
 
-
-
 // MARK: - This protocol is a Facade that hides some of the implementation details for interacting with 1Password.
 //
 class OnePasswordFacade {
@@ -124,7 +122,6 @@ enum OnePasswordDefaults {
     ///
     static let passwordTitle = "WordPress"
 }
-
 
 // MARK: - OnePasswordError
 //

--- a/WordPressAuthenticator/Services/OnePasswordResultsFetcher.swift
+++ b/WordPressAuthenticator/Services/OnePasswordResultsFetcher.swift
@@ -5,4 +5,3 @@ protocol OnePasswordResultsFetcher {
                    success: @escaping (_ username: String, _ password: String, _ otp: String?) -> Void,
                    failure: @escaping (OnePasswordError) -> Void)
 }
-

--- a/WordPressAuthenticator/Services/SafariCredentialsService.swift
+++ b/WordPressAuthenticator/Services/SafariCredentialsService.swift
@@ -3,8 +3,7 @@
 class SafariCredentialsService {
 
     @objc static let LoginSharedWebCredentialFQDN: CFString = "wordpress.com" as CFString
-    typealias SharedWebCredentialsCallback = (_ credentialsFound: Bool, _ username: String?, _ password: String?) -> ()
-
+    typealias SharedWebCredentialsCallback = (_ credentialsFound: Bool, _ username: String?, _ password: String?) -> Void
 
     /// Update safari stored credentials.
     ///

--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -3,7 +3,6 @@ import CocoaLumberjack
 import WordPressShared
 import WordPressKit
 
-
 /// SignupService: Responsible for creating a new WPCom user and blog.
 ///
 class SignupService {
@@ -38,7 +37,7 @@ class SignupService {
             failure(error ?? SignupError.unknown)
         })
     }
-    
+
     /// Create a new WPcom account using Apple ID
     ///
     /// - Parameters:
@@ -58,7 +57,7 @@ class SignupService {
                                                     _ wpcomToken: String) -> Void,
                                   failure: @escaping (_ error: Error) -> Void) {
         let remote = WordPressComServiceRemote(wordPressComRestApi: anonymousAPI)
-        
+
         remote.createWPComAccount(withApple: token,
                                   andEmail: email,
                                   andFullName: fullName,
@@ -70,7 +69,7 @@ class SignupService {
                                             failure(SignupError.unknown)
                                             return
                                     }
-                                    
+
                                     let createdAccount = (response?[ResponseKeys.createdAccount] as? Int ?? 0) == 1
                                     success(createdAccount, false, false, username, bearer_token)
         }, failure: { error in
@@ -82,7 +81,7 @@ class SignupService {
                 }
 
                 if (error.userInfo[ErrorKeys.errorCode] as? String ?? "") == ErrorKeys.existingNonSocialUser {
-                    
+
                     // If an account already exists, the account email should be returned in the Error response.
                     // Extract it and return it.
                     var existingEmail = ""
@@ -91,7 +90,7 @@ class SignupService {
                         let email = emailDict?.value ?? ""
                         existingEmail = email
                     }
-                    
+
                     success(false, true, false, existingEmail, "")
                     return
                 }
@@ -100,9 +99,8 @@ class SignupService {
             failure(error ?? SignupError.unknown)
         })
     }
-    
-}
 
+}
 
 // MARK: - Private
 //
@@ -130,7 +128,6 @@ private extension SignupService {
         static let twoFactorEnabled = "2FA_enabled"
     }
 }
-
 
 // MARK: - Errors
 //

--- a/WordPressAuthenticator/Services/SocialService.swift
+++ b/WordPressAuthenticator/Services/SocialService.swift
@@ -7,7 +7,7 @@ public enum SocialService {
     /// Google's Signup Linked Account
     ///
     case google(user: GIDGoogleUser)
-    
+
     /// Apple's Signup Linked Account
     ///
     case apple(user: AppleUser)

--- a/WordPressAuthenticator/Services/WordPressComAccountService.swift
+++ b/WordPressAuthenticator/Services/WordPressComAccountService.swift
@@ -1,7 +1,6 @@
 import Foundation
 import WordPressKit
 
-
 // MARK: - WordPressComAccountService
 //
 class WordPressComAccountService {
@@ -24,7 +23,7 @@ class WordPressComAccountService {
     func connect(wpcomAuthToken: String,
                  serviceName: SocialServiceName,
                  serviceToken: String,
-                 connectParameters: [String:AnyObject]? = nil,
+                 connectParameters: [String: AnyObject]? = nil,
                  success: @escaping () -> Void,
                  failure: @escaping (Error) -> Void) {
         let loggedAPI  = WordPressComRestApi(oAuthToken: wpcomAuthToken,
@@ -47,7 +46,7 @@ class WordPressComAccountService {
     ///
     func requestAuthenticationLink(for email: String, jetpackLogin: Bool, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let remote = AccountServiceRemoteREST(wordPressComRestApi: anonymousAPI)
-        
+
         remote.requestWPComAuthLink(forEmail: email,
                                     clientID: configuration.wpcomClientId,
                                     clientSecret: configuration.wpcomSecret,
@@ -90,7 +89,6 @@ class WordPressComAccountService {
         return WordPressAuthenticator.shared.configuration
     }
 }
-
 
 // MARK: - Nested Types
 //

--- a/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -1,7 +1,6 @@
 import Foundation
 import WordPressKit
 
-
 // MARK: - WordPress.com BlogService
 //
 class WordPressComBlogService {
@@ -13,7 +12,6 @@ class WordPressComBlogService {
         let baseUrl = WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL
         return WordPressComRestApi(oAuthToken: nil, userAgent: userAgent, baseUrlString: baseUrl)
     }
-
 
     /// Retrieves the WordPressComSiteInfo instance associated to a WordPress.com Site Address.
     ///
@@ -34,7 +32,7 @@ class WordPressComBlogService {
             failure(result)
         })
     }
-    
+
      func fetchUnauthenticatedSiteInfoForAddress(for address: String, success: @escaping (WordPressComSiteInfo) -> Void, failure: @escaping (Error) -> Void) {
         let remote = BlogServiceRemoteREST(wordPressComRestApi: anonymousAPI, siteID: 0)
         remote.fetchUnauthenticatedSiteInfo(forAddress: address, success: { response in
@@ -42,16 +40,15 @@ class WordPressComBlogService {
                 failure(ServiceError.unknown)
                 return
             }
-            
+
             let site = WordPressComSiteInfo(remote: response)
             success(site)
         }, failure: { error in
             let result = error ?? ServiceError.unknown
             failure(result)
-        }) 
+        })
     }
 }
-
 
 // MARK: - Nested Types
 //

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -27,7 +27,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
 
     // MARK: - Lifecycle Methods
 
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -43,7 +42,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         styleSendCodeButton()
     }
 
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -57,7 +55,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         WordPressAuthenticator.track(.loginTwoFactorFormViewed)
     }
 
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
@@ -69,8 +66,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         verificationCodeField.text = ""
     }
 
-
-    /// MARK: Dynamic Type
+    // MARK: Dynamic Type
     override func didChangePreferredContentSize() {
         super.didChangePreferredContentSize()
         styleSendCodeButton()
@@ -83,7 +79,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
     }
 
     // MARK: Configuration Methods
-
 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
@@ -128,7 +123,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         )
     }
 
-
     /// Configure the view's loading state.
     ///
     /// - Parameter loading: True if the form should be configured to a "loading" state.
@@ -139,7 +133,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         configureSubmitButton(animating: loading)
         navigationItem.hidesBackButton = loading
     }
-
 
     /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
@@ -152,9 +145,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         }
     }
 
-
     // MARK: - Instance Methods
-
 
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action.
@@ -185,7 +176,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         // consult with your lead before removing this event.
         WordPressAuthenticator.track(.signedIn)
 
-        var properties = [AnyHashable:Any]()
+        var properties = [AnyHashable: Any]()
         if let service = loginFields.meta.socialService?.rawValue {
             properties["source"] = service
         }
@@ -255,17 +246,15 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         validateForm()
     }
 
-
     @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {
         tracker.track(click: .submit)
-        
+
         validateForm()
     }
 
-
     @IBAction func handleSendVerificationButtonTapped(_ sender: UIButton) {
         self.tracker.track(click: .sendCodeWithText)
-        
+
         let message = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
         SVProgressHUD.showSuccess(withStatus: message)
         SVProgressHUD.dismiss(withDelay: Constants.headsUpDismissDelay)
@@ -278,15 +267,11 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         }
     }
 
-
-
     // MARK: - Handle application state changes.
-
 
     @objc func applicationBecameInactive() {
         pasteboardChangeCountBeforeBackground = UIPasteboard.general.changeCount
     }
-
 
     @objc func applicationBecameActive() {
         let emptyField = verificationCodeField.text?.isEmpty ?? true
@@ -296,7 +281,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         }
 
         if #available(iOS 14.0, *) {
-            UIPasteboard.general.detectAuthenticatorCode() { [weak self] result in
+            UIPasteboard.general.detectAuthenticatorCode { [weak self] result in
                 switch result {
                     case .success(let authenticatorCode):
                         self?.handle(code: authenticatorCode)
@@ -322,20 +307,16 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         }
     }
 
-
     // MARK: - Keyboard Notifications
-
 
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
         keyboardWillShow(notification)
     }
 
-
     @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
         keyboardWillHide(notification)
     }
 }
-
 
 extension Login2FAViewController {
 

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import WordPressShared
 import WordPressKit
 
-
 /// This is the first screen following the log in prologue screen if the user chooses to log in.
 ///
 open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
@@ -35,9 +34,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         static let keyboardThreshold: CGFloat = 100.0
     }
 
-
     // MARK: Lifecycle Methods
-
 
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -88,7 +85,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         errorToPresent = nil
     }
 
-
     override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
@@ -108,9 +104,8 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         navigationController?.pushViewController(vc, animated: true)
     }
-    
-    // MARK: - Setup and Configuration
 
+    // MARK: - Setup and Configuration
 
     /// Hides the self-hosted login option.
     ///
@@ -118,7 +113,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         wpcomSignupButton?.isHidden = !offerSignupOption
         selfHostedLoginButton?.isHidden = loginFields.restrictToWPCom
     }
-
 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
@@ -138,7 +132,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         submitButton?.setTitle(submitButtonTitle, for: .highlighted)
         submitButton?.accessibilityIdentifier = "Login Email Next Button"
     }
-
 
     /// Sets up a 1Password button if 1Password is available.
     ///
@@ -162,7 +155,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
-            button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor),
+            button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
             ])
 
         googleLoginButton = button
@@ -182,7 +175,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
-            button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor),
+            button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
             ])
 
         selfHostedLoginButton = button
@@ -203,7 +196,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         // Tapping the Sign up text link in "Don't have an account? _Sign up_"
         // will present the 3 button view for signing up.
-        button.on(.touchUpInside) { [weak self] (button) in
+        button.on(.touchUpInside) { [weak self] (_) in
             guard let vc = LoginPrologueSignupMethodViewController.instantiate(from: .login) else {
                 DDLogError("Failed to navigate to LoginPrologueSignupMethodViewController")
                 return
@@ -230,9 +223,9 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
                 guard let self = self else {
                     return
                 }
-                
+
                 self.tracker.track(click: .signupWithGoogle)
-                
+
                 guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
                     self.presentGoogleSignupView()
                     return
@@ -250,7 +243,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
-            button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor),
+            button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
             ])
 
         wpcomSignupButton = button
@@ -277,7 +270,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         submitButton?.isEnabled = canSubmit()
     }
 
-
     /// Sets the view's state to loading or not loading.
     ///
     /// - Parameter loading: True if the form should be configured to a "loading" state.
@@ -290,7 +282,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         submitButton?.showActivityIndicator(loading)
     }
 
-
     /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
     ///
@@ -302,9 +293,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-
     // MARK: - Instance Methods
-
 
     /// Makes the call to retrieve Safari shared credentials if they exist.
     ///
@@ -314,7 +303,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             self?.handleFetchedWebCredentials(found, username: username, password: password)
         }
     }
-
 
     /// Handles Safari shared credentials if any where found.
     ///
@@ -341,7 +329,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         WordPressAuthenticator.track(.loginAutoFillCredentialsFilled)
     }
-
 
     /// Displays the wpcom sign in form, optionally telling it to immedately make
     /// the call to authenticate with the available credentials.
@@ -382,7 +369,6 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         navigationController?.pushViewController(vc, animated: true)
     }
-
 
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action. Empties loginFields.meta.socialService as
@@ -468,18 +454,15 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     // MARK: - Actions
 
-
     @IBAction func handleSubmitForm() {
         if canSubmit() {
             validateForm()
         }
     }
 
-
     @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {
         validateForm()
     }
-
 
     @objc func handleOnePasswordButtonTapped(_ sender: UIButton) {
         view.endEditing(true)
@@ -501,7 +484,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     @objc func googleTapped() {
         self.tracker.track(click: .loginWithGoogle)
-        
+
         guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             GoogleAuthenticator.sharedInstance.loginDelegate = self
             GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
@@ -517,7 +500,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             DDLogError("Failed to navigate to GoogleAuthViewController from LoginPrologueVC")
             return
         }
-        
+
         navigationController?.pushViewController(toVC, animated: true)
     }
 
@@ -543,23 +526,19 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-
     @IBAction func handleTextFieldEditingDidBegin(_ sender: UITextField) {
         if !didRequestSafariSharedCredentials {
             fetchSharedWebCredentialsIfAvailable()
         }
     }
 
-
     // MARK: - Keyboard Notifications
-
 
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
         keyboardWillShow(notification)
 
         adjustAlternativeLogInElementsVisibility(true)
     }
-
 
     @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
         keyboardWillHide(notification)
@@ -629,7 +608,7 @@ extension LoginEmailViewController: GoogleAuthenticatorLoginDelegate {
     func googleNeedsMultifactorCode(loginFields: LoginFields) {
         self.loginFields = loginFields
         configureViewLoading(false)
-        
+
         guard let vc = Login2FAViewController.instantiate(from: .login) else {
             DDLogError("Failed to navigate from LoginViewController to Login2FAViewController")
             return
@@ -645,7 +624,7 @@ extension LoginEmailViewController: GoogleAuthenticatorLoginDelegate {
     func googleExistingUserNeedsConnection(loginFields: LoginFields) {
         self.loginFields = loginFields
         configureViewLoading(false)
-        
+
         guard let vc = LoginWPComViewController.instantiate(from: .login) else {
             DDLogError("Failed to navigate from Google Login to LoginWPComViewController (password VC)")
             return

--- a/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import CocoaLumberjack
 import WordPressShared
 
-
 /// Step one in the auth link flow. This VC displays a form to request a "magic"
 /// authentication link be emailed to the user.  Allows the user to signin via
 /// email instead of their password.
@@ -17,7 +16,6 @@ class LoginLinkRequestViewController: LoginViewController {
             return .loginMagicLink
         }
     }
-
 
     // MARK: - Lifecycle Methods
 
@@ -86,7 +84,6 @@ class LoginLinkRequestViewController: LoginViewController {
         WPStyleGuide.configureTextButton(usePasswordButton)
     }
 
-
     // MARK: - Instance Methods
 
     /// Makes the call to request a magic authentication link be emailed to the user.
@@ -132,7 +129,6 @@ class LoginLinkRequestViewController: LoginViewController {
     }
 
     // MARK: - Actions
-
 
     @IBAction func handleUsePasswordTapped(_ sender: UIButton) {
         guard let vc = LoginWPComViewController.instantiate(from: .login) else {

--- a/WordPressAuthenticator/Signin/LoginNavigationController.swift
+++ b/WordPressAuthenticator/Signin/LoginNavigationController.swift
@@ -2,7 +2,6 @@ import UIKit
 import WordPressShared
 import WordPressUI
 
-
 public class LoginNavigationController: RotationAwareNavigationViewController {
 
     public override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -13,7 +12,7 @@ public class LoginNavigationController: RotationAwareNavigationViewController {
         // By default, the back button label uses the previous view's title.
         // To override that, reset the label when pushing a new view controller.
         self.viewControllers.last?.navigationItem.backBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Back", comment: "Back button title."), style: .plain, target: nil, action: nil)
-        
+
         super.pushViewController(viewController, animated: animated)
     }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -1,7 +1,6 @@
 import WordPressUI
 import WordPressShared
 
-
 /// This class houses the "3 button view":
 /// Continue with WordPress.com, Continue with Google, Continue with Apple
 /// and a text link - Or log in by entering your site address.
@@ -21,7 +20,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     private var tracker: AuthenticatorAnalyticsTracker {
         AuthenticatorAnalyticsTracker.shared
     }
-    
+
     /// The big transparent (dismiss) button behind the buttons
     @IBOutlet private weak var dismissButton: UIButton!
 
@@ -48,14 +47,14 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
         guard let buttonViewController = buttonViewController else {
             return
         }
-        
+
         let wordpressTitle = NSLocalizedString("Log in or sign up with WordPress.com", comment: "Button title. Tapping begins our normal log in process.")
         buttonViewController.setupTopButton(title: wordpressTitle, isPrimary: false, accessibilityIdentifier: "Log in with Email Button") { [weak self] in
-            
+
             guard let self = self else {
                 return
             }
-            
+
             self.tracker.set(flow: .wpCom)
             self.dismiss(animated: true)
             self.emailTapped?()
@@ -84,10 +83,10 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
 
     @IBAction func handleSelfHostedButtonTapped(_ sender: UIButton) {
         dismiss(animated: true)
-        
+
         tracker.set(flow: .loginWithSiteAddress)
         tracker.track(click: .loginWithSiteAddress)
-        
+
         selfHostedTapped?()
     }
 
@@ -96,7 +95,7 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
         tracker.track(click: .loginWithApple, ifTrackingNotEnabled: {
             WordPressAuthenticator.track(.loginSocialButtonClick, properties: ["source": "apple"])
         })
-        
+
         dismiss(animated: true)
         appleTapped?()
     }
@@ -104,11 +103,11 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     @objc func handleGoogleButtonTapped() {
         tracker.set(flow: .loginWithGoogle)
         tracker.track(click: .loginWithGoogle)
-        
+
         dismiss(animated: true)
         googleTapped?()
     }
-    
+
     // MARK: - Accessibility
 
     private func configureForAccessibility() {

--- a/WordPressAuthenticator/Signin/LoginProloguePageViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginProloguePageViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import WordPressShared
 
-
 class LoginProloguePageViewController: UIPageViewController {
     @objc var pages: [UIViewController] = []
     fileprivate var pageControl: UIPageControl?
@@ -46,7 +45,6 @@ class LoginProloguePageViewController: UIPageViewController {
         newControl.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
         newControl.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
         newControl.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: Constants.pagerHeight).isActive = true
-
 
         newControl.numberOfPages = pages.count
         newControl.addTarget(self, action: #selector(handlePageControlValueChanged(sender:)), for: .valueChanged)

--- a/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginProloguePromoViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import Lottie
 import WordPressShared
 
-
 class LoginProloguePromoViewController: UIViewController {
     fileprivate let type: PromoType
     fileprivate let stackView: UIStackView
@@ -134,7 +133,6 @@ class LoginProloguePromoViewController: UIViewController {
             headingLabel.sizeToFit()
         }
     }
-
 
     // MARK: layout
 

--- a/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -2,7 +2,6 @@ import SafariServices
 import WordPressUI
 import WordPressShared
 
-
 class LoginPrologueSignupMethodViewController: NUXViewController {
     /// Buttons at bottom of screen
     private var buttonViewController: NUXButtonViewController?
@@ -13,7 +12,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
     open var emailTapped: (() -> Void)?
     open var googleTapped: (() -> Void)?
     open var appleTapped: (() -> Void)?
-    
+
     private var tracker: AuthenticatorAnalyticsTracker {
         AuthenticatorAnalyticsTracker.shared
     }
@@ -47,9 +46,9 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
 
         let loginTitle = NSLocalizedString("Sign up with Email", comment: "Button title. Tapping begins our normal sign up process.")
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Sign up with Email Button") { [weak self] in
-            
+
             self?.tracker.set(flow: .wpCom)
-            
+
             defer {
                 WordPressAuthenticator.track(.signupEmailButtonTapped)
             }
@@ -60,7 +59,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         buttonViewController.setupButtomButtonFor(socialService: .google, onTap: handleGoogleButtonTapped)
 
         let termsButton = WPStyleGuide.termsButton()
-        termsButton.on(.touchUpInside) { [weak self] button in
+        termsButton.on(.touchUpInside) { [weak self] _ in
             defer {
                 self?.tracker.track(click: .termsOfService, ifTrackingNotEnabled: {
                     WordPressAuthenticator.track(.signupTermsButtonTapped)
@@ -94,7 +93,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         tracker.track(click: .signupWithApple, ifTrackingNotEnabled: {
             WordPressAuthenticator.track(.signupSocialButtonTapped, properties: ["source": "apple"])
         })
-        
+
         dismiss(animated: true)
         appleTapped?()
     }
@@ -108,7 +107,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
         dismiss(animated: true)
         googleTapped?()
     }
-    
+
     private func trackCancellationAndThenDismiss() {
         WordPressAuthenticator.track(.signupCancelled)
         dismiss(animated: true)

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -59,7 +59,7 @@ class LoginPrologueViewController: LoginViewController {
             topContainerChildViewController.view.translatesAutoresizingMaskIntoConstraints = false
             topContainerView.pinSubviewToAllEdges(topContainerChildViewController.view)
         }
-        
+
         defaultButtonViewMargin = buttonViewLeadingConstraint?.constant ?? 0
     }
 
@@ -68,20 +68,20 @@ class LoginPrologueViewController: LoginViewController {
             super.styleBackground()
             return
         }
-        
+
         view.backgroundColor = unifiedBackgroundColor
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         configureButtonVC()
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         // We've found some instances where the iCloud Keychain login flow was being started
         // when the device was idle and the app was logged out and in the background.  I couldn't
         // find precise reproduction steps for this issue but my guess is that some background
@@ -93,7 +93,7 @@ class LoginPrologueViewController: LoginViewController {
         guard UIApplication.shared.applicationState != .background else {
             return
         }
-        
+
         WordPressAuthenticator.track(.loginPrologueViewed)
 
         tracker.set(flow: .prologue)
@@ -104,7 +104,7 @@ class LoginPrologueViewController: LoginViewController {
         } else {
             tracker.set(step: .prologue)
         }
-        
+
         showiCloudKeychainLoginFlow()
     }
 
@@ -117,19 +117,19 @@ class LoginPrologueViewController: LoginViewController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UIDevice.isPad() ? .all : .portrait
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         setButtonViewMargins(forWidth: view.frame.width)
     }
-    
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         setButtonViewMargins(forWidth: size.width)
     }
-    
+
     // MARK: - iCloud Keychain Login
-    
+
     /// Starts the iCloud Keychain login flow if the conditions are given.
     ///
     private func showiCloudKeychainLoginFlow() {
@@ -199,15 +199,15 @@ class LoginPrologueViewController: LoginViewController {
         let displayStrings = WordPressAuthenticator.shared.displayStrings
         let loginTitle = displayStrings.continueWithWPButtonTitle
         let siteAddressTitle = displayStrings.enterYourSiteAddressButtonTitle
-        
+
         if configuration.continueWithSiteAddressFirst {
             buildUnifiedPrologueButtonsWithSiteAddressFirst(buttonViewController, loginTitle: loginTitle, siteAddressTitle: siteAddressTitle)
             return
         }
-        
+
         buildDefaultUnifiedPrologueButtons(buttonViewController, loginTitle: loginTitle, siteAddressTitle: siteAddressTitle)
     }
-    
+
     private func buildDefaultUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController, loginTitle: String, siteAddressTitle: String) {
 
         setButtonViewMargins(forWidth: view.frame.width)
@@ -222,23 +222,23 @@ class LoginPrologueViewController: LoginViewController {
 
         setButtonViewControllerBackground(buttonViewController)
     }
-    
+
     private func buildUnifiedPrologueButtonsWithSiteAddressFirst(_ buttonViewController: NUXButtonViewController, loginTitle: String, siteAddressTitle: String) {
         guard configuration.enableUnifiedAuth == true else {
             return
         }
-        
+
         setButtonViewMargins(forWidth: view.frame.width)
 
         buttonViewController.setupTopButton(title: siteAddressTitle, isPrimary: true, accessibilityIdentifier: "Prologue Self Hosted Button", onTap: siteAddressTapCallback())
-        
-        buttonViewController.setupBottomButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Continue Button", onTap:loginTapCallback())
-        
+
+        buttonViewController.setupBottomButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Continue Button", onTap: loginTapCallback())
+
         showCancelIfNeccessary(buttonViewController)
 
         setButtonViewControllerBackground(buttonViewController)
     }
-    
+
     private func siteAddressTapCallback() -> NUXButtonViewController.CallBackType {
         return { [weak self] in
             self?.siteAddressTapped()
@@ -250,12 +250,12 @@ class LoginPrologueViewController: LoginViewController {
             guard let self = self else {
                 return
             }
-            
+
             self.tracker.track(click: .continueWithWordPressCom)
             self.continueWithDotCom()
         }
     }
-    
+
     private func showCancelIfNeccessary(_ buttonViewController: NUXButtonViewController) {
         if showCancel {
             let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
@@ -264,7 +264,7 @@ class LoginPrologueViewController: LoginViewController {
             }
         }
     }
-    
+
     private func setButtonViewControllerBackground(_ buttonViewController: NUXButtonViewController) {
         // Fallback to setting the button background color to clear so the blur effect blurs the Prologue background color.
         let buttonsBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.prologueButtonsBackgroundColor ?? .clear
@@ -330,7 +330,7 @@ class LoginPrologueViewController: LoginViewController {
     ///
     private func signupTapped() {
         tracker.set(source: .default)
-        
+
         // This stat is part of a funnel that provides critical information.
         // Before making ANY modification to this stat please refer to: p4qSXL-35X-p2
         WordPressAuthenticator.track(.signupButtonTapped)
@@ -362,7 +362,7 @@ class LoginPrologueViewController: LoginViewController {
             guard let self = self else {
                 return
             }
-            
+
             guard self.configuration.enableUnifiedAuth else {
                 self.presentGoogleSignupView()
                 return
@@ -389,7 +389,7 @@ class LoginPrologueViewController: LoginViewController {
             GoogleAuthenticator.sharedInstance.showFrom(viewController: self, loginFields: loginFields, for: .login)
             return
         }
-        
+
         presentUnifiedGoogleView()
     }
 
@@ -454,7 +454,7 @@ class LoginPrologueViewController: LoginViewController {
             DDLogError("Failed to navigate to GoogleAuthViewController from LoginPrologueVC")
             return
         }
-        
+
         navigationController?.pushViewController(toVC, animated: true)
     }
 
@@ -473,20 +473,20 @@ class LoginPrologueViewController: LoginViewController {
             DDLogError("Failed to navigate from LoginPrologueViewController to LoginWPComViewController")
             return
         }
-        
+
         vc.loginFields = self.loginFields
         vc.dismissBlock = dismissBlock
         vc.errorToPresent = errorToPresent
-        
+
         navigationController?.pushViewController(vc, animated: true)
     }
-    
+
     private func presentUnifiedPassword() {
         guard let vc = PasswordViewController.instantiate(from: .password) else {
             DDLogError("Failed to navigate from LoginPrologueViewController to PasswordViewController")
             return
         }
-        
+
         vc.loginFields = loginFields
         navigationController?.pushViewController(vc, animated: true)
     }
@@ -525,7 +525,7 @@ extension LoginPrologueViewController: AppleAuthenticatorDelegate {
         self.loginFields = loginFields
         signInAppleAccount()
     }
-    
+
     func authFailedWithError(message: String) {
         displayErrorAlert(message, sourceTag: .loginApple)
     }
@@ -592,28 +592,28 @@ private extension LoginPrologueViewController {
     /// Used only in unified views.
     ///
     func setButtonViewMargins(forWidth viewWidth: CGFloat) {
-        
+
         guard configuration.enableUnifiedAuth else {
             return
         }
-        
+
         guard traitCollection.horizontalSizeClass == .regular &&
             traitCollection.verticalSizeClass == .regular else {
                 buttonViewLeadingConstraint?.constant = defaultButtonViewMargin
                 buttonViewTrailingConstraint?.constant = defaultButtonViewMargin
                 return
         }
-        
+
         let marginMultiplier = UIDevice.current.orientation.isLandscape ?
             ButtonViewMarginMultipliers.ipadLandscape :
             ButtonViewMarginMultipliers.ipadPortrait
-        
+
         let margin = viewWidth * marginMultiplier
-        
+
         buttonViewLeadingConstraint?.constant = margin
         buttonViewTrailingConstraint?.constant = margin
     }
-    
+
     private enum ButtonViewMarginMultipliers {
         static let ipadPortrait: CGFloat = 0.1667
         static let ipadLandscape: CGFloat = 0.25

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -26,7 +26,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-
     // MARK: - Lifecycle Methods
 
     override func viewDidLoad() {
@@ -38,7 +37,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         displayLoginMessage("")
         configureForAcessibility()
     }
-
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -53,7 +51,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         setupNavBarIcon()
     }
 
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -63,16 +60,12 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         WordPressAuthenticator.track(.loginUsernamePasswordFormViewed)
     }
 
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
     }
 
-
-
     // MARK: - Setup and Configuration
-
 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
@@ -89,7 +82,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         forgotPasswordButton.setTitle(forgotPasswordTitle, for: .highlighted)
         forgotPasswordButton.titleLabel?.numberOfLines = 0
     }
-
 
     /// Sets up necessary accessibility labels and attributes for the all the UI elements in self.
     ///
@@ -110,7 +102,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         forgotPasswordButton.accessibilityTraits = .link
     }
 
-
     /// Sets up a 1Password button if 1Password is available.
     ///
     @objc func setupOnePasswordButtonIfNeeded() {
@@ -118,7 +109,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
                                                             target: self,
                                                             selector: #selector(handleOnePasswordButtonTapped(_:)))
     }
-
 
     /// Configures the content of the text fields based on what is saved in `loginFields`.
     ///
@@ -129,14 +119,12 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         usernameField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
     }
 
-
     /// Configures the appearance and state of the forgot password button.
     ///
     @objc func configureForgotPasswordButton() {
         forgotPasswordButton.isEnabled = enableSubmit(animating: false)
         WPStyleGuide.configureTextButton(forgotPasswordButton)
     }
-
 
     /// Configures the appearance and state of the submit button.
     ///
@@ -149,7 +137,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
                 !loginFields.password.isEmpty
         )
     }
-
 
     /// Sets the view's state to loading or not loading.
     ///
@@ -164,7 +151,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         navigationItem.hidesBackButton = loading
     }
 
-
     /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
     ///
@@ -176,7 +162,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-
     /// Configure the site header.
     ///
     @objc func configureHeader() {
@@ -186,7 +171,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
             configureSiteAddressHeader()
         }
     }
-
 
     /// Configure the site header to show the BlogDetailsHeaderView
     ///
@@ -200,7 +184,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         siteHeaderView.downloadBlavatar(at: siteInfo.icon)
     }
 
-
     /// Configure the site header to show the site address label.
     ///
     @objc func configureSiteAddressHeader() {
@@ -210,7 +193,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         siteHeaderView.blavatarBorderIsHidden = true
         siteHeaderView.blavatarImage = .linkFieldImage
     }
-
 
     /// Sanitize and format the site address we show to users.
     ///
@@ -222,9 +204,7 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         return siteAddress
     }
 
-
     // MARK: - Instance Methods
-
 
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action.
@@ -232,7 +212,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
     @objc func validateForm() {
         validateFormAndLogin()
     }
-
 
     // MARK: - Actions
 
@@ -244,11 +223,9 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         configureSubmitButton(animating: false)
     }
 
-
     @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {
         validateForm()
     }
-
 
     @objc func handleOnePasswordButtonTapped(_ sender: UIButton) {
         view.endEditing(true)
@@ -267,17 +244,14 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
 
     // MARK: - Keyboard Notifications
 
-
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
         keyboardWillShow(notification)
     }
-
 
     @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
         keyboardWillHide(notification)
     }
 }
-
 
 extension LoginSelfHostedViewController {
 
@@ -297,11 +271,9 @@ extension LoginSelfHostedViewController {
         }
     }
 
-
     func displayLoginMessage(_ message: String) {
         configureForgotPasswordButton()
     }
-
 
     override func displayRemoteError(_ error: Error) {
         displayLoginMessage("")
@@ -316,7 +288,6 @@ extension LoginSelfHostedViewController {
         }
     }
 }
-
 
 extension LoginSelfHostedViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -3,7 +3,6 @@ import WordPressShared
 import WordPressKit
 import WordPressUI
 
-
 class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder {
     @IBOutlet weak var siteURLField: WPWalkthroughTextField!
     @IBOutlet var siteAddressHelpButton: UIButton!
@@ -15,7 +14,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         }
     }
 
-
     override var loginFields: LoginFields {
         didSet {
             // Clear the site url and site info (if any) from LoginFields
@@ -23,12 +21,12 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             loginFields.meta.siteInfo = nil
         }
     }
-    
+
     // MARK: - URL Validation
-    
+
     private lazy var urlErrorDebouncer = Debouncer(delay: 2) { [weak self] in
         let errorMessage = NSLocalizedString("Please enter a complete website address, like example.com.", comment: "Error message shown when a URL is invalid.")
-        
+
         self?.displayError(message: errorMessage)
     }
 
@@ -39,7 +37,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         localizeControls()
         configureForAccessibility()
     }
-
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -55,7 +52,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -64,14 +60,12 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         WordPressAuthenticator.track(.loginURLFormViewed)
     }
 
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
     }
 
     // MARK: Setup and Configuration
-
 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
@@ -105,7 +99,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         siteURLField.text = loginFields.siteAddress
     }
 
-
     /// Configures the appearance and state of the submit button.
     ///
     override func configureSubmitButton(animating: Bool) {
@@ -115,7 +108,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             !animating && canSubmit()
         )
     }
-
 
     /// Sets the view's state to loading or not loading.
     ///
@@ -127,7 +119,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         configureSubmitButton(animating: loading)
         navigationItem.hidesBackButton = loading
     }
-
 
     /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
@@ -144,9 +135,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         WPStyleGuide.configureTextButton(siteAddressHelpButton)
     }
 
-
     // MARK: - Instance Methods
-
 
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action.
@@ -154,7 +143,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     @objc func validateForm() {
         view.endEditing(true)
         displayError(message: "")
-        
+
         // We need to to this here because before this point we need the URL to be pre-validated
         // exactly as the user inputs it, and after this point we need the URL to be the base site URL.
         // This isn't really great, but it's the only sane solution I could come up with given the current
@@ -200,7 +189,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             }
         })
     }
-    
+
     @objc func fetchSiteInfo() {
         let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: loginFields.siteAddress)
         let service = WordPressComBlogService()
@@ -216,7 +205,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             }
             self.presentNextControllerIfPossible(siteInfo: siteInfo)
         }
-        service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] error in
+        service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] _ in
             self?.configureViewLoading(false)
             guard let self = self else {
                 return
@@ -235,11 +224,11 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                     self.showSelfHostedUsernamePassword()
                 }
 
-                self.showWPUsernamePassword()                
+                self.showWPUsernamePassword()
             case .presentEmailController:
                 // This case is only used for UL&S
                 break
-            case .injectViewController(_):
+            case .injectViewController:
                 // This case is only used for UL&S
                 break
             }
@@ -252,7 +241,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         }
         return err
     }
-    
+
     /// Here we will continue with the self-hosted flow.
     ///
     @objc func showSelfHostedUsernamePassword() {
@@ -300,9 +289,9 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         alertController.addDefaultActionWithTitle(acceptActionTitle)
         present(alertController, animated: true)
     }
-    
+
     // MARK: - URL Validation
-    
+
     /// Does a local / quick Site Address validation and refreshes the UI with an error
     /// if necessary.
     ///
@@ -310,7 +299,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     ///
     private func refreshSiteAddressError(immediate: Bool) {
         let showError = !loginFields.siteAddress.isEmpty && !loginFields.validateSiteForSignin()
-        
+
         if showError {
             urlErrorDebouncer.call(immediate: immediate)
         } else {
@@ -349,14 +338,12 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     @IBAction func handleEditingDidEnd(_ sender: UITextField) {
         refreshSiteAddressError(immediate: true)
     }
-    
-    // MARK: - Keyboard Notifications
 
+    // MARK: - Keyboard Notifications
 
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
         keyboardWillShow(notification)
     }
-
 
     @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
         keyboardWillHide(notification)

--- a/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
@@ -1,6 +1,5 @@
 import WordPressShared
 
-
 open class LoginSocialErrorCell: UITableViewCell {
     private let errorTitle: String
     private let errorDescription: String
@@ -10,7 +9,7 @@ open class LoginSocialErrorCell: UITableViewCell {
     private let labelStack: UIStackView
 
     private var forUnified: Bool = false
-    
+
     private struct Constants {
         static let labelSpacing: CGFloat = 15.0
         static let labelVerticalMargin: CGFloat = 20.0
@@ -84,12 +83,12 @@ open class LoginSocialErrorCell: UITableViewCell {
         } else {
             descriptionLabel.text = errorDescription
         }
-        
+
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
             backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
             return
         }
-        
+
         backgroundColor = forUnified ? unifiedBackgroundColor : WordPressAuthenticator.shared.style.viewControllerBackgroundColor
     }
 }

--- a/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -2,7 +2,6 @@ import Foundation
 import Gridicons
 import WordPressShared
 
-
 @objc
 protocol LoginSocialErrorViewControllerDelegate {
     func retryWithEmail()
@@ -15,12 +14,12 @@ protocol LoginSocialErrorViewControllerDelegate {
 class LoginSocialErrorViewController: NUXTableViewController {
     fileprivate var errorTitle: String
     fileprivate var errorDescription: String
-    @objc var delegate: LoginSocialErrorViewControllerDelegate?
-    
+    @objc weak var delegate: LoginSocialErrorViewControllerDelegate?
+
     private var forUnified: Bool = false
     private var actionButtonTapped: Bool = false
     private let unifiedAuthEnabled = WordPressAuthenticator.shared.configuration.enableUnifiedAuth
-    
+
     fileprivate enum Sections: Int {
         case titleAndDescription = 0
         case buttons = 1
@@ -77,7 +76,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
             delegate?.errorDismissed()
         }
     }
-    
+
     private func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
             view.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
@@ -86,7 +85,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
 
         view.backgroundColor = forUnified ? unifiedBackgroundColor : WordPressAuthenticator.shared.style.viewControllerBackgroundColor
     }
-    
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard indexPath.section == Sections.buttons.rawValue,
             let delegate = delegate else {
@@ -94,7 +93,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
         }
 
         actionButtonTapped = true
-        
+
         switch indexPath.row {
         case Buttons.tryEmail.rawValue:
             delegate.retryWithEmail()
@@ -111,7 +110,6 @@ class LoginSocialErrorViewController: NUXTableViewController {
         }
     }
 }
-
 
 // MARK: UITableViewDelegate methods
 
@@ -130,14 +128,13 @@ extension LoginSocialErrorViewController {
     }
 }
 
-
 // MARK: UITableViewDataSource methods
 
 extension LoginSocialErrorViewController {
     private func numberOfButtonsToShow() -> Int {
-        
+
         var buttonCount = loginFields.restrictToWPCom ? Buttons.count - 1 : Buttons.count
-        
+
         // Don't show the Signup Retry if showing unified social flows.
         // At this point, we've already tried signup and are past it.
         let unifiedGoogle = unifiedAuthEnabled && loginFields.meta.socialService == .google
@@ -146,7 +143,7 @@ extension LoginSocialErrorViewController {
         if unifiedGoogle || unifiedApple {
             buttonCount -= 1
         }
-        
+
         return buttonCount
     }
 

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -26,7 +26,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         }
     }
 
-
     // MARK: - Lifecycle Methods
 
     override func viewDidLoad() {
@@ -37,7 +36,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         setupOnePasswordButtonIfNeeded()
         displayLoginMessage("")
     }
-
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -52,7 +50,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         setupNavBarIcon()
     }
 
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -62,16 +59,12 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         WordPressAuthenticator.track(.loginUsernamePasswordFormViewed)
     }
 
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
     }
 
-
-
     // MARK: - Setup and Configuration
-
 
     /// Assigns localized strings to various UIControl defined in the storyboard.
     ///
@@ -91,7 +84,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         forgotPasswordButton.titleLabel?.numberOfLines = 0
     }
 
-
     /// Sets up a 1Password button if 1Password is available.
     ///
     @objc func setupOnePasswordButtonIfNeeded() {
@@ -99,7 +91,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
                                                             target: self,
                                                             selector: #selector(handleOnePasswordButtonTapped(_:)))
     }
-
 
     /// Configures the content of the text fields based on what is saved in `loginFields`.
     ///
@@ -110,14 +101,12 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         usernameField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
     }
 
-
     /// Configures the appearance and state of the forgot password button.
     ///
     @objc func configureForgotPasswordButton() {
         forgotPasswordButton.isEnabled = enableSubmit(animating: false)
         WPStyleGuide.configureTextButton(forgotPasswordButton)
     }
-
 
     /// Configures the appearance and state of the submit button.
     ///
@@ -130,7 +119,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
                 !loginFields.password.isEmpty
         )
     }
-
 
     /// Sets the view's state to loading or not loading.
     ///
@@ -145,7 +133,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         navigationItem.hidesBackButton = loading
     }
 
-
     /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
     ///
@@ -157,7 +144,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         }
     }
 
-
     /// Configure the site header.
     ///
     @objc func configureHeader() {
@@ -167,7 +153,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
             configureSiteAddressHeader()
         }
     }
-
 
     /// Configure the site header to show the BlogDetailsHeaderView
     ///
@@ -181,7 +166,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         siteHeaderView.downloadBlavatar(at: siteInfo.icon)
     }
 
-
     /// Configure the site header to show the site address label.
     ///
     @objc func configureSiteAddressHeader() {
@@ -191,7 +175,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         siteHeaderView.blavatarBorderIsHidden = true
         siteHeaderView.blavatarImage = .linkFieldImage
     }
-
 
     /// Sanitize and format the site address we show to users.
     ///
@@ -203,7 +186,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         return siteAddress
     }
 
-
     // MARK: - Instance Methods
 
     /// Validates what is entered in the various form fields and, if valid,
@@ -212,7 +194,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
     @objc func validateForm() {
         validateFormAndLogin()
     }
-
 
     // MARK: - Actions
 
@@ -224,11 +205,9 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
         configureSubmitButton(animating: false)
     }
 
-
     @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {
         validateForm()
     }
-
 
     @objc func handleOnePasswordButtonTapped(_ sender: UIButton) {
         view.endEditing(true)
@@ -247,24 +226,20 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
 
     // MARK: - Keyboard Notifications
 
-
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
         keyboardWillShow(notification)
     }
-
 
     @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
         keyboardWillHide(notification)
     }
 }
 
-
 extension LoginUsernamePasswordViewController {
 
     func displayLoginMessage(_ message: String) {
         configureForgotPasswordButton()
     }
-
 
     override func displayRemoteError(_ error: Error) {
         displayLoginMessage("")
@@ -278,7 +253,6 @@ extension LoginUsernamePasswordViewController {
     }
 }
 
-
 extension LoginUsernamePasswordViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if textField == usernameField {
@@ -289,4 +263,3 @@ extension LoginUsernamePasswordViewController: UITextFieldDelegate {
         return true
     }
 }
-

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -26,9 +26,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         }
     }
 
-
     // MARK: - Lifecycle Methods
-
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -50,7 +48,6 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         configureViewForEditingIfNeeded()
     }
 
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -61,11 +58,10 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         WordPressAuthenticator.track(.loginPasswordFormViewed)
     }
 
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
-        
+
         if isMovingFromParent {
             // There was a bug that was causing iOS's update password prompt to come up
             // when this VC was being dismissed pressing the "< Back" button.  The following
@@ -77,7 +73,6 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
             passwordField?.text = ""
         }
     }
-
 
     // MARK: Setup and Configuration
 
@@ -112,7 +107,6 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         configureSubmitButton(animating: loading)
         navigationItem.hidesBackButton = loading
     }
-
 
     /// Configure the view for an editing state. Should only be called from viewWillAppear
     /// as this method skips animating any change in height.
@@ -153,11 +147,11 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
             guard let service = loginFields.meta.socialService else {
                 return NSLocalizedString("Enter the password for your WordPress.com account.", comment: "Instructional text shown when requesting the user's password for login.")
             }
-            
+
             if service == SocialServiceName.google {
                 return NSLocalizedString("To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once.", comment: "")
             }
-            
+
             return NSLocalizedString("Please enter the password for your WordPress.com account to log in with your Apple ID.", comment: "")
         }()
 
@@ -174,7 +168,6 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         forgotPasswordButton?.setTitle(forgotPasswordTitle, for: .highlighted)
         forgotPasswordButton?.titleLabel?.numberOfLines = 0
     }
-
 
     // MARK: - Instance Methods
 
@@ -226,7 +219,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
         let allowUsernameChange = (loginFields.meta.socialService == nil)
 
         WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sender, loginFields: loginFields, allowUsernameChange: allowUsernameChange) { [weak self] (loginFields) in
-            
+
             self?.emailLabel?.text = loginFields.username
             self?.passwordField?.text = loginFields.password
             self?.validateForm()
@@ -262,7 +255,6 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     @objc func handleKeyboardWillHide(_ notification: Foundation.Notification) {
         keyboardWillHide(notification)
     }
-
 
     // MARK: Keyboard Events
 

--- a/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import WordPressShared
 import WordPressKit
 
-
 class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     // MARK: - NUXKeyboardResponder Properties
@@ -121,7 +120,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
             return
         }
 
-        checkEmailAvailability() { available in
+        checkEmailAvailability { available in
             if available {
                 self.loginFields.username = self.loginFields.emailAddress
                 self.loginFields.meta.emailMagicLinkSource = .signup
@@ -137,7 +136,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
     // MARK: - Email Availability
 
-    private func checkEmailAvailability(completion:@escaping (Bool) -> ()) {
+    private func checkEmailAvailability(completion:@escaping (Bool) -> Void) {
 
         let remote = AccountServiceRemoteREST(
             wordPressComRestApi: WordPressComRestApi(baseUrlString: WordPressAuthenticator.shared.configuration.wpcomAPIBaseURL))
@@ -169,9 +168,9 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
                 completion(false)
                 return
             }
-            
+
             DDLogError("Error checking email availability: \(error.localizedDescription)")
-            
+
             switch error {
             case AccountServiceRemoteError.emailAddressInvalid:
                 self.displayError(message: error.localizedDescription)
@@ -197,7 +196,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
                                     self?.didRequestSignupLink()
                                     self?.configureSubmitButton(animating: false)
 
-            }, failure: { [weak self] (error: Error) in
+            }, failure: { [weak self] (_: Error) in
                 DDLogError("Request for signup link email failed.")
                 WordPressAuthenticator.track(.signupMagicLinkFailed)
                 self?.displayError(message: ErrorMessage.magicLinkRequestFail.description())

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -1,4 +1,3 @@
-
 /// View controller that handles the google signup flow
 ///
 class SignupGoogleViewController: LoginViewController {
@@ -61,12 +60,12 @@ extension SignupGoogleViewController: GoogleAuthenticatorSignupDelegate {
         self.loginFields = loginFields
         showSignupEpilogue(for: credentials)
     }
-    
+
     func googleLoggedInInstead(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
         self.loginFields = loginFields
         showLoginEpilogue(for: credentials)
     }
-    
+
     func googleSignupFailed(error: Error, loginFields: LoginFields) {
         self.loginFields = loginFields
         titleLabel?.textColor = WPStyleGuide.errorRed()

--- a/WordPressAuthenticator/Signup/SignupNavigationController.swift
+++ b/WordPressAuthenticator/Signup/SignupNavigationController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import WordPressUI
 
-
 class SignupNavigationController: RotationAwareNavigationViewController {
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/WordPressAuthenticator/UI/CircularImageView.swift
+++ b/WordPressAuthenticator/UI/CircularImageView.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// UIImageView with a circular shape.
 ///
 class CircularImageView: UIImageView {

--- a/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WordPressAuthenticator/UI/LoginTextField.swift
@@ -38,7 +38,7 @@ open class LoginTextField: WPWalkthroughTextField {
                 return
             }
 
-            let attributes: [NSAttributedString.Key : Any] = [
+            let attributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: WordPressAuthenticator.shared.style.placeholderColor,
                 .font: font
             ]

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -1,13 +1,11 @@
 import UIKit
 import WordPressShared
 
-
 // MARK: - SearchTableViewCellDelegate
 //
 public protocol SearchTableViewCellDelegate: class {
     func startSearch(for: String)
 }
-
 
 // MARK: - SearchTableViewCell
 //
@@ -36,7 +34,6 @@ open class SearchTableViewCell: UITableViewCell {
         }
     }
 
-
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
@@ -53,7 +50,6 @@ open class SearchTableViewCell: UITableViewCell {
     }
 }
 
-
 // MARK: - Settings
 //
 private extension SearchTableViewCell {
@@ -61,7 +57,6 @@ private extension SearchTableViewCell {
         static let textInsetsWithIcon = WPStyleGuide.edgeInsetForLoginTextFields()
     }
 }
-
 
 // MARK: - UITextFieldDelegate
 //

--- a/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
+++ b/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
@@ -1,7 +1,6 @@
 import UIKit
 import WordPressShared
 
-
 // MARK: - SiteInfoHeaderView
 //
 class SiteInfoHeaderView: UIView {
@@ -62,7 +61,6 @@ class SiteInfoHeaderView: UIView {
         }
     }
 
-
     /// Downloads the Blavatar Image at the specified URL.
     ///
     func downloadBlavatar(at path: String) {
@@ -73,14 +71,12 @@ class SiteInfoHeaderView: UIView {
         }
     }
 
-
     // MARK: - Overriden Methods
 
     override func awakeFromNib() {
         super.awakeFromNib()
         refreshLabelStyles()
     }
-
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
@@ -92,7 +88,6 @@ class SiteInfoHeaderView: UIView {
         refreshLabelStyles()
     }
 }
-
 
 // MARK: - Private
 //

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -103,7 +103,7 @@ class GoogleAuthenticator: NSObject {
         return facade
     }()
 
-    private lazy weak var authenticationDelegate: WordPressAuthenticatorDelegate = {
+    private weak var authenticationDelegate: WordPressAuthenticatorDelegate? = {
         guard let delegate = WordPressAuthenticator.shared.delegate else {
             fatalError()
         }
@@ -359,7 +359,7 @@ private extension GoogleAuthenticator {
             if accountCreated {
                 SVProgressHUD.dismiss()
                 // Notify the host app
-                self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
+                self?.authenticationDelegate?.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
                 // Notify the delegate
                 self?.accountCreated(credentials: credentials)
 
@@ -368,7 +368,7 @@ private extension GoogleAuthenticator {
 
             // Existing Account
             // Sync host app
-            self?.authenticationDelegate.sync(credentials: credentials) {
+            self?.authenticationDelegate?.sync(credentials: credentials) {
                 SVProgressHUD.dismiss()
                 // Notify delegate
                 self?.logInInstead(credentials: credentials)

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -3,7 +3,6 @@ import GoogleSignIn
 import WordPressKit
 import SVProgressHUD
 
-
 /// Contains delegate methods for Google authentication unified auth flow.
 /// Both Login and Signup are handled via this delegate.
 ///
@@ -16,7 +15,7 @@ protocol GoogleAuthenticatorDelegate: class {
 
     // Google account login was successful, but a WP password is required.
     func googleExistingUserNeedsConnection(loginFields: LoginFields)
-    
+
     // Google account login failed.
     func googleLoginFailed(errorTitle: String, errorDescription: String, loginFields: LoginFields, unknownUser: Bool)
 
@@ -57,7 +56,7 @@ protocol GoogleAuthenticatorLoginDelegate: class {
 
     // Google account login was successful, but a WP password is required.
     func googleExistingUserNeedsConnection(loginFields: LoginFields)
-    
+
     // Google account login failed.
     func googleLoginFailed(errorTitle: String, errorDescription: String, loginFields: LoginFields)
 }
@@ -91,11 +90,11 @@ class GoogleAuthenticator: NSObject {
     private var loginFields = LoginFields()
     private let authConfig = WordPressAuthenticator.shared.configuration
     private var authType: GoogleAuthType = .login
-    
+
     private var tracker: AuthenticatorAnalyticsTracker {
         AuthenticatorAnalyticsTracker.shared
     }
-    
+
     private lazy var loginFacade: LoginFacade = {
         let facade = LoginFacade(dotcomClientID: authConfig.wpcomClientId,
                                  dotcomSecret: authConfig.wpcomSecret,
@@ -104,7 +103,7 @@ class GoogleAuthenticator: NSObject {
         return facade
     }()
 
-    private lazy var authenticationDelegate: WordPressAuthenticatorDelegate = {
+    private lazy weak var authenticationDelegate: WordPressAuthenticatorDelegate = {
         guard let delegate = WordPressAuthenticator.shared.delegate else {
             fatalError()
         }
@@ -112,7 +111,7 @@ class GoogleAuthenticator: NSObject {
     }()
 
     // MARK: - Start Authentication
-    
+
     /// Public method to initiate the Google auth process.
     /// - Parameters:
     ///   - viewController: The UIViewController that Google is being presented from.
@@ -127,7 +126,7 @@ class GoogleAuthenticator: NSObject {
         self.authType = authType
         requestAuthorization(from: viewController)
     }
-    
+
     /// Public method to create a WP account with a Google account.
     /// - Parameters:
     ///   - loginFields: LoginFields from the calling view controller.
@@ -174,7 +173,7 @@ private extension GoogleAuthenticator {
 
         // This has no effect since we don't use Google UI, but presentingViewController is required, so here we are.
         googleInstance.presentingViewController = viewController
-        
+
         googleInstance.delegate = self
         googleInstance.clientID = authConfig.googleLoginClientId
         googleInstance.serverClientID = authConfig.googleLoginServerClientId
@@ -188,7 +187,7 @@ private extension GoogleAuthenticator {
         trackProperties["source"] = "google"
         WordPressAuthenticator.track(event, properties: trackProperties)
     }
-    
+
     enum LocalizedText {
         static let googleConnected = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
         static let googleConnectedError = NSLocalizedString("The Google account \"%@\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
@@ -207,10 +206,10 @@ extension GoogleAuthenticator: GIDSignInDelegate {
         guard let user = user,
             let token = user.authentication.idToken,
             let email = user.profile.email else {
-                
+
                 // The Google SignIn may have been cancelled.
                 let failure = error?.localizedDescription ?? "Unknown error"
-                
+
                 tracker.track(failure: failure, ifTrackingNotEnabled: {
                     let properties = ["error": failure]
 
@@ -225,10 +224,10 @@ extension GoogleAuthenticator: GIDSignInDelegate {
                 // Notify the delegates so the Google Auth view can be dismissed.
                 signupDelegate?.googleSignupCancelled()
                 delegate?.googleAuthCancelled()
-                
+
                 return
         }
-        
+
         // Save account information to pass back to delegate later.
         loginFields.emailAddress = email
         loginFields.username = email
@@ -252,7 +251,7 @@ extension GoogleAuthenticator: GIDSignInDelegate {
         SVProgressHUD.show()
         loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
     }
-    
+
 }
 
 // MARK: - LoginFacadeDelegate
@@ -263,15 +262,15 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
     func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
         SVProgressHUD.dismiss()
         GIDSignIn.sharedInstance().disconnect()
-        
+
         // This stat is part of a funnel that provides critical information.  Please
         // consult with your lead before removing this event.
         track(.signedIn)
-        
+
         if tracker.shouldUseLegacyTracker() {
             track(.loginSocialSuccess)
         }
-        
+
         let wpcom = WordPressComCredentials(authToken: authToken,
                                             isJetpackLogin: loginFields.meta.jetpackLogin,
                                             multifactor: false,
@@ -293,7 +292,7 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
         if tracker.shouldUseLegacyTracker() {
             track(.loginSocial2faNeeded)
         }
-        
+
         loginDelegate?.googleNeedsMultifactorCode(loginFields: loginFields)
         delegate?.googleNeedsMultifactorCode(loginFields: loginFields)
     }
@@ -305,11 +304,11 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
 
         loginFields.username = email
         loginFields.emailAddress = email
-        
+
         if tracker.shouldUseLegacyTracker() {
             track(.loginSocialAccountsNeedConnecting)
         }
-        
+
         loginDelegate?.googleExistingUserNeedsConnection(loginFields: loginFields)
         delegate?.googleExistingUserNeedsConnection(loginFields: loginFields)
     }
@@ -326,7 +325,7 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
         if unknownUser {
             errorTitle = LocalizedText.googleConnected
             errorDescription = String(format: LocalizedText.googleConnectedError, loginFields.username)
-            
+
             if tracker.shouldUseLegacyTracker() {
                 track(.loginSocialErrorUnknownUser)
             }
@@ -338,7 +337,7 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
         loginDelegate?.googleLoginFailed(errorTitle: errorTitle, errorDescription: errorDescription, loginFields: loginFields)
         delegate?.googleLoginFailed(errorTitle: errorTitle, errorDescription: errorDescription, loginFields: loginFields, unknownUser: unknownUser)
     }
-    
+
 }
 
 // MARK: - Sign Up Methods
@@ -381,16 +380,16 @@ private extension GoogleAuthenticator {
                 self?.signupFailed(error: error)
         })
     }
-    
+
     func accountCreated(credentials: AuthenticatorCredentials) {
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         track(.createdAccount)
-        
+
         // This stat is part of a funnel that provides critical information.  Please
         // consult with your lead before removing this event.
         track(.signedIn)
-        
+
         tracker.track(step: .success, ifTrackingNotEnabled: {
             track(.signupSocialSuccess)
         })
@@ -398,14 +397,14 @@ private extension GoogleAuthenticator {
         signupDelegate?.googleFinishedSignup(credentials: credentials, loginFields: loginFields)
         delegate?.googleFinishedSignup(credentials: credentials, loginFields: loginFields)
     }
-    
+
     func logInInstead(credentials: AuthenticatorCredentials) {
         tracker.set(flow: .loginWithGoogle)
-        
+
         // This stat is part of a funnel that provides critical information.  Please
         // consult with your lead before removing this event.
         track(.signedIn)
-        
+
         tracker.track(step: .start) {
             track(.signupSocialToLogin)
             track(.loginSocialSuccess)
@@ -414,7 +413,7 @@ private extension GoogleAuthenticator {
         signupDelegate?.googleLoggedInInstead(credentials: credentials, loginFields: loginFields)
         delegate?.googleLoggedInInstead(credentials: credentials, loginFields: loginFields)
     }
-    
+
     func signupFailed(error: Error) {
         tracker.track(failure: error.localizedDescription, ifTrackingNotEnabled: {
             track(.signupSocialFailure, properties: ["error": error.localizedDescription])

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsPicker.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsPicker.swift
@@ -9,26 +9,26 @@ import AuthenticationServices
 ///
 @available(iOS 13, *)
 class StoredCredentialsPicker: NSObject {
-    
-    typealias CompletionClosure = (Result<ASAuthorization, Error>) -> ()
-    
+
+    typealias CompletionClosure = (Result<ASAuthorization, Error>) -> Void
+
     /// The closure that will be executed once the credentials are picked and returned by the OS,
     /// or once there's an Error.
     ///
     private var onComplete: CompletionClosure!
-    
+
     /// The window where the quick authentication flow will be shown.
     ///
     private var window: UIWindow!
 
     func show(in window: UIWindow, onComplete: @escaping CompletionClosure) {
-        
+
         self.onComplete = onComplete
         self.window = window
-        
+
         let requests = [ASAuthorizationPasswordProvider().createRequest()]
         let controller = ASAuthorizationController(authorizationRequests: requests)
-        
+
         controller.delegate = self
         controller.presentationContextProvider = self
         controller.performRequests()

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -5,7 +5,7 @@ import WordPressKit
 class GetStartedViewController: LoginViewController {
 
     // MARK: - Properties
-    
+
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet private weak var leadingDividerLine: UIView!
     @IBOutlet private weak var leadingDividerLineWidth: NSLayoutConstraint!
@@ -17,10 +17,10 @@ class GetStartedViewController: LoginViewController {
     // This is to contain the password selected by password auto-fill.
     // When it is populated, login is attempted.
     @IBOutlet private weak var hiddenPasswordField: UITextField?
-    
+
     // This is public so it can be set from StoredCredentialsAuthenticator.
     var errorMessage: String?
-    
+
     private var rows = [Row]()
     private var buttonViewController: NUXButtonViewController?
     private let configuration = WordPressAuthenticator.shared.configuration
@@ -30,25 +30,25 @@ class GetStartedViewController: LoginViewController {
     private let continueButton: NUXButton = {
         let button = NUXButton()
         button.isPrimary = true
-        
+
         let title = WordPressAuthenticator.shared.displayStrings.continueButtonTitle
         button.setTitle(title, for: .normal)
         button.setTitle(title, for: .highlighted)
-        
+
         return button
     }()
-    
+
     override open var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginEmail
         }
     }
-    
+
     // MARK: - View
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         configureNavBar()
         setupTable()
         registerTableViewCells()
@@ -61,52 +61,52 @@ class GetStartedViewController: LoginViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureSubmitButton(animating: false)
-        
+
         if errorMessage != nil {
             shouldChangeVoiceOverFocus = true
         }
     }
-    
+
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         tracker.set(flow: .wpCom)
-        
+
         if isMovingToParent {
             tracker.track(step: .start)
         } else {
             tracker.set(step: .start)
         }
-        
+
         errorMessage = nil
         hiddenPasswordField?.text = nil
         hiddenPasswordField?.isAccessibilityElement = false
     }
 
     // MARK: - Overrides
-    
+
     override func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
             super.styleBackground()
             return
         }
-        
+
         view.backgroundColor = unifiedBackgroundColor
     }
-    
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ??
             WordPressAuthenticator.shared.style.statusBarStyle
     }
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
-        
+
         if let vc = segue.destination as? NUXButtonViewController {
             buttonViewController = vc
         }
     }
-    
+
     override func configureViewLoading(_ loading: Bool) {
         configureContinueButton(animating: loading)
         navigationItem.hidesBackButton = loading
@@ -121,18 +121,18 @@ class GetStartedViewController: LoginViewController {
 // MARK: - UITableViewDataSource
 
 extension GetStartedViewController: UITableViewDataSource {
-    
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return rows.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let row = rows[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
         configure(cell, for: row, at: indexPath)
         return cell
     }
-    
+
 }
 
 // MARK: - Private methods
@@ -140,12 +140,12 @@ extension GetStartedViewController: UITableViewDataSource {
 private extension GetStartedViewController {
 
     // MARK: - Configuration
-    
+
     func configureNavBar() {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.getStartedTitle
         styleNavigationBar(forUnified: true)
     }
-    
+
     func setupTable() {
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
@@ -173,22 +173,22 @@ private extension GetStartedViewController {
         dividerLabel.textColor = color
         dividerLabel.text = NSLocalizedString("Or", comment: "Divider on initial auth view separating auth options.").localizedUppercase
     }
-    
+
     // MARK: - Continue Button Action
-    
+
     @IBAction func handleSubmitButtonTapped(_ sender: UIButton) {
         tracker.track(click: .submit)
         validateForm()
     }
-    
+
     // MARK: - Hidden Password Field Action
-    
+
     @IBAction func handlePasswordFieldDidChange(_ sender: UITextField) {
         attemptAutofillLogin()
     }
-    
+
     // MARK: - Table Management
-    
+
     /// Registers all of the available TableViewCells.
     ///
     func registerTableViewCells() {
@@ -198,12 +198,12 @@ private extension GetStartedViewController {
             TextWithLinkTableViewCell.reuseIdentifier: TextWithLinkTableViewCell.loadNib(),
             SpacerTableViewCell.reuseIdentifier: SpacerTableViewCell.loadNib()
         ]
-        
+
         for (reuseIdentifier, nib) in cells {
             tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
         }
     }
-    
+
     /// Describes how the tableView rows should be rendered.
     ///
     func loadRows() {
@@ -219,7 +219,7 @@ private extension GetStartedViewController {
             rows.append(.errorMessage)
         }
     }
-    
+
     /// Configure cells.
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
@@ -238,13 +238,13 @@ private extension GetStartedViewController {
             DDLogError("Error: Unidentified tableViewCell type found.")
         }
     }
-    
+
     /// Configure the instruction cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.getStartedInstructions)
     }
-    
+
     /// Configure the email cell.
     ///
     func configureEmailField(_ cell: TextFieldTableViewCell) {
@@ -253,12 +253,12 @@ private extension GetStartedViewController {
                        text: loginFields.username)
         cell.textField.delegate = self
         emailField = cell.textField
-        
+
         cell.onChangeSelectionHandler = { [weak self] textfield in
             self?.loginFields.username = textfield.nonNilTrimmedText()
             self?.configureContinueButton(animating: false)
         }
-        
+
         cell.onePasswordHandler = { [weak self] in
             guard let self = self,
             let sourceView = self.emailField else {
@@ -272,18 +272,18 @@ private extension GetStartedViewController {
                 self?.validateFormAndLogin()
             }
         }
-        
+
         if UIAccessibility.isVoiceOverRunning {
             // Quiet repetitive elements in VoiceOver.
             emailField?.placeholder = nil
         }
     }
-    
+
     /// Configure the link cell.
     ///
     func configureTextWithLink(_ cell: TextWithLinkTableViewCell) {
         cell.configureButton(markedText: WordPressAuthenticator.shared.displayStrings.loginTermsOfService)
-        
+
         cell.actionHandler = { [weak self] in
             self?.termsTapped()
         }
@@ -293,12 +293,12 @@ private extension GetStartedViewController {
     ///
     func configureErrorLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: errorMessage, style: .error)
-        
+
         if shouldChangeVoiceOverFocus {
             UIAccessibility.post(notification: .layoutChanged, argument: cell)
         }
     }
-    
+
     /// Rows listed in the order they were created.
     ///
     enum Row {
@@ -307,7 +307,7 @@ private extension GetStartedViewController {
         case tos
         case spacer
         case errorMessage
-        
+
         var reuseIdentifier: String {
             switch self {
             case .instructions, .errorMessage:
@@ -321,18 +321,18 @@ private extension GetStartedViewController {
             }
         }
     }
-    
+
     enum Constants {
         static let footerFrame = CGRect(x: 0, y: 0, width: 0, height: 44)
         static let footerButtonInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
     }
-    
+
 }
 
 // MARK: - Validation
 
 private extension GetStartedViewController {
-    
+
     /// Configures appearance of the submit button.
     ///
     func configureContinueButton(animating: Bool) {
@@ -351,7 +351,7 @@ private extension GetStartedViewController {
     /// social signin does not require form validation.
     ///
     func validateForm() {
-        
+
         loginFields.meta.socialService = nil
         displayError(message: "")
 
@@ -379,7 +379,7 @@ private extension GetStartedViewController {
                                         self.handleLoginError(error)
         })
     }
-    
+
     /// Show the Password entry view.
     ///
     func showPasswordView() {
@@ -387,10 +387,10 @@ private extension GetStartedViewController {
             DDLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
             return
         }
-        
+
         vc.loginFields = loginFields
         vc.trackAsPasswordChallenge = false
-        
+
         navigationController?.pushViewController(vc, animated: true)
     }
 
@@ -411,7 +411,7 @@ private extension GetStartedViewController {
             self.displayError(error as NSError, sourceTag: self.sourceTag)
         }
     }
-    
+
     // MARK: - Send email
 
     /// Makes the call to request a magic signup link be emailed to the user.
@@ -430,11 +430,11 @@ private extension GetStartedViewController {
 
             }, failure: { [weak self] (error: Error) in
                 DDLogError("Request for signup link email failed.")
-                
+
                 guard let self = self else {
                     return
                 }
-                
+
                 self.tracker.track(failure: error.localizedDescription)
                 self.displayError(error as NSError, sourceTag: self.sourceTag)
                 self.configureSubmitButton(animating: false)
@@ -452,7 +452,7 @@ private extension GetStartedViewController {
 
         navigationController?.pushViewController(vc, animated: true)
     }
-    
+
     /// Makes the call to request a magic authentication link be emailed to the user.
     ///
     func requestAuthenticationLink() {
@@ -476,7 +476,7 @@ private extension GetStartedViewController {
                 guard let self = self else {
                     return
                 }
-                
+
                 self.tracker.track(failure: error.localizedDescription)
 
                 self.displayError(error as NSError, sourceTag: self.sourceTag)
@@ -496,7 +496,7 @@ private extension GetStartedViewController {
         vc.loginFields.restrictToWPCom = true
         navigationController?.pushViewController(vc, animated: true)
     }
-    
+
     /// Build the alert message when the email address is invalid.
     ///
     func buildInvalidEmailAlert() -> UIAlertController {
@@ -520,27 +520,27 @@ private extension GetStartedViewController {
 
         return alert
     }
-    
+
     /// When password autofill has entered a password on this screen, attempt to login immediately
     ///
     func attemptAutofillLogin() {
         // Even though there was no explicit submit action by the user, we'll interpret
         // the credentials selection as such.
         tracker.track(click: .submit)
-        
+
         loginFields.password = hiddenPasswordField?.text ?? ""
         loginFields.meta.socialService = nil
         displayError(message: "")
         validateFormAndLogin()
     }
-    
+
     /// Configures loginFields to log into wordpress.com and navigates to the selfhosted username/password form.
     /// Displays the specified error message when the new view controller appears.
     ///
     func showSelfHostedWithError(_ error: Error) {
         loginFields.siteAddress = "https://wordpress.com"
         errorToPresent = error
-        
+
         tracker.track(failure: error.localizedDescription)
 
         guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
@@ -554,51 +554,51 @@ private extension GetStartedViewController {
 
         navigationController?.pushViewController(vc, animated: true)
     }
-    
+
 }
 
 // MARK: - Social Button Management
 
 private extension GetStartedViewController {
-    
+
     func configureSocialButtons() {
         guard let buttonViewController = buttonViewController else {
             return
         }
-        
+
         buttonViewController.hideShadowView()
-        
+
         if WordPressAuthenticator.shared.configuration.enableSignInWithApple {
             if #available(iOS 13.0, *) {
                 buttonViewController.setupTopButtonFor(socialService: .apple, onTap: appleTapped)
             }
         }
-        
+
         buttonViewController.setupButtomButtonFor(socialService: .google, onTap: googleTapped)
-        
+
         let termsButton = WPStyleGuide.signupTermsButton()
         buttonViewController.stackView?.addArrangedSubview(termsButton)
         termsButton.addTarget(self, action: #selector(termsTapped), for: .touchUpInside)
     }
-    
+
     @objc func appleTapped() {
         tracker.track(click: .loginWithApple)
-        
+
         AppleAuthenticator.sharedInstance.delegate = self
         AppleAuthenticator.sharedInstance.showFrom(viewController: self)
     }
-    
+
     @objc func googleTapped() {
         tracker.track(click: .loginWithGoogle)
-        
+
         guard let toVC = GoogleAuthViewController.instantiate(from: .googleAuth) else {
             DDLogError("Failed to navigate to GoogleAuthViewController from GetStartedViewController")
             return
         }
-        
+
         navigationController?.pushViewController(toVC, animated: true)
     }
-    
+
     @objc func termsTapped() {
         tracker.track(click: .termsOfService)
 
@@ -606,7 +606,7 @@ private extension GetStartedViewController {
             DDLogError("GetStartedViewController: wpcomTermsOfServiceURL unavailable.")
             return
         }
-        
+
         let safariViewController = SFSafariViewController(url: url)
         safariViewController.modalPresentationStyle = .pageSheet
         safariViewController.delegate = self
@@ -629,35 +629,35 @@ extension GetStartedViewController: SFSafariViewControllerDelegate {
 // MARK: - AppleAuthenticatorDelegate
 
 extension GetStartedViewController: AppleAuthenticatorDelegate {
-    
+
     func showWPComLogin(loginFields: LoginFields) {
         self.loginFields = loginFields
         showPasswordView()
     }
-    
+
     func showApple2FA(loginFields: LoginFields) {
         self.loginFields = loginFields
         signInAppleAccount()
     }
-    
+
     func authFailedWithError(message: String) {
         displayErrorAlert(message, sourceTag: .loginApple)
         tracker.set(flow: .wpCom)
     }
-    
+
 }
 
 // MARK: - LoginFacadeDelegate
 
 extension GetStartedViewController {
-    
+
     // Used by SIWA when logging with with a passwordless, 2FA account.
     //
     func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         configureViewLoading(false)
         socialNeedsMultifactorCode(forUserID: userID, andNonceInfo: nonceInfo)
     }
-    
+
 }
 
 // MARK: - UITextFieldDelegate
@@ -667,7 +667,7 @@ extension GetStartedViewController: UITextFieldDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
         tracker.track(click: .selectEmailField)
     }
-    
+
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if canSubmit() {
             validateForm()

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
@@ -34,7 +34,7 @@ class GoogleAuthViewController: LoginViewController {
             AuthenticatorAnalyticsTracker.shared.track(click: .dismiss)
         }
     }
-    
+
     // MARK: - Overrides
 
     /// Style individual ViewController backgrounds, for now.

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 class GoogleSignupConfirmationViewController: LoginViewController {
 
     // MARK: - Properties
-    
+
     @IBOutlet private weak var tableView: UITableView!
     private var rows = [Row]()
     private var errorMessage: String?
@@ -14,14 +14,14 @@ class GoogleSignupConfirmationViewController: LoginViewController {
             return .wpComAuthGoogleSignupConfirmation
         }
     }
-    
+
     // MARK: - View
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         removeGoogleWaitingView()
-        
+
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)
 
@@ -33,12 +33,12 @@ class GoogleSignupConfirmationViewController: LoginViewController {
         loadRows()
         configureForAccessibility()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         tracker.set(flow: .signupWithGoogle)
-        
+
         if isBeingPresentedInAnyWay {
             tracker.track(step: .start)
         } else {
@@ -79,7 +79,7 @@ class GoogleSignupConfirmationViewController: LoginViewController {
             tableView.reloadData()
         }
     }
-    
+
 }
 
 // MARK: - UITableViewDataSource
@@ -106,20 +106,20 @@ extension GoogleSignupConfirmationViewController: UITableViewDataSource {
 // MARK: - Private Extension
 
 private extension GoogleSignupConfirmationViewController {
-    
+
     // MARK: - Button Handling
 
     @IBAction func handleSubmit() {
         tracker.track(click: .submit)
         tracker.track(click: .createAccount)
-        
+
         configureSubmitButton(animating: true)
         GoogleAuthenticator.sharedInstance.delegate = self
         GoogleAuthenticator.sharedInstance.createGoogleAccount(loginFields: loginFields)
     }
 
     // MARK: - Table Management
-    
+
     /// Registers all of the available TableViewCells.
     ///
     func registerTableViewCells() {
@@ -190,7 +190,7 @@ private extension GoogleSignupConfirmationViewController {
 
         UIAccessibility.post(notification: .screenChanged, argument: tableView)
     }
-    
+
     // MARK: - Private Constants
 
     /// Rows listed in the order they were created.
@@ -215,9 +215,9 @@ private extension GoogleSignupConfirmationViewController {
 // MARK: - GoogleAuthenticatorDelegate
 
 extension GoogleSignupConfirmationViewController: GoogleAuthenticatorDelegate {
-    
+
     // MARK: - Signup
-    
+
     func googleFinishedSignup(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
         self.loginFields = loginFields
         showSignupEpilogue(for: credentials)
@@ -227,27 +227,27 @@ extension GoogleSignupConfirmationViewController: GoogleAuthenticatorDelegate {
         self.loginFields = loginFields
         showLoginEpilogue(for: credentials)
     }
-    
+
     func googleSignupFailed(error: Error, loginFields: LoginFields) {
         configureSubmitButton(animating: false)
         self.loginFields = loginFields
         displayError(message: error.localizedDescription, moveVoiceOverFocus: true)
     }
-    
+
     // MARK: - Login
 
     func googleFinishedLogin(credentials: AuthenticatorCredentials, loginFields: LoginFields) {
         // Here for protocol compliance.
     }
-    
+
     func googleNeedsMultifactorCode(loginFields: LoginFields) {
         // Here for protocol compliance.
     }
-    
+
     func googleExistingUserNeedsConnection(loginFields: LoginFields) {
         // Here for protocol compliance.
     }
-    
+
     func googleLoginFailed(errorTitle: String, errorDescription: String, loginFields: LoginFields, unknownUser: Bool) {
         // Here for protocol compliance.
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// Unified LoginMagicLinkViewController: login to .com with a magic link
 ///
 final class LoginMagicLinkViewController: LoginViewController {
@@ -11,7 +10,7 @@ final class LoginMagicLinkViewController: LoginViewController {
     private var rows = [Row]()
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
-    
+
     override var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginMagicLink
@@ -22,7 +21,7 @@ final class LoginMagicLinkViewController: LoginViewController {
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         tracker.track(click: .openEmailClient)
         tracker.track(step: .emailOpened)
-        
+
         let linkMailPresenter = LinkMailPresenter(emailAddress: loginFields.username)
         let appSelector = AppSelector(sourceView: sender)
         linkMailPresenter.presentEmailClients(on: self, appSelector: appSelector)
@@ -43,19 +42,19 @@ final class LoginMagicLinkViewController: LoginViewController {
         registerTableViewCells()
         loadRows()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         tracker.set(flow: .loginWithMagicLink)
-        
+
         if isMovingToParent {
             tracker.track(step: .magicLinkRequested)
         } else {
             tracker.set(step: .magicLinkRequested)
         }
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
     }
@@ -87,7 +86,6 @@ final class LoginMagicLinkViewController: LoginViewController {
     }
 }
 
-
 // MARK: - UITableViewDataSource
 extension LoginMagicLinkViewController: UITableViewDataSource {
     /// Returns the number of rows in a section.
@@ -106,7 +104,6 @@ extension LoginMagicLinkViewController: UITableViewDataSource {
         return cell
     }
 }
-
 
 // MARK: - Private Methods
 private extension LoginMagicLinkViewController {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// GravatarEmailTableViewCell: Gravatar image + Email address in a UITableViewCell.
 ///
 class GravatarEmailTableViewCell: UITableViewCell {
@@ -16,15 +15,15 @@ class GravatarEmailTableViewCell: UITableViewCell {
     // When iOS12 support is removed, the emailStackView can be removed as it only facilitates 1Password.
     @IBOutlet private weak var emailLabel: UITextField?
     @IBOutlet private weak var emailStackView: UIStackView?
-    
+
     private let gridiconSize = CGSize(width: 48, height: 48)
-    
+
     /// Public properties
     ///
     public static let reuseIdentifier = "GravatarEmailTableViewCell"
     public var onePasswordHandler: ((_ sourceView: UITextField) -> Void)?
     public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
-    
+
     /// Public Methods
     ///
     public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil) {
@@ -34,9 +33,9 @@ class GravatarEmailTableViewCell: UITableViewCell {
         emailLabel?.text = email
 
         setupOnePasswordButtonIfNeeded()
-        
+
         let gridicon = UIImage.gridicon(.userCircle, size: gridiconSize)
-        
+
         guard let email = email,
             email.isValidEmail() else {
                 gravatarImageView?.image = gridicon
@@ -55,13 +54,13 @@ class GravatarEmailTableViewCell: UITableViewCell {
 // MARK: - Password Manager Handling
 
 private extension GravatarEmailTableViewCell {
-    
+
     // MARK: - 1Password
 
     /// Sets up a 1Password button if 1Password is available and user is on iOS 12.
     ///
     func setupOnePasswordButtonIfNeeded() {
-        
+
         if #available(iOS 13, *) {
             // no-op, we rely on the key icon in the keyboard to initiate a password manager.
         } else {
@@ -69,13 +68,13 @@ private extension GravatarEmailTableViewCell {
                 !(emailStackView.arrangedSubviews.last is UIButton) else {
                 return
             }
-            
+
             WPStyleGuide.configureOnePasswordButtonForStackView(emailStackView,
                                                                 target: self,
                                                                 selector: #selector(onePasswordTapped(_:)))
         }
     }
-    
+
     @objc func onePasswordTapped(_ sender: UIButton) {
         guard let emailTextField = emailLabel else {
             return
@@ -83,9 +82,9 @@ private extension GravatarEmailTableViewCell {
 
         onePasswordHandler?(emailTextField)
     }
-    
+
     // MARK: - All Password Managers
-    
+
     /// Call the handler when the text field changes.
     ///
     /// - Note: we have to manually add an action to the textfield

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// TextFieldTableViewCell: a textfield with a custom border line in a UITableViewCell.
 ///
 final class TextFieldTableViewCell: UITableViewCell {
@@ -59,7 +58,6 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.text = text
     }
 }
-
 
 // MARK: - Private methods
 private extension TextFieldTableViewCell {
@@ -145,7 +143,6 @@ private extension TextFieldTableViewCell {
     }
 }
 
-
 // MARK: - Secure Text Entry
 /// Methods ported from WPWalkthroughTextField.h/.m
 ///
@@ -209,7 +206,6 @@ private extension TextFieldTableViewCell {
     }
 }
 
-
 // MARK: - Constants
 extension TextFieldTableViewCell {
 
@@ -231,7 +227,7 @@ extension TextFieldTableViewCell {
         static let passwordShown = NSLocalizedString("Shown",
                                                      comment: "Accessibility value if login page's password field is displaying the password.")
         static let showPassword = NSLocalizedString("Show password",
-                                                    comment:"Accessibility label for the 'Show password' button in the login page's password field.")
+                                                    comment: "Accessibility label for the 'Show password' button in the login page's password field.")
         static let siteAddress = NSLocalizedString("Site address",
                                                    comment: "Accessibility label of the site address field shown when adding a self-hosted site.")
         static let username = NSLocalizedString("Username",

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,7 +18,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Kgt-SJ-dhF">
                         <rect key="frame" x="16" y="6" width="288" height="51"/>
                         <accessibility key="accessibilityConfiguration">
                             <accessibilityTraits key="traits" updatesFrequently="YES" allowsDirectInteraction="YES"/>
@@ -33,7 +34,7 @@
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="40b-u3-ydU" userLabel="border view">
                         <rect key="frame" x="16" y="61" width="304" height="1"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="CX4-ly-vLV"/>
                         </constraints>
@@ -58,4 +59,9 @@
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// TextLabelTableViewCell: a text label in a UITableViewCell.
 ///
 public final class TextLabelTableViewCell: UITableViewCell {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -1,10 +1,9 @@
 import UIKit
 
-
 /// TextLinkButtonTableViewCell: a plain button made to look like a text link.
 ///
 class TextLinkButtonTableViewCell: UITableViewCell {
-    
+
     /// Private properties
     ///
     @IBOutlet private weak var button: UIButton!
@@ -13,32 +12,32 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     @IBAction private func textLinkButtonTapped(_ sender: UIButton) {
         actionHandler?()
     }
-    
+
     /// Public properties
     ///
     public static let reuseIdentifier = "TextLinkButtonTableViewCell"
-    
+
     public var actionHandler: (() -> Void)?
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         styleBorder()
     }
-    
+
     public func configureButton(text: String?, accessibilityTrait: UIAccessibilityTraits = .button, showBorder: Bool = false) {
         button.setTitle(text, for: .normal)
-        
+
         let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
         let buttonHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
         button.accessibilityTraits = accessibilityTrait
-        
+
         borderView.isHidden = !showBorder
     }
-    
+
     /// Toggle button enabled / disabled
     ///
     public func enableButton(_ isEnabled: Bool) {
@@ -46,7 +45,6 @@ class TextLinkButtonTableViewCell: UITableViewCell {
     }
 
 }
-
 
 // MARK: - Private methods
 private extension TextLinkButtonTableViewCell {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextWithLinkTableViewCell.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// TextWithLinkTableViewCell: a button with the title regular text and an underlined link.
 ///
 class TextWithLinkTableViewCell: UITableViewCell {
@@ -21,7 +20,7 @@ class TextWithLinkTableViewCell: UITableViewCell {
         super.awakeFromNib()
         button.titleLabel?.adjustsFontForContentSizeCategory = true
     }
-    
+
     /// Creates an attributed string from the provided marked text and assigns it to the button title.
     ///
     /// - Parameters:
@@ -36,7 +35,7 @@ class TextWithLinkTableViewCell: UITableViewCell {
 
         let attributedString = text.underlined(color: textColor, underlineColor: linkColor)
         let highlightAttributedString = text.underlined(color: textColor, underlineColor: linkHighlightColor)
-        
+
         button.setAttributedTitle(attributedString, for: .normal)
         button.setAttributedTitle(highlightAttributedString, for: .highlighted)
         button.accessibilityTraits = accessibilityTrait

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// SignupMagicLinkViewController: step two in the signup flow.
 /// This VC prompts the user to open their email app to look for the magic link we sent.
 ///
@@ -23,14 +22,14 @@ final class SignupMagicLinkViewController: LoginViewController {
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         tracker.track(click: .openEmailClient)
         tracker.track(step: .emailOpened)
-        
+
         let linkMailPresenter = LinkMailPresenter(emailAddress: loginFields.username)
         let appSelector = AppSelector(sourceView: sender)
         linkMailPresenter.presentEmailClients(on: self, appSelector: appSelector)
     }
 
     // MARK: - View lifecycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -47,10 +46,10 @@ final class SignupMagicLinkViewController: LoginViewController {
         registerTableViewCells()
         loadRows()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         if isMovingToParent {
             tracker.track(step: .magicLinkRequested)
         } else {
@@ -93,7 +92,6 @@ final class SignupMagicLinkViewController: LoginViewController {
     }
 }
 
-
 // MARK: - UITableViewDataSource
 extension SignupMagicLinkViewController: UITableViewDataSource {
     /// Returns the number of rows in a section.
@@ -112,7 +110,6 @@ extension SignupMagicLinkViewController: UITableViewDataSource {
         return cell
     }
 }
-
 
 // MARK: - Private Methods
 private extension SignupMagicLinkViewController {
@@ -169,7 +166,7 @@ private extension SignupMagicLinkViewController {
     func configureCheckSpamLabel(_ cell: TextLabelTableViewCell) {
         cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.checkSpamInstructions, style: .body)
     }
-    
+
     /// Configure the "Check spam" cell.
     ///
     func configureoopsLabel(_ cell: TextLabelTableViewCell) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -33,12 +33,12 @@ class UnifiedSignupViewController: LoginViewController {
         registerTableViewCells()
         loadRows()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         tracker.set(flow: .signup)
-        
+
         if isMovingToParent {
             tracker.track(step: .start)
         } else {
@@ -83,7 +83,6 @@ class UnifiedSignupViewController: LoginViewController {
     }
 }
 
-
 // MARK: - UITableViewDataSource
 extension UnifiedSignupViewController: UITableViewDataSource {
 
@@ -104,10 +103,8 @@ extension UnifiedSignupViewController: UITableViewDataSource {
     }
 }
 
-
 // MARK: - UITableViewDelegate conformance
 extension UnifiedSignupViewController: UITableViewDelegate { }
-
 
 // MARK: - Private methods
 private extension UnifiedSignupViewController {
@@ -208,8 +205,7 @@ private extension UnifiedSignupViewController {
 
 }
 
-
-// Mark: - Instance Methods
+// MARK: - Instance Methods
 /// Implementation methods imported from SignupEmailViewController.
 ///
 extension UnifiedSignupViewController {
@@ -230,11 +226,11 @@ extension UnifiedSignupViewController {
 
             }, failure: { [weak self] (error: Error) in
                 DDLogError("Request for signup link email failed.")
-                
+
                 guard let self = self else {
                     return
                 }
-                
+
                 self.tracker.track(failure: error.localizedDescription)
                 self.displayError(message: ErrorMessage.magicLinkRequestFail.description())
                 self.configureSubmitButton(animating: false)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import WordPressUI
 import WordPressKit
 
-
 /// SiteAddressViewController: log in by Site Address.
 ///
 final class SiteAddressViewController: LoginViewController {
@@ -23,15 +22,14 @@ final class SiteAddressViewController: LoginViewController {
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         tracker.track(click: .submit)
-        
+
         validateForm()
     }
-
 
     // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         removeGoogleWaitingView()
         configureNavBar()
         setupTable()
@@ -41,7 +39,7 @@ final class SiteAddressViewController: LoginViewController {
         configureSubmitButton(animating: false)
         configureForAccessibility()
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
@@ -51,20 +49,19 @@ final class SiteAddressViewController: LoginViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         tracker.set(flow: .loginWithSiteAddress)
-        
+
         if isMovingToParent {
             tracker.track(step: .start)
         } else {
             tracker.set(step: .start)
         }
-        
+
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
         configureViewForEditingIfNeeded()
     }
-
 
     // MARK: - Overrides
 
@@ -90,7 +87,7 @@ final class SiteAddressViewController: LoginViewController {
     override func configureSubmitButton(animating: Bool) {
         // This matches the string in WPiOS UI tests.
         submitButton?.accessibilityIdentifier = "Site Address Next Button"
-        
+
         submitButton?.showActivityIndicator(animating)
 
         submitButton?.isEnabled = (
@@ -154,11 +151,11 @@ final class SiteAddressViewController: LoginViewController {
     /// Reload the tableview and show errors, if any.
     ///
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
-        if errorMessage != message {            
+        if errorMessage != message {
             if !message.isEmpty {
                 tracker.track(failure: message)
             }
-            
+
             errorMessage = message
             shouldChangeVoiceOverFocus = moveVoiceOverFocus
             loadRows()
@@ -166,7 +163,6 @@ final class SiteAddressViewController: LoginViewController {
         }
     }
 }
-
 
 // MARK: - UITableViewDataSource
 extension SiteAddressViewController: UITableViewDataSource {
@@ -187,7 +183,6 @@ extension SiteAddressViewController: UITableViewDataSource {
     }
 }
 
-
 // MARK: - UITableViewDelegate conformance
 extension SiteAddressViewController: UITableViewDelegate {
     /// After the site address textfield cell is done displaying, remove the textfield reference.
@@ -203,7 +198,6 @@ extension SiteAddressViewController: UITableViewDelegate {
     }
 }
 
-
 // MARK: - Keyboard Notifications
 extension SiteAddressViewController: NUXKeyboardResponder {
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
@@ -214,7 +208,6 @@ extension SiteAddressViewController: NUXKeyboardResponder {
         keyboardWillHide(notification)
     }
 }
-
 
 // MARK: - TextField Delegate conformance
 extension SiteAddressViewController: UITextFieldDelegate {
@@ -231,27 +224,26 @@ extension SiteAddressViewController: UITextFieldDelegate {
     }
 }
 
-
 // MARK: - Private methods
 private extension SiteAddressViewController {
 
     // MARK: - Configuration
-    
+
     func configureNavBar() {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
-        
+
         // Nav bar could be hidden from the host app, so reshow it.
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
-    
+
     func setupTable() {
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
     }
-    
+
     // MARK: - Table Management
-    
+
     /// Registers all of the available TableViewCells.
     ///
     func registerTableViewCells() {
@@ -308,7 +300,7 @@ private extension SiteAddressViewController {
     func configureTextField(_ cell: TextFieldTableViewCell) {
         cell.configure(withStyle: .url,
                        placeholder: WordPressAuthenticator.shared.displayStrings.siteAddressPlaceholder)
-        
+
         // Save a reference to the first textField so it can becomeFirstResponder.
         siteURLField = cell.textField
         cell.textField.delegate = self
@@ -328,7 +320,7 @@ private extension SiteAddressViewController {
             guard let self = self else {
                 return
             }
-            
+
             self.tracker.track(click: .showHelp)
 
             let alert = FancyAlertViewController.siteAddressHelpController(
@@ -339,7 +331,7 @@ private extension SiteAddressViewController {
             },
                 onDismiss: {
                     self.tracker.track(click: .dismiss)
-                    
+
                     // Since we're showing an alert on top of this VC, `viewDidAppear` will not be called
                     // once the alert is dismissed (which is where the step would be reset automagically),
                     // so we need to manually reset the step here.
@@ -399,7 +391,6 @@ private extension SiteAddressViewController {
         }
     }
 }
-
 
 // MARK: - Instance Methods
 
@@ -471,6 +462,7 @@ private extension SiteAddressViewController {
     }
 
     func fetchSiteInfo() {
+        print("🔴 SAVC > fetchSiteInfo")
         let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: loginFields.siteAddress)
         let service = WordPressComBlogService()
 
@@ -486,8 +478,8 @@ private extension SiteAddressViewController {
             }
             self.presentNextControllerIfPossible(siteInfo: siteInfo)
         }
-        
-        service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] error in
+
+        service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] _ in
             self?.configureViewLoading(false)
             guard let self = self else {
                 return
@@ -501,7 +493,7 @@ private extension SiteAddressViewController {
             showGetStarted()
             return
         }
-        
+
         WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (result) in
             switch result {
             case let .error(error):
@@ -511,7 +503,7 @@ private extension SiteAddressViewController {
                     self.showSelfHostedUsernamePassword()
                     return
                 }
-                
+
                 self.showWPUsernamePassword()
             case .presentEmailController:
                 self.showGetStarted()
@@ -562,7 +554,7 @@ private extension SiteAddressViewController {
 
         navigationController?.pushViewController(vc, animated: true)
     }
-    
+
     /// If the site is WordPressDotCom, redirect to WP login.
     ///
     func showGetStarted() {
@@ -570,14 +562,14 @@ private extension SiteAddressViewController {
             DDLogError("Failed to navigate from SiteAddressViewController to GetStartedViewController")
             return
         }
-        
+
         vc.loginFields = loginFields
         vc.dismissBlock = dismissBlock
         vc.errorToPresent = errorToPresent
 
         navigationController?.pushViewController(vc, animated: true)
     }
-    
+
     /// Whether the form can be submitted.
     ///
     func canSubmit() -> Bool {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 /// Part two of the self-hosted sign in flow: username + password. Used by WPiOS and NiOS.
 /// A valid site address should be acquired before presenting this view controller.
 ///
@@ -36,7 +35,7 @@ final class SiteCredentialsViewController: LoginViewController {
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         tracker.track(click: .submit)
-        
+
         validateForm()
     }
 
@@ -67,7 +66,7 @@ final class SiteCredentialsViewController: LoginViewController {
         } else {
             tracker.set(step: .usernamePassword)
         }
-        
+
         configureSubmitButton(animating: false)
 
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
@@ -79,7 +78,6 @@ final class SiteCredentialsViewController: LoginViewController {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
     }
-
 
     // MARK: - Overrides
 
@@ -93,7 +91,7 @@ final class SiteCredentialsViewController: LoginViewController {
 
         view.backgroundColor = unifiedBackgroundColor
     }
-    
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
@@ -142,7 +140,7 @@ final class SiteCredentialsViewController: LoginViewController {
             if !message.isEmpty {
                 tracker.track(failure: message)
             }
-            
+
             errorMessage = message
             shouldChangeVoiceOverFocus = moveVoiceOverFocus
             loadRows()
@@ -153,7 +151,6 @@ final class SiteCredentialsViewController: LoginViewController {
     /// No-op. Required by LoginFacade.
     func displayLoginMessage(_ message: String) {}
 }
-
 
 // MARK: - UITableViewDataSource
 extension SiteCredentialsViewController: UITableViewDataSource {
@@ -174,7 +171,6 @@ extension SiteCredentialsViewController: UITableViewDataSource {
     }
 }
 
-
 // MARK: - UITableViewDelegate conformance
 extension SiteCredentialsViewController: UITableViewDelegate {
     /// After a textfield cell is done displaying, remove the textfield reference.
@@ -192,7 +188,6 @@ extension SiteCredentialsViewController: UITableViewDelegate {
     }
 }
 
-
 // MARK: - Keyboard Notifications
 extension SiteCredentialsViewController: NUXKeyboardResponder {
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {
@@ -203,7 +198,6 @@ extension SiteCredentialsViewController: NUXKeyboardResponder {
         keyboardWillHide(notification)
     }
 }
-
 
 // MARK: - TextField Delegate conformance
 extension SiteCredentialsViewController: UITextFieldDelegate {
@@ -222,7 +216,6 @@ extension SiteCredentialsViewController: UITextFieldDelegate {
         return true
     }
 }
-
 
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
@@ -347,7 +340,7 @@ private extension SiteCredentialsViewController {
             guard let self = self else {
                 return
             }
-            
+
             self.tracker.track(click: .forgottenPassword)
 
             // If information is currently processing, ignore button tap.
@@ -377,7 +370,7 @@ private extension SiteCredentialsViewController {
             usernameField?.becomeFirstResponder()
         }
     }
-    
+
     // MARK: - Private Constants
 
     /// Rows listed in the order they were created.
@@ -405,7 +398,6 @@ private extension SiteCredentialsViewController {
         }
     }
 }
-
 
 // MARK: - Instance Methods
 /// Implementation methods copied from LoginSelfHostedViewController.

--- a/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
+++ b/WordPressAuthenticatorTests/Analytics/AnalyticsTrackerTests.swift
@@ -2,34 +2,34 @@ import XCTest
 @testable import WordPressAuthenticator
 
 class AnalyticsTrackerTests: XCTestCase {
-    
+
     // MARK: - Expectations: Building the properties dictionary
-    
+
     private func expectedProperties(source: AuthenticatorAnalyticsTracker.Source, flow: AuthenticatorAnalyticsTracker.Flow, step: AuthenticatorAnalyticsTracker.Step) -> [String: String] {
-        
+
         return [
             AuthenticatorAnalyticsTracker.Property.source.rawValue: source.rawValue,
             AuthenticatorAnalyticsTracker.Property.flow.rawValue: flow.rawValue,
             AuthenticatorAnalyticsTracker.Property.step.rawValue: step.rawValue
         ]
     }
-    
+
     private func expectedProperties(source: AuthenticatorAnalyticsTracker.Source, flow: AuthenticatorAnalyticsTracker.Flow, step: AuthenticatorAnalyticsTracker.Step, failure: String) -> [String: String] {
-        
+
         var properties = expectedProperties(source: source, flow: flow, step: step)
         properties[AuthenticatorAnalyticsTracker.Property.failure.rawValue] = failure
-        
+
         return properties
     }
-    
+
     private func expectedProperties(source: AuthenticatorAnalyticsTracker.Source, flow: AuthenticatorAnalyticsTracker.Flow, step: AuthenticatorAnalyticsTracker.Step, click: AuthenticatorAnalyticsTracker.ClickTarget) -> [String: String] {
-        
+
         var properties = expectedProperties(source: source, flow: flow, step: step)
         properties[AuthenticatorAnalyticsTracker.Property.click.rawValue] = click.rawValue
-        
+
         return properties
     }
-    
+
     /// Test that when tracking an event through the AnalyticsTracker, the backing analytics tracker
     /// receives a matching event.
     ///
@@ -37,28 +37,28 @@ class AnalyticsTrackerTests: XCTestCase {
         let source = AuthenticatorAnalyticsTracker.Source.reauthentication
         let flow = AuthenticatorAnalyticsTracker.Flow.loginWithGoogle
         let step = AuthenticatorAnalyticsTracker.Step.start
-        
+
         let expectedEventName = AuthenticatorAnalyticsTracker.EventType.step.rawValue
         let expectedEventProperties = self.expectedProperties(source: source, flow: flow, step: step)
         let trackingIsOk = expectation(description: "The parameters of the tracking call are as expected")
-        
+
         let track = { (event: AnalyticsEvent) in
             if event.name == expectedEventName
                 && event.properties == expectedEventProperties {
-                
+
                 trackingIsOk.fulfill()
             }
         }
-    
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
-        
+
         tracker.set(source: source)
         tracker.set(flow: flow)
         tracker.track(step: step)
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     /// Test that tracking a failure maintains the source, flow and step from the previously recorded step.
     ///
     /// Ref: pbArwn-I6-p2
@@ -68,30 +68,30 @@ class AnalyticsTrackerTests: XCTestCase {
         let flow = AuthenticatorAnalyticsTracker.Flow.loginWithGoogle
         let step = AuthenticatorAnalyticsTracker.Step.start
         let failure = "some error"
-        
+
         let expectedEventName = AuthenticatorAnalyticsTracker.EventType.failure.rawValue
         let expectedEventProperties = self.expectedProperties(source: source, flow: flow, step: step, failure: failure)
         let trackingIsOk = expectation(description: "The parameters of the tracking call are as expected")
-        
+
         let track = { (event: AnalyticsEvent) in
             // We'll ignore the first event and only check the properties from the failure.
             if event.name == expectedEventName
                 && event.properties == expectedEventProperties {
-                
+
                 trackingIsOk.fulfill()
             }
         }
 
         let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
-        
+
         tracker.set(source: source)
         tracker.set(flow: flow)
         tracker.track(step: step)
         tracker.track(failure: failure)
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     /// Test that tracking a click maintains the source, flow and step from the previously recorded step.
     ///
     /// Ref: pbArwn-I6-p2
@@ -101,195 +101,195 @@ class AnalyticsTrackerTests: XCTestCase {
         let flow = AuthenticatorAnalyticsTracker.Flow.loginWithGoogle
         let step = AuthenticatorAnalyticsTracker.Step.start
         let click = AuthenticatorAnalyticsTracker.ClickTarget.dismiss
-        
+
         let expectedEventName = AuthenticatorAnalyticsTracker.EventType.interaction.rawValue
         let expectedEventProperties = self.expectedProperties(source: source, flow: flow, step: step, click: click)
         let trackingIsOk = expectation(description: "The parameters of the tracking call are as expected")
-        
+
         let track = { (event: AnalyticsEvent) in
             // We'll ignore the first event and only check the properties from the failure.
             if event.name == expectedEventName
                 && event.properties == expectedEventProperties {
-                
+
                 trackingIsOk.fulfill()
             }
         }
-        
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
-        
+
         tracker.set(source: source)
         tracker.set(flow: flow)
         tracker.track(step: step)
         tracker.track(click: click)
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     // MARK: - Legacy Tracking Support Tests
-    
+
     /// Tests legacy tracking for a step
     ///
     func testStepLegacyTracking() {
         let source = AuthenticatorAnalyticsTracker.Source.default
         let flows: [AuthenticatorAnalyticsTracker.Flow] = [.loginWithApple, .signupWithApple, .loginWithGoogle, .signupWithGoogle, .loginWithSiteAddress]
         let step = AuthenticatorAnalyticsTracker.Step.start
-        
+
         let legacyTrackingExecuted = expectation(description: "The legacy tracking block was executed.")
         legacyTrackingExecuted.expectedFulfillmentCount = flows.count
-        
-        let track = { (event: AnalyticsEvent) in
+
+        let track = { (_: AnalyticsEvent) in
             XCTFail()
         }
-        
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: false, track: track)
-        
+
         tracker.set(source: source)
-        
+
         for flow in flows {
             tracker.set(flow: flow)
             tracker.track(step: step, ifTrackingNotEnabled: {
                 legacyTrackingExecuted.fulfill()
             })
         }
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     /// Tests the new  tracking for a step
     ///
     func testStepNewTracking() {
         let source = AuthenticatorAnalyticsTracker.Source.default
         let flows: [AuthenticatorAnalyticsTracker.Flow] = [.loginWithApple, .signupWithApple, .loginWithGoogle, .signupWithGoogle, .loginWithSiteAddress]
         let step = AuthenticatorAnalyticsTracker.Step.start
-        
+
         let legacyTrackingExecuted = expectation(description: "The legacy tracking block was executed.")
         legacyTrackingExecuted.expectedFulfillmentCount = flows.count
-        
-        let track = { (event: AnalyticsEvent) in
+
+        let track = { (_: AnalyticsEvent) in
             legacyTrackingExecuted.fulfill()
         }
-        
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
-        
+
         tracker.set(source: source)
-        
+
         for flow in flows {
             tracker.set(flow: flow)
             tracker.track(step: step, ifTrackingNotEnabled: {
                 XCTFail()
             })
         }
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     /// Tests legacy tracking for a click interaction
     ///
     func testClickLegacyTracking() {
         let source = AuthenticatorAnalyticsTracker.Source.default
         let flows: [AuthenticatorAnalyticsTracker.Flow] = [.loginWithApple, .signupWithApple, .loginWithGoogle, .signupWithGoogle, .loginWithSiteAddress]
         let click = AuthenticatorAnalyticsTracker.ClickTarget.connectSite
-        
+
         let legacyTrackingExecuted = expectation(description: "The legacy tracking block was executed.")
         legacyTrackingExecuted.expectedFulfillmentCount = flows.count
-        
-        let track = { (event: AnalyticsEvent) in
+
+        let track = { (_: AnalyticsEvent) in
             XCTFail()
         }
-        
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: false, track: track)
-        
+
         tracker.set(source: source)
-        
+
         for flow in flows {
             tracker.set(flow: flow)
             tracker.track(click: click, ifTrackingNotEnabled: {
                 legacyTrackingExecuted.fulfill()
             })
         }
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     /// Tests the new  tracking for a click interaction
     ///
     func testClickNewTracking() {
         let source = AuthenticatorAnalyticsTracker.Source.default
         let flows: [AuthenticatorAnalyticsTracker.Flow] = [.loginWithApple, .signupWithApple, .loginWithGoogle, .signupWithGoogle, .loginWithSiteAddress]
         let click = AuthenticatorAnalyticsTracker.ClickTarget.connectSite
-        
+
         let legacyTrackingExecuted = expectation(description: "The legacy tracking block was executed.")
         legacyTrackingExecuted.expectedFulfillmentCount = flows.count
-        
-        let track = { (event: AnalyticsEvent) in
+
+        let track = { (_: AnalyticsEvent) in
             legacyTrackingExecuted.fulfill()
         }
-        
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
-        
+
         tracker.set(source: source)
-        
+
         for flow in flows {
             tracker.set(flow: flow)
             tracker.track(click: click, ifTrackingNotEnabled: {
                 XCTFail()
             })
         }
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     /// Tests legacy tracking for a failure
     ///
     func testFailureLegacyTracking() {
         let source = AuthenticatorAnalyticsTracker.Source.default
         let flows: [AuthenticatorAnalyticsTracker.Flow] = [.loginWithApple, .signupWithApple, .loginWithGoogle, .signupWithGoogle, .loginWithSiteAddress]
-        
+
         let legacyTrackingExecuted = expectation(description: "The legacy tracking block was executed.")
         legacyTrackingExecuted.expectedFulfillmentCount = flows.count
-        
-        let track = { (event: AnalyticsEvent) in
+
+        let track = { (_: AnalyticsEvent) in
             XCTFail()
         }
-        
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: false, track: track)
-        
+
         tracker.set(source: source)
-        
+
         for flow in flows {
             tracker.set(flow: flow)
             tracker.track(failure: "error", ifTrackingNotEnabled: {
                 legacyTrackingExecuted.fulfill()
             })
         }
-        
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     /// Tests the new  tracking for a failure
     ///
     func testFailureNewTracking() {
         let source = AuthenticatorAnalyticsTracker.Source.default
         let flows: [AuthenticatorAnalyticsTracker.Flow] = [.loginWithApple, .signupWithApple, .loginWithGoogle, .signupWithGoogle, .loginWithSiteAddress]
-        
+
         let legacyTrackingExecuted = expectation(description: "The legacy tracking block was executed.")
         legacyTrackingExecuted.expectedFulfillmentCount = flows.count
-        
-        let track = { (event: AnalyticsEvent) in
+
+        let track = { (_: AnalyticsEvent) in
             legacyTrackingExecuted.fulfill()
         }
-        
+
         let tracker = AuthenticatorAnalyticsTracker(enabled: true, track: track)
-        
+
         tracker.set(source: source)
-        
+
         for flow in flows {
             tracker.set(flow: flow)
             tracker.track(failure: "error", ifTrackingNotEnabled: {
                 XCTFail()
             })
         }
-        
+
         waitForExpectations(timeout: 0.1)
     }
 }

--- a/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
@@ -18,11 +18,11 @@ class PasteboardTests: XCTestCase {
         let pasteboard = UIPasteboard.general
         pasteboard.string = "123456"
 
-        UIPasteboard.general.detectAuthenticatorCode() { result in
+        UIPasteboard.general.detectAuthenticatorCode { result in
             switch result {
                 case .success(let authenticationCode):
                     XCTAssertEqual(authenticationCode, "123456")
-                case .failure(_):
+                case .failure:
                     XCTAssert(false)
             }
             expect.fulfill()
@@ -40,11 +40,11 @@ class PasteboardTests: XCTestCase {
         let pasteboard = UIPasteboard.general
         pasteboard.string = "012345"
 
-        UIPasteboard.general.detectAuthenticatorCode() { result in
+        UIPasteboard.general.detectAuthenticatorCode { result in
             switch result {
                 case .success(let authenticationCode):
                     XCTAssertEqual(authenticationCode, "012345")
-                case .failure(_):
+                case .failure:
                     XCTAssert(false)
             }
             expect.fulfill()

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorDisplayTextTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorDisplayTextTests.swift
@@ -7,7 +7,7 @@ class WordPressAuthenticatorDisplayTextTests: XCTestCase {
     /// Default display text instance
     ///
     let displayTextDefaults = WordPressAuthenticatorDisplayStrings.defaultStrings
-    
+
     /// Verifies that values in defaultText are not nil
     ///
     func testThatDefaultTextValuesAreNotNil() {

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -52,7 +52,7 @@ class WordPressAuthenticatorTests: XCTestCase {
     // MARK: WordPressAuthenticator Notification Tests
     func testDispatchesSupportPushNotificationReceived() {
         let authenticator = WordpressAuthenticatorProvider.getWordpressAuthenticator()
-        let _ = expectation(forNotification: .wordpressSupportNotificationReceived, object: nil, handler: nil)
+        _ = expectation(forNotification: .wordpressSupportNotificationReceived, object: nil, handler: nil)
 
         authenticator.supportPushNotificationReceived()
 
@@ -61,7 +61,7 @@ class WordPressAuthenticatorTests: XCTestCase {
 
     func testDispatchesSupportPushNotificationCleared() {
         let authenticator = WordpressAuthenticatorProvider.getWordpressAuthenticator()
-        let _ = expectation(forNotification: .wordpressSupportNotificationCleared, object: nil, handler: nil)
+        _ = expectation(forNotification: .wordpressSupportNotificationCleared, object: nil, handler: nil)
 
         authenticator.supportPushNotificationCleared()
 
@@ -74,7 +74,6 @@ class WordPressAuthenticatorTests: XCTestCase {
         let nuxViewController = NUXViewController()
         let nuxTableViewController = NUXTableViewController()
         let basicViewController = UIViewController()
-
 
         XCTAssertTrue(WordPressAuthenticator.isAuthenticationViewController(loginViewcontroller))
         XCTAssertTrue(WordPressAuthenticator.isAuthenticationViewController(nuxViewController))

--- a/WordPressAuthenticatorTests/Authenticator/WordPressSourceTagTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressSourceTagTests.swift
@@ -2,122 +2,122 @@ import XCTest
 import WordPressAuthenticator
 
 class WordPressSourceTagTests: XCTestCase {
-    
+
     func testGeneralLoginSourceTag() {
         let tag = WordPressSupportSourceTag.generalLogin
-        
+
         XCTAssertEqual(tag.name, "generalLogin")
         XCTAssertEqual(tag.origin, "origin:login-screen")
     }
-    
+
     func testJetpackLoginSourceTag() {
         let tag = WordPressSupportSourceTag.jetpackLogin
-        
+
         XCTAssertEqual(tag.name, "jetpackLogin")
         XCTAssertEqual(tag.origin, "origin:jetpack-login-screen")
     }
-    
+
     func testLoginEmailSourceTag() {
         let tag = WordPressSupportSourceTag.loginEmail
-        
+
         XCTAssertEqual(tag.name, "loginEmail")
         XCTAssertEqual(tag.origin, "origin:login-email")
     }
-    
+
     func testLoginAppleSourceTag() {
         let tag = WordPressSupportSourceTag.loginApple
 
         XCTAssertEqual(tag.name, "loginApple")
         XCTAssertEqual(tag.origin, "origin:login-apple")
     }
-    
+
     func testlogin2FASourceTag() {
         let tag = WordPressSupportSourceTag.login2FA
 
         XCTAssertEqual(tag.name, "login2FA")
         XCTAssertEqual(tag.origin, "origin:login-2fa")
     }
-    
+
     func testLoginMagicLinkSourceTag() {
         let tag = WordPressSupportSourceTag.loginMagicLink
-        
+
         XCTAssertEqual(tag.name, "loginMagicLink")
         XCTAssertEqual(tag.origin, "origin:login-magic-link")
     }
-    
+
     func testSiteAddressSourceTag() {
         let tag = WordPressSupportSourceTag.loginSiteAddress
 
         XCTAssertEqual(tag.name, "loginSiteAddress")
         XCTAssertEqual(tag.origin, "origin:login-site-address")
     }
-    
+
     func testLoginUsernameSourceTag() {
         let tag = WordPressSupportSourceTag.loginUsernamePassword
 
         XCTAssertEqual(tag.name, "loginUsernamePassword")
         XCTAssertEqual(tag.origin, "origin:login-username-password")
     }
-    
+
     func testLoginUsernamePasswordSourceTag() {
         let tag = WordPressSupportSourceTag.loginWPComUsernamePassword
 
         XCTAssertEqual(tag.name, "loginWPComUsernamePassword")
         XCTAssertEqual(tag.origin, "origin:wpcom-login-username-password")
     }
-    
+
     func testLoginWPComPasswordSourceTag() {
         let tag = WordPressSupportSourceTag.loginWPComPassword
 
         XCTAssertEqual(tag.name, "loginWPComPassword")
         XCTAssertEqual(tag.origin, "origin:login-wpcom-password")
     }
-    
+
     func testWPComSignupEmailSourceTag() {
         let tag = WordPressSupportSourceTag.wpComSignupEmail
 
         XCTAssertEqual(tag.name, "wpComSignupEmail")
         XCTAssertEqual(tag.origin, "origin:wpcom-signup-email-entry")
     }
-    
+
     func testWPComSignupSourceTag() {
         let tag = WordPressSupportSourceTag.wpComSignup
 
         XCTAssertEqual(tag.name, "wpComSignup")
         XCTAssertEqual(tag.origin, "origin:signup-screen")
     }
-    
+
     func testWPComSignupWaitingForGoogleSourceTag() {
         let tag = WordPressSupportSourceTag.wpComSignupWaitingForGoogle
 
         XCTAssertEqual(tag.name, "wpComSignupWaitingForGoogle")
         XCTAssertEqual(tag.origin, "origin:signup-waiting-for-google")
     }
-    
+
     func testWPComAuthGoogleSignupWaitingForGoogleSourceTag() {
         let tag = WordPressSupportSourceTag.wpComAuthWaitingForGoogle
 
         XCTAssertEqual(tag.name, "wpComAuthWaitingForGoogle")
         XCTAssertEqual(tag.origin, "origin:auth-waiting-for-google")
     }
-    
+
     func testWPComAuthGoogleSignupConfirmationSourceTag() {
         let tag = WordPressSupportSourceTag.wpComAuthGoogleSignupConfirmation
 
         XCTAssertEqual(tag.name, "wpComAuthGoogleSignupConfirmation")
         XCTAssertEqual(tag.origin, "origin:auth-google-signup-confirmation")
     }
-    
+
     func testWPComSignupMagicLinkSourceTag() {
         let tag = WordPressSupportSourceTag.wpComSignupMagicLink
 
         XCTAssertEqual(tag.name, "wpComSignupMagicLink")
         XCTAssertEqual(tag.origin, "origin:signup-magic-link")
     }
-    
+
     func testWPComSignupAppleSourceTag() {
         let tag = WordPressSupportSourceTag.wpComSignupApple
-        
+
         XCTAssertEqual(tag.name, "wpComSignupApple")
         XCTAssertEqual(tag.origin, "origin:signup-apple")
     }

--- a/WordPressAuthenticatorTests/Credentials/CredentialsTests.swift
+++ b/WordPressAuthenticatorTests/Credentials/CredentialsTests.swift
@@ -2,37 +2,36 @@ import XCTest
 @testable import WordPressAuthenticator
 
 class CredentialsTests: XCTestCase {
-    
+
     let token = "arstdhneio123456789qwfpgjluy"
     let siteURL = "https://example.com"
     let username = "user123"
     let password = "arstdhneio"
     let xmlrpc = "https://example.com/xmlrpc.php"
-    
-    
+
     func testWordpressComCredentialsInit() {
         let wpcomCredentials = WordPressComCredentials(authToken: token,
                                                        isJetpackLogin: false,
                                                        multifactor: false,
                                                        siteURL: siteURL)
-        
+
         XCTAssertEqual(wpcomCredentials.authToken, token)
         XCTAssertEqual(wpcomCredentials.isJetpackLogin, false)
         XCTAssertEqual(wpcomCredentials.multifactor, false)
         XCTAssertEqual(wpcomCredentials.siteURL, siteURL)
     }
-    
+
     func testWordPressComCredentialsSiteURLReturnsDefaultValue() {
         let wpcomCredentials = WordPressComCredentials(authToken: token,
                                                        isJetpackLogin: false,
                                                        multifactor: false,
                                                        siteURL: "")
-        
+
         let expected = "https://wordpress.com"
-    
+
         XCTAssertEqual(wpcomCredentials.siteURL, expected)
     }
-    
+
     func testWordPressComCredentialsEquatableReturnsCorrectValue() {
         let credential = WordPressComCredentials(authToken: token,
                                                  isJetpackLogin: false,
@@ -65,46 +64,46 @@ class CredentialsTests: XCTestCase {
         XCTAssertNotEqual(credential, differentSiteURL)
         XCTAssertNotEqual(credential, differentAuthToken)
     }
-    
+
     func testWordpressOrgCredentialsInit() {
         let wporgcredentials = WordPressOrgCredentials(username: username,
                                                   password: password,
                                                   xmlrpc: xmlrpc,
                                                   options: [:])
-        
+
         XCTAssertEqual(wporgcredentials.username, username)
         XCTAssertEqual(wporgcredentials.password, password)
         XCTAssertEqual(wporgcredentials.xmlrpc, xmlrpc)
     }
-    
+
     func testWordPressOrgCredentialsEquatable() {
         let lhs = WordPressOrgCredentials(username: username,
                                           password: password,
                                           xmlrpc: xmlrpc,
                                           options: [:])
-        
+
         let rhs = WordPressOrgCredentials(username: username,
                                           password: password,
                                           xmlrpc: xmlrpc,
                                           options: [:])
-        
+
         XCTAssertTrue(lhs == rhs)
     }
-    
+
     func testWordPressOrgCredentialsNotEquatable() {
         let lhs = WordPressOrgCredentials(username: username,
                                           password: password,
                                           xmlrpc: xmlrpc,
                                           options: [:])
-        
+
         let rhs = WordPressOrgCredentials(username: "username5678",
                                           password: password,
                                           xmlrpc: xmlrpc,
                                           options: [:])
-        
+
         XCTAssertFalse(lhs == rhs)
     }
-    
+
     func testAuthenticatorCredentialsInit() {
         let wporgCredentials = WordPressOrgCredentials(username: username,
                                                        password: password,
@@ -116,8 +115,7 @@ class CredentialsTests: XCTestCase {
                                                        siteURL: siteURL)
         let authenticatorCredentials = AuthenticatorCredentials(wpcom: wpcomCredentials,
                                                                 wporg: wporgCredentials)
-        
-        
+
         XCTAssertEqual(authenticatorCredentials.wpcom?.authToken, token)
         XCTAssertEqual(authenticatorCredentials.wpcom?.isJetpackLogin, false)
         XCTAssertEqual(authenticatorCredentials.wpcom?.multifactor, false)
@@ -127,6 +125,4 @@ class CredentialsTests: XCTestCase {
         XCTAssertEqual(authenticatorCredentials.wporg?.xmlrpc, xmlrpc)
     }
 
-    
 }
-    

--- a/WordPressAuthenticatorTests/Email Client Picker/AppSelectorTests.swift
+++ b/WordPressAuthenticatorTests/Email Client Picker/AppSelectorTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import WordPressAuthenticator
 
-
 struct URLMocks {
 
     static let mockAppList = ["gmail": "googlemail://", "airmail": "airmail://"]
@@ -20,7 +19,7 @@ class MockUrlHandler: URLHandler {
         return shouldOpenUrls
     }
 
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?) {
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
         openUrlExpectation?.fulfill()
     }
 }

--- a/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
+++ b/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
@@ -12,13 +12,13 @@ public class WordpressAuthenticatorProvider: NSObject {
                                                    googleLoginScheme: "com.googleuserconsent.apps",
                                                    userAgent: "")
     }
-    
+
     static func wordPressAuthenticatorStyle(_ style: AuthenticatorStyeType) -> WordPressAuthenticatorStyle {
         var wpAuthStyle: WordPressAuthenticatorStyle!
-        
+
         switch style {
         case .random:
-            wpAuthStyle = WordPressAuthenticatorStyle (
+            wpAuthStyle = WordPressAuthenticatorStyle(
                 primaryNormalBackgroundColor: UIColor.random(),
                 primaryNormalBorderColor: UIColor.random(),
                 primaryHighlightBackgroundColor: UIColor.random(),
@@ -47,13 +47,13 @@ public class WordpressAuthenticatorProvider: NSObject {
             return wpAuthStyle
         }
     }
-    
+
     static func wordPressAuthenticatorUnifiedStyle(_ style: AuthenticatorStyeType) -> WordPressAuthenticatorUnifiedStyle {
         var wpUnifiedAuthStyle: WordPressAuthenticatorUnifiedStyle!
-        
+
         switch style {
         case .random:
-            wpUnifiedAuthStyle = WordPressAuthenticatorUnifiedStyle (
+            wpUnifiedAuthStyle = WordPressAuthenticatorUnifiedStyle(
                 borderColor: UIColor.random(),
                 errorColor: UIColor.random(),
                 textColor: UIColor.random(),
@@ -71,29 +71,27 @@ public class WordpressAuthenticatorProvider: NSObject {
 
     static func getWordpressAuthenticator() -> WordPressAuthenticator {
         return WordPressAuthenticator(
-            configuration:wordPressAuthenticatorConfiguration(),
+            configuration: wordPressAuthenticatorConfiguration(),
             style: wordPressAuthenticatorStyle(.random),
             unifiedStyle: wordPressAuthenticatorUnifiedStyle(.random),
             displayImages: WordPressAuthenticatorDisplayImages.defaultImages,
             displayStrings: WordPressAuthenticatorDisplayStrings.defaultStrings)
     }
-    
+
     @objc
     static func initializeWordPressAuthenticator() {
         WordPressAuthenticator.initialize(
-            configuration:wordPressAuthenticatorConfiguration(),
+            configuration: wordPressAuthenticatorConfiguration(),
             style: wordPressAuthenticatorStyle(.random),
             unifiedStyle: wordPressAuthenticatorUnifiedStyle(.random),
             displayImages: WordPressAuthenticatorDisplayImages.defaultImages,
             displayStrings: WordPressAuthenticatorDisplayStrings.defaultStrings)
     }
 }
-
 
 enum AuthenticatorStyeType {
     case random
 }
-
 
 extension CGFloat {
     static func random() -> CGFloat {
@@ -104,9 +102,9 @@ extension CGFloat {
 extension UIColor {
     static func random() -> UIColor {
         return UIColor(
-            red:   .random(),
+            red: .random(),
             green: .random(),
-            blue:  .random(),
+            blue: .random(),
             alpha: 1.0
         )
     }

--- a/WordPressAuthenticatorTests/Model/LoginFieldsValidationTests.swift
+++ b/WordPressAuthenticatorTests/Model/LoginFieldsValidationTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import WordPressAuthenticator
 
-
 // MARK: - LoginFields Validation Tests
 //
 class LoginFieldsValidationTests: XCTestCase {
@@ -33,10 +32,10 @@ class LoginFieldsValidationTests: XCTestCase {
 
         loginFields.siteAddress = "hostname"
         XCTAssertTrue(loginFields.validateSiteForSignin(), "Hostnames should validate.")
-        
+
         loginFields.siteAddress = "http://hostname"
         XCTAssert(loginFields.validateSiteForSignin(), "Since we want to validate simple mistakes, to use a hostname you'll need an http:// or https:// prefix.")
-        
+
         loginFields.siteAddress = "https://hostname"
         XCTAssert(loginFields.validateSiteForSignin(), "Since we want to validate simple mistakes, to use a hostname you'll need an http:// or https:// prefix.")
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/16145
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16186

When a user enters a site address to log in, `wp-admin` is removed before string is validated. Previously, if anything came after `wp-admin` the regex match would fail, causing the API not to recognize the URL. This change updates the regex pattern to remove `wp-admin` and anything after it.

Bonus: I added the clear button to text entry fields in the auth views, set to appear when editing.

<kbd><img width="400" alt="Screen Shot 2021-03-29 at 3 28 02 PM" src="https://user-images.githubusercontent.com/1816888/112902676-b70bb980-90a3-11eb-89b6-80915602ab8b.png">
</kbd>


Can be tested with the referenced WPiOS PR.

Note: `swiftlint autocorrect` found _a lot_ of changes. The commit for this fix is https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/commit/c03682599606e28298c472327f80a459510f12fb.