### PR TITLE
Log site address on errors. Bumps podspec version.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.38.0"
+  s.version       = "1.39.0-beta.1"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -430,7 +430,9 @@ private extension SiteAddressViewController {
                 guard let error = error, let self = self else {
                     return
                 }
-
+                // Intentionally log the attempted address on failures.
+                // It's not guarenteed to be included in the error object depending on the error.
+                DDLogInfo("Error attempting to connect to site address: \(self.loginFields.siteAddress)")
                 DDLogError(error.localizedDescription)
                 // TODO: - Tracks.
                 // WordPressAuthenticator.track(.loginFailedToGuessXMLRPC, error: error)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -431,7 +431,7 @@ private extension SiteAddressViewController {
                     return
                 }
                 // Intentionally log the attempted address on failures.
-                // It's not guarenteed to be included in the error object depending on the error.
+                // It's not guaranteed to be included in the error object depending on the error.
                 DDLogInfo("Error attempting to connect to site address: \(self.loginFields.siteAddress)")
                 DDLogError(error.localizedDescription)
                 // TODO: - Tracks.


### PR DESCRIPTION
This PR intentionally logs the attempted URL when there is an error trying to connect to a site address, since not all errors include the address. This will help happiness engineers to troubleshoot issues with a site before responding to a help request. 

This can be tested with the related WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16747

@ScoutHarris would you mind? 