### PR TITLE
Update GoogleSignIn to 6.0.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ def wordpress_authenticator_pods
   pod '1PasswordExtension', '1.8.6'
   pod 'Alamofire', '4.8'
   pod 'CocoaLumberjack', '3.5.2'
-  pod 'GoogleSignIn', '5.0.2'
+  pod 'GoogleSignIn', '6.0.1'
   pod 'lottie-ios', '3.1.6'
   pod 'NSURL+IDN', '0.4'
   pod 'SVProgressHUD', '2.2.5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - 1PasswordExtension (1.8.6)
   - Alamofire (4.8.0)
-  - AppAuth (1.3.0):
-    - AppAuth/Core (= 1.3.0)
-    - AppAuth/ExternalUserAgent (= 1.3.0)
-  - AppAuth/Core (1.3.0)
-  - AppAuth/ExternalUserAgent (1.3.0)
+  - AppAuth (1.4.0):
+    - AppAuth/Core (= 1.4.0)
+    - AppAuth/ExternalUserAgent (= 1.4.0)
+  - AppAuth/Core (1.4.0)
+  - AppAuth/ExternalUserAgent (1.4.0)
   - CocoaLumberjack (3.5.2):
     - CocoaLumberjack/Core (= 3.5.2)
   - CocoaLumberjack/Core (3.5.2)
@@ -13,19 +13,15 @@ PODS:
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
-  - GoogleSignIn (5.0.2):
-    - AppAuth (~> 1.2)
+  - GoogleSignIn (6.0.1):
+    - AppAuth (~> 1.4)
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
   - Gridicons (1.0.1)
-  - GTMAppAuth (1.0.0):
-    - AppAuth/Core (~> 1.0)
-    - GTMSessionFetcher (~> 1.1)
-  - GTMSessionFetcher (1.4.0):
-    - GTMSessionFetcher/Full (= 1.4.0)
-  - GTMSessionFetcher/Core (1.4.0)
-  - GTMSessionFetcher/Full (1.4.0):
-    - GTMSessionFetcher/Core (= 1.4.0)
+  - GTMAppAuth (1.2.2):
+    - AppAuth/Core (~> 1.4)
+    - GTMSessionFetcher/Core (~> 1.5)
+  - GTMSessionFetcher/Core (1.6.1)
   - lottie-ios (3.1.6)
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
@@ -66,7 +62,7 @@ DEPENDENCIES:
   - Alamofire (= 4.8)
   - CocoaLumberjack (= 3.5.2)
   - Expecta (= 1.0.6)
-  - GoogleSignIn (= 5.0.2)
+  - GoogleSignIn (= 6.0.1)
   - Gridicons (~> 1.0-beta)
   - lottie-ios (= 3.1.6)
   - "NSURL+IDN (= 0.4)"
@@ -107,14 +103,14 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
-  AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
+  AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
-  GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
+  GoogleSignIn: 1b0c4ec33a6fe282f4fa35d8ac64263230ddaf36
   Gridicons: 8e19276b20bb15d1fda1d4d0db96d066d170135b
-  GTMAppAuth: 4deac854479704f348309e7b66189e604cf5e01e
-  GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
+  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
+  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
   lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
@@ -128,6 +124,6 @@ SPEC CHECKSUMS:
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
-PODFILE CHECKSUM: a6d2af0a12a196a91634fccfc78a369b39e2be2b
+PODFILE CHECKSUM: 8cba285326010a5f8e3da755a3a83ec7643e858c
 
 COCOAPODS: 1.10.0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.dependency 'NSURL+IDN', '0.4'
   s.dependency 'SVProgressHUD', '~> 2.2.5'
   s.dependency 'Gridicons', '~> 1.0'
-  s.dependency 'GoogleSignIn', '~> 5.0.2'
+  s.dependency 'GoogleSignIn', '~> 6.0.1'
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.41.0-beta.1"
+  s.version       = "1.41.0-beta.2"
   
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -984,7 +984,6 @@
 				B5ED78F1207E976500A8FD8C /* Headers */,
 				B5ED78F2207E976500A8FD8C /* Resources */,
 				B5A5274B20B479D30065BE81 /* CopyFiles */,
-				5ABD4390CE7F425565FA9BD2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1004,7 +1003,6 @@
 				B5ED78FA207E976500A8FD8C /* Frameworks */,
 				B5ED78FB207E976500A8FD8C /* Resources */,
 				E708E1947D7E55D6347CD251 /* [CP] Embed Pods Frameworks */,
-				557F1B615C0496D7C3F3DDAB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -1097,42 +1095,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		557F1B615C0496D7C3F3DDAB /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-resources.sh",
-				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSignIn.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5ABD4390CE7F425565FA9BD2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator-resources.sh",
-				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSignIn.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		6CD6648B820552D8638F8EDA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1183,6 +1145,7 @@
 				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleSignIn/GoogleSignIn.framework",
 				"${BUILT_PRODUCTS_DIR}/Gridicons/Gridicons.framework",
 				"${BUILT_PRODUCTS_DIR}/NSObject-SafeExpectations/NSObject_SafeExpectations.framework",
 				"${BUILT_PRODUCTS_DIR}/NSURL+IDN/NSURL_IDN.framework",
@@ -1207,6 +1170,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Gridicons.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSObject_SafeExpectations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSURL_IDN.framework",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -129,7 +129,7 @@ import WordPressKit
     /// Attempts to process the specified URL as a Google Authentication Link. Returns *true* on success.
     ///
     @objc public func handleGoogleAuthUrl(_ url: URL, sourceApplication: String?, annotation: Any?) -> Bool {
-        return GIDSignIn.sharedInstance().handle(url)
+        return GIDSignIn.sharedInstance.handle(url)
     }
 
     /// Attempts to process the specified URL as a WordPress Authentication Link. Returns *true* on success.

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -170,7 +170,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         syncWPComAndPresentEpilogue(credentials: credentials)
 
         // Disconnect now that we're done with Google.
-        GIDSignIn.sharedInstance().disconnect()
+        GIDSignIn.sharedInstance.disconnect()
 
         // This stat is part of a funnel that provides critical information.  Please
         // consult with your lead before removing this event.

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -182,18 +182,8 @@ private extension GoogleAuthenticator {
         WordPressAuthenticator.track(event, properties: trackProperties)
     }
 
-    enum LocalizedText {
-        static let googleConnected = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
-        static let googleConnectedError = NSLocalizedString("The Google account \"%@\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
-        static let googleUnableToConnect = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
-    }
-
-}
-
-// MARK: - GIDSignInDelegate
-
-extension GoogleAuthenticator {
-
+    /// Handles when the sign in process is either succeeded or failed.
+    /// This is invoked after signing in through `GIDSignIn`'s `signIn` method.
     func didSignIn(for user: GIDGoogleUser?, error: Error?) {
         // Get account information
         guard let user = user,
@@ -243,6 +233,12 @@ extension GoogleAuthenticator {
         // Initiate unified path by attempting to login first.
         SVProgressHUD.show()
         loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
+    }
+
+    enum LocalizedText {
+        static let googleConnected = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
+        static let googleConnectedError = NSLocalizedString("The Google account \"%@\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
+        static let googleUnableToConnect = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
     }
 
 }


### PR DESCRIPTION
Closes #609

This updates `GoogleSignIn` to version `6.0.1`, enabling support for M1. Some adjustments were required due to breaking changes introduced in version `6.0.0`. Google has conveniently provided a [migration checklist](https://developers.google.com/identity/sign-in/ios/quick-migration-guide):

- [x] Update all `[GIDSignIn sharedInstance]` (or `GIDSignIn.sharedInstance()`) calls to `GIDSignIn.sharedInstance` property accesses.
- [x] Move all client configuration (client IDs, etc.) to a `GIDConfiguration` object.
- [x] Update calls to removed methods to their new equivalents:

  v5.x.x | v6.0.0 | Status
  --|--|--
  `signIn` | `signInWithConfiguration:presentingViewController:callback:` | ✅  Done. Previous `signIn` method in `GIDSignInDelegate` extension is migrated.
  `restorePreviousSignIn` | `restorePreviousSignInWithCallback:` | ✅  Done. Method is not used.
  `disconnect` | `disconnectWithCallBack:` | ✅  Done. Previous disconnect method in `GIDSignInDelegate` is not implemented, so there's no need to define the callback.
  `getTokensWithHandler:` | `doWithFreshTokens:` | ✅  Done. Method is not used.
  `refreshTokensWithHandler:` | `doWithFreshTokens` | ✅  Done. Method is not used.
- [x] Remove all references to the `GIDSignInDelegate` protocol and its methods.
  - [x] Move the logic from `signIn:didSignInForUser:withError:` to the callback block of `signInWithConfiguration:presentingViewController:callback:`.
  - [x] Move the logic from `signIn:didDisconnectWithUser:withError:` to the callback block of `disconnectWithCallback:`. 
- [x] Manually connect `GIDSignInButton` to a method that calls `signInWithConfiguration:presentingViewController:callback:` using an `IBAction` or similar.

## Todos:
- [x] Ensure that this change does not affect the authentication flow in WordPress.
- [x] Ensure that this change does not affect the authentication flow in WooCommerce.
- [x] Bump podspec version to `1.41.0-beta.2`