### PR TITLE
Fix: Flickering navigation bar when going back to LoginPrologueViewController with interactive gesture

### DIFF
--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -76,7 +76,7 @@ class LoginPrologueViewController: LoginViewController {
         super.viewWillAppear(animated)
 
         configureButtonVC()
-        navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -45,6 +45,9 @@ final class SiteAddressViewController: LoginViewController {
 
         siteURLField?.text = loginFields.siteAddress
         configureSubmitButton(animating: false)
+
+        // Nav bar could be hidden from the host app, so reshow it.
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -232,9 +235,6 @@ private extension SiteAddressViewController {
     func configureNavBar() {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
-
-        // Nav bar could be hidden from the host app, so reshow it.
-        navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
     func setupTable() {


### PR DESCRIPTION
Simple fix for flickering navigation bar while interactive pop gesture. 
Turned out that similar issue was also present in SiteAddressViewController.swift.

|Was|After fix|
|---|---|
| ![appVideo-bug](https://user-images.githubusercontent.com/21970451/113187954-c0d71d80-9259-11eb-9e08-23d957be5e2a.gif) | ![appVideo](https://user-images.githubusercontent.com/21970451/113187964-c3d20e00-9259-11eb-8b51-d115fd7ce87e.gif)|

Fixes #584 