### PR TITLE
Fix/Make SearchTableViewCell extension public

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.38.0-beta.2"
+  s.version       = "1.38.0-beta.3"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -76,7 +76,7 @@ extension SearchTableViewCell: UITextFieldDelegate {
 
 // MARK: - Loader
 //
-extension SearchTableViewCell {
+public extension SearchTableViewCell {
     func showLoader() {
         guard let leftView = textField.leftView else { return }
         let spinner = UIActivityIndicatorView(frame: leftView.frame)


### PR DESCRIPTION
This PR makes loading indicator methods public, which were implemented [here](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/597).