### PR TITLE
Disable sending of the email if the enableSignUp isn't on

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.36.0"
+  s.version       = "1.37.0-beta.1"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -400,7 +400,7 @@ private extension GetStartedViewController {
         let userInfo = (error as NSError).userInfo
         let errorCode = userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
 
-        if errorCode == "unknown_user" {
+        if WordPressAuthenticator.shared.configuration.enableSignUp, errorCode == "unknown_user" {
             self.sendEmail()
         } else if errorCode == "email_login_not_allowed" {
                 // If we get this error, we know we have a WordPress.com user but their


### PR DESCRIPTION
If the `enableSignUp` flag is off would still send the user an email to sign up, this adds a check to make sure the flag is enabled before doing that.

You can test using: https://github.com/wordpress-mobile/WordPress-iOS/pull/16344

