### PR TITLE
Fix the error message for sites that retun a 403 error

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -396,7 +396,7 @@
 		F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsAuthenticator.swift; sourceTree = "<group>"; };
 		F5C817E62582B2F300BD5A3B /* UIPasteboard+Detect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Detect.swift"; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
-		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; };
+		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressKit
 
 /// Part two of the self-hosted sign in flow: username + password. Used by WPiOS and NiOS.
 /// A valid site address should be acquired before presenting this view controller.
@@ -436,7 +437,8 @@ extension SiteCredentialsViewController {
     override func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
         let err = error as NSError
-        if err.code == 403 {
+        let statusCode = err.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String] as? Int
+        if err.code == 403 || statusCode == 403 {
             let message = NSLocalizedString("It looks like this username/password isn't associated with this site.",
                                             comment: "An error message shown during log in when the username or password is incorrect.")
             displayError(message: message, moveVoiceOverFocus: true)


### PR DESCRIPTION
### Description

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16337

Similar to https://github.com/wordpress-mobile/WordPressKit-iOS/pull/403

This PR uses the `WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode` to check against and see if 403 gets returned. This is the case when the username and password do not match. 

Before:
<img  width="200" src="https://user-images.githubusercontent.com/115071/119910903-0c7e0e80-bf0d-11eb-87cf-e44b82c5dee7.png" />

After:
<img  width="200" src="https://user-images.githubusercontent.com/115071/119910919-16a00d00-bf0d-11eb-9192-7c553f278c33.png" />

### Testing Details
Apply this patch and build the WordPress App. 

Try to add a new .org site.  
Type in the wrong username and password. Notice that the error makes sense.
