### PR TITLE
Fix Site Address UI Bugs When Displaying In-Page Errors

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.38.0-beta.2"
+  s.version       = "1.38.0-beta.3"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -289,6 +289,7 @@ private extension SiteAddressViewController {
         // Save a reference to the first textField so it can becomeFirstResponder.
         siteURLField = cell.textField
         cell.textField.delegate = self
+        cell.textField.text = loginFields.siteAddress
         cell.onChangeSelectionHandler = { [weak self] textfield in
             self?.loginFields.siteAddress = textfield.nonNilTrimmedText()
             self?.configureSubmitButton(animating: false)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -503,8 +503,9 @@ private extension SiteAddressViewController {
         // this causes the value of `loginFields.siteAddress` to be reset to what the user entered.
         //
         // Using the user-entered `loginFields.siteAddress` causes problems when we try to log
-        // the user in. For example, validating their self-hosted site credentials somehow
-        // fails. Especially if they only entered the domain (no url scheme).
+        // the user in especially if they just use a domain. For example, validating their
+        // self-hosted site credentials fails because the
+        // `WordPressOrgXMLRPCValidator.guessXMLRPCURLForSite` expects a complete site URL.
         //
         // This routine fixes that problem. We'll use what we already validated from
         // `fetchSiteInfo()`.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -494,6 +494,25 @@ private extension SiteAddressViewController {
     }
 
     func presentNextControllerIfPossible(siteInfo: WordPressComSiteInfo?) {
+
+        // Ensure that we're using the verified URL before passing the `loginFields` to the next
+        // view controller.
+        //
+        // In some scenarios, the text field change callback in `configureTextField()` gets executed
+        // right after we validated and modified `loginFields.siteAddress` in `validateForm()`. And
+        // this causes the value of `loginFields.siteAddress` to be reset to what the user entered.
+        //
+        // Using the user-entered `loginFields.siteAddress` causes problems when we try to log
+        // the user in. For example, validating their self-hosted site credentials somehow
+        // fails. Especially if they only entered the domain (no url scheme).
+        //
+        // This routine fixes that problem. We'll use what we already validated from
+        // `fetchSiteInfo()`.
+        //
+        if let verifiedSiteAddress = siteInfo?.url {
+            loginFields.siteAddress = verifiedSiteAddress
+        }
+
         guard siteInfo?.isWPCom == false else {
             showGetStarted()
             return

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -19,6 +19,8 @@ final class SiteAddressViewController: LoginViewController {
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
 
+    private var viewIsLoading: Bool = false
+
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         tracker.track(click: .submit)
@@ -120,6 +122,8 @@ final class SiteAddressViewController: LoginViewController {
     /// - Parameter loading: True if the form should be configured to a "loading" state.
     ///
     override func configureViewLoading(_ loading: Bool) {
+        viewIsLoading = loading
+
         siteURLField?.isEnabled = !loading
 
         configureSubmitButton(animating: loading)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -38,7 +38,7 @@ final class SiteAddressViewController: LoginViewController {
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()
-        configureSubmitButton(animating: false)
+        configureSubmitButton()
         configureForAccessibility()
     }
 
@@ -46,7 +46,7 @@ final class SiteAddressViewController: LoginViewController {
         super.viewWillAppear(animated)
 
         siteURLField?.text = loginFields.siteAddress
-        configureSubmitButton(animating: false)
+        configureSubmitButton()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -82,6 +82,10 @@ final class SiteAddressViewController: LoginViewController {
     ///
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
+    }
+
+    private func configureSubmitButton() {
+        configureSubmitButton(animating: viewIsLoading)
     }
 
     /// Configures the appearance and state of the submit button.
@@ -126,7 +130,7 @@ final class SiteAddressViewController: LoginViewController {
 
         siteURLField?.isEnabled = !loading
 
-        configureSubmitButton(animating: loading)
+        configureSubmitButton()
         navigationItem.hidesBackButton = loading
     }
 
@@ -296,7 +300,7 @@ private extension SiteAddressViewController {
         cell.textField.text = loginFields.siteAddress
         cell.onChangeSelectionHandler = { [weak self] textfield in
             self?.loginFields.siteAddress = textfield.nonNilTrimmedText()
-            self?.configureSubmitButton(animating: false)
+            self?.configureSubmitButton()
         }
 
         SigninEditingState.signinEditingStateActive = true

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -467,7 +467,6 @@ private extension SiteAddressViewController {
     }
 
     func fetchSiteInfo() {
-        print("🔴 SAVC > fetchSiteInfo")
         let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: loginFields.siteAddress)
         let service = WordPressComBlogService()
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -183,21 +183,6 @@ extension SiteAddressViewController: UITableViewDataSource {
     }
 }
 
-// MARK: - UITableViewDelegate conformance
-extension SiteAddressViewController: UITableViewDelegate {
-    /// After the site address textfield cell is done displaying, remove the textfield reference.
-    ///
-    func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        guard let row = rows[safe: indexPath.row] else {
-            return
-        }
-
-        if row == .siteAddress {
-            siteURLField = nil
-        }
-    }
-}
-
 // MARK: - Keyboard Notifications
 extension SiteAddressViewController: NUXKeyboardResponder {
     @objc func handleKeyboardWillShow(_ notification: Foundation.Notification) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -19,6 +19,13 @@ final class SiteAddressViewController: LoginViewController {
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
 
+    /// A state variable that is `true` if network calls are currently happening and so the
+    /// view should be showing a loading indicator.
+    ///
+    /// This should only be modified within `configureViewLoading(_ loading:)`.
+    ///
+    /// This state is mainly used in `configureSubmitButton()` to determine whether the button
+    /// should show an activity indicator.
     private var viewIsLoading: Bool = false
 
     // MARK: - Actions
@@ -84,6 +91,10 @@ final class SiteAddressViewController: LoginViewController {
         return WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
 
+    /// Configures the appearance and state of the submit button.
+    ///
+    /// Use this instead of the overridden `configureSubmitButton(animating:)` since this uses the
+    /// _current_ `viewIsLoading` state.
     private func configureSubmitButton() {
         configureSubmitButton(animating: viewIsLoading)
     }

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -49,6 +49,12 @@ class WordPressAuthenticatorTests: XCTestCase {
         XCTAssert(url == punycode)
     }
 
+    func testBaseSiteURLKeepsHTTPSchemeForNonWPSites() {
+        let url = "http://selfhostedsite.com"
+        let correctedURL = WordPressAuthenticator.baseSiteURL(string: url)
+        XCTAssertEqual(correctedURL, url)
+    }
+
     // MARK: WordPressAuthenticator Notification Tests
     func testDispatchesSupportPushNotificationReceived() {
         let authenticator = WordpressAuthenticatorProvider.getWordpressAuthenticator()


### PR DESCRIPTION
Part of fixing https://github.com/woocommerce/woocommerce-ios/issues/4034. 

There is a linked WP PR for this: https://github.com/wordpress-mobile/WordPress-iOS/pull/16655.

Originally intended to fix just WooCommerce but apparently, WP has the same issue. So this fixes both apps. 🤸 

## Findings

Both apps have this problem when logging in with a site address. This is for WordPress specifically:

1. Log in with a valid self-hosted site address **domain**. Don't include the scheme. Add a typo.
2. After the error is displayed, fix the typo. Still exclude the scheme.
3. Continue logging in, providing the valid credentials. The app will fail to log the user in. The `WordPressOrgXMLRPCValidator.guessXMLRPCURLForSite` fails because we did not provide the scheme. 

This problem only surfaces when the user made a mistake on the first try. Which is quite likely. It also happens if there was previously an XML-RPC error. Or any other error that is displayed below the site address text field. 

Here is a video showing this bug:


https://user-images.githubusercontent.com/198826/121266808-65886380-c878-11eb-9a6b-bdcd0c961036.mov


If there was no error on the first try, the app is able to log the user in because we [automatically fix the `siteAddress`](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/26e7de706cf36aee32a44134ae771e655e7d11cd/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L410). 

You'll also notice in the video that the text disappears when the error is displayed. And the Continue button also does not show the activity indicator anymore if the user tries a second time. It looks like the app is doing nothing. 

## Solution

### Logging In

For some reason, if the error is displayed at some point, the `loginFields.siteAddress` gets reset because this callback gets called: 

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/45d02a709a9c010131a320767c227d2fe072c146/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L312-L315

I still have no idea why that text field change callback is called. But I fixed it by resetting `loginFields.siteAddress` before any view controller is displayed. See [here for the fix](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/45d02a709a9c010131a320767c227d2fe072c146/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L498-L514). Let me know if there's a better way for this. 

### Disappearing Text

I fixed the disappearing text by resetting the value when the cell is recreated in `configureTextField`: 

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/aa020aa62cc50f6bc24e51d0fb6f64bcf871d79b/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L311

### Activity Indicator

The reason the activity indicator on the button does not show up when the user retries because this block gets called right after the activity indicator is shown:

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/26e7de706cf36aee32a44134ae771e655e7d11cd/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L309

So the activity indicator gets dismissed immediately. 

I fixed this by keeping the “view is loading” state in a variable: 

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/aa020aa62cc50f6bc24e51d0fb6f64bcf871d79b/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L22-L29

And making sure that the `configureSubmitButton` uses that state so the activity indicator is not unintentionally dismissed:

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/aa020aa62cc50f6bc24e51d0fb6f64bcf871d79b/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L94-L98

Let me know if there's a better way to do this. I wasn't quite sure how to properly handle this. I wanted to use a `didSet` handler but it looks like [`configureViewLoading`](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/aa020aa62cc50f6bc24e51d0fb6f64bcf871d79b/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteAddressViewController.swift#L135-L139) is an override from the parent class. So I couldn't just remove it. 

Here is the final result: 


https://user-images.githubusercontent.com/198826/121270712-71c3ef00-c87f-11eb-8bd1-77e3d8b87175.mov


## Testing

1. You can use the branch in https://github.com/wordpress-mobile/WordPress-iOS/pull/16655. 
2. Log in with a valid self-hosted site address **domain**. Don't include the scheme. Add a typo.
3. After the error is displayed, fix the typo. Still exclude the scheme.
4. Press Continue.
5. Confirm that the activity indicator is visible and the text field is disabled.
6. Provide the credentials.
7. Confirm that you were able to log in.


