### PR TITLE
Restore Allowing UI Overrides for Login Errors

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.37.0"
+  s.version       = "1.38.0-beta.1"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/3962.

## Findings

The WooCommerce app does not allow automatic sign-up emails. If the entered email address is not recognized, it displays this custom error message:

<img src="https://user-images.githubusercontent.com/198826/120700219-a1818a00-c46e-11eb-93d9-ef442d2c7497.png" width="280">

However, this regressed when https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/574 was merged. And eventually got “fixed” again when https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/590 was merged. Funny how life works. It wasn't a complete fix though because it doesn't show the custom UI. It only shows an alert:

<img src="https://user-images.githubusercontent.com/198826/120701469-1acdac80-c470-11eb-94a9-8fa370c8caf9.gif" width="280">

## Solution

I restored a part of the changes in #574 so that the `WordPressAuthenticator.shared.delegate` is now inquired if it would like to display a custom UI before calling `displayError()`. 

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/968c1f2af497ac7a063c344d915a30bf7f3aecc1/WordPressAuthenticator/Unified%20Auth/View%20Related/Get%20Started/GetStartedViewController.swift#L411-L426

This is pretty much the same code as before, only in a different location. This is enough for the WooCommerce app to handle and display the UI. See https://github.com/woocommerce/woocommerce-ios/pull/4365 for the WIP branch. 

## Testing

### WordPress and Jetpack

Please test for regressions in WordPress and Jetpack. 

1. Use the draft branch in https://github.com/wordpress-mobile/WordPress-iOS/pull/16627. 
2. In WordPress, log in with an email that is not registered in WPCOM. WordPress should respond with “We've emailed you a signup link...”:
    <img src="https://user-images.githubusercontent.com/198826/120702288-253c7600-c471-11eb-98b6-622a0f18ee62.gif" width="280">
3. In Jetpack, log in with an email that is not registered in WPCOM. Jetpack should respond with “User does not exist”. 

    <img src="https://user-images.githubusercontent.com/198826/120702488-5cab2280-c471-11eb-953a-cce7118984c4.gif" width="280">

### WooCommerce (Optional)

If you have time, please test that WooCommerce will now display a custom UI. 

1. Use the draft branch: https://github.com/woocommerce/woocommerce-ios/pull/4365. 
2. Log in with an email that is not registered in WPCOM. The app should respond with the custom UI saying “It looks like this email is not associated with...”
    <img src="https://user-images.githubusercontent.com/198826/120702773-b4e22480-c471-11eb-87d4-1c694cbefbb9.gif" width="280">



