### PR TITLE
Update version to 1.38.0-beta.4

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.38.0-beta.3"
+  s.version       = "1.38.0-beta.4"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC


### PR DESCRIPTION
I messed up and didn't know there was already a 1.38.0-beta.3 when I merged https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/596. 