### PR TITLE
Merge 1.39.0 into trunk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,7 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
@@ -92,4 +95,4 @@ DEPENDENCIES
   cocoapods (~> 1.10.0)!
 
 BUNDLED WITH
-   2.2.1
+   2.2.21

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.38.0"
+  s.version       = "1.39.0-beta.1"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.39.0-beta.1"
+  s.version       = "1.39.0"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -430,7 +430,9 @@ private extension SiteAddressViewController {
                 guard let error = error, let self = self else {
                     return
                 }
-
+                // Intentionally log the attempted address on failures.
+                // It's not guarenteed to be included in the error object depending on the error.
+                DDLogInfo("Error attempting to connect to site address: \(self.loginFields.siteAddress)")
                 DDLogError(error.localizedDescription)
                 // TODO: - Tracks.
                 // WordPressAuthenticator.track(.loginFailedToGuessXMLRPC, error: error)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -431,7 +431,7 @@ private extension SiteAddressViewController {
                     return
                 }
                 // Intentionally log the attempted address on failures.
-                // It's not guarenteed to be included in the error object depending on the error.
+                // It's not guaranteed to be included in the error object depending on the error.
                 DDLogInfo("Error attempting to connect to site address: \(self.loginFields.siteAddress)")
                 DDLogError(error.localizedDescription)
                 // TODO: - Tracks.


### PR DESCRIPTION
Merges the 1.39.0 changes into `trunk`.

No test required other than verifying the `.podspec` changes and that CI passes.