### PR TITLE
Redirect Terms and service to open the page in an external web view

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.39.0"
+  s.version       = "1.40.0-beta.1"
 
   s.summary       = "WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps."
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -622,10 +622,7 @@ private extension GetStartedViewController {
             return
         }
 
-        let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = .pageSheet
-        safariViewController.delegate = self
-        self.present(safariViewController, animated: true, completion: nil)
+        UIApplication.shared.open(url)
     }
 }
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/14756
**Testable in:** https://github.com/wordpress-mobile/WordPress-iOS/pull/16907

## Description

This change updates the TOS page to open in an external web browser instead of opening in the app. This modified experience will now match the experience an Android user will have with the app and also matches the experience they would get if they selected "Help" followed by "WordPress Help Center"

### Alternatives
I feel like the experience would be better if we kept them in the app. So I wanted to think about some alternative paths. The option that came to mind is that we could refactor this to use a WKWebView and inject CSS to hide the `wpcom-masterbar`. Although I think that's an ok solution it is slightly more fragile so I wanted to at least raise the question. 

Ultimately I opted to go for simplicity since the pattern on Android is already defined this way. 

@ScoutHarris @diegoreymendez  since you two worked in this area last I wonder if you had any thoughts?