### PR TITLE
Fixes a styling issue.

### DIFF
--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -52,7 +52,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         super.viewDidLoad()
 
         displayError(message: "")
-        styleNavigationBar()
+        styleNavigationBar(forUnified: true)
         styleBackground()
         styleInstructions()
 


### PR DESCRIPTION
Fixes a styling issue within the navigation bar (when embedded in a `LoginViewController`), that would show the wrong color for text in nav bar buttons and titles.

Related to https://github.com/wordpress-mobile/WordPress-iOS/issues/16380

## Known issues:

These will be tackled incrementally, to avoid holding this fix back.

- The back button is not perfectly aligned with the left chevron.
- The "Change Username" screen is shown twice the first time the user taps to open it.
- The UI looks a bit odd in terms of the coloring, both in the login epilogue and in the username selection screens.

## Associated PRs

WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/16389

## Testing:

Follow the instructions in the associated WPiOS PR.