### PR TITLE
Add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Plus: WordPress.com *signup*  is supported.
 ## Setup
 
 ```sh
-# Install required ruby 2.6.5 
-rbenv install 2.6.5
+# Install required ruby version
+rbenv install -s
 
 # Install bundler and Gemfile dependencies
 gem install bundler

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Plus: WordPress.com *signup*  is supported.
 rbenv install 2.6.5
 
 # Install bundler and Gemfile dependencies
-gem install bundle
+gem install bundler
 bundle install
 
 # Install CocoaPods dependencies

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ This framework encapsulates everything required to display the Authentication UI
 
 Plus: WordPress.com *signup*  is supported.
 
+## Setup
+
+```sh
+# Install required ruby 2.6.5 
+rbenv install 2.6.5
+
+# Install bundler and Gemfile dependencies
+gem install bundle
+bundle install
+
+# Install CocoaPods dependencies
+bundle exec pod install
+```
+
 ## Integrating the Library with CocoaPods
 
 WordPressAuthenticator is available through [CocoaPods](http://cocoapods.org). To install


### PR DESCRIPTION
I ran into some trouble building WordPressAuthenticator, and wanted to add instructions to make it more clear for other newcomers.
Please let me know if anything could be more clear here.