### PR TITLE
Remove text from back buttons

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-  s.name          = "WordPressAuthenticator"
-  s.version       = "1.41.0-beta.3"
+  s.name          = 'WordPressAuthenticator'
+  s.version       = '1.41.0-beta.3'
   
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressAuthenticator"
-  s.version       = "1.41.0-beta.1"
+  s.version       = "1.41.0-beta.3"
   
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginNavigationController.swift
+++ b/WordPressAuthenticator/Signin/LoginNavigationController.swift
@@ -11,7 +11,11 @@ public class LoginNavigationController: RotationAwareNavigationViewController {
     public override func pushViewController(_ viewController: UIViewController, animated: Bool) {
         // By default, the back button label uses the previous view's title.
         // To override that, reset the label when pushing a new view controller.
-        self.viewControllers.last?.navigationItem.backBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Back", comment: "Back button title."), style: .plain, target: nil, action: nil)
+        if #available(iOS 14.0, *) {
+            self.viewControllers.last?.navigationItem.backButtonDisplayMode = .minimal
+        } else {
+            self.viewControllers.last?.navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
+        }
 
         super.pushViewController(viewController, animated: animated)
     }


### PR DESCRIPTION
## Description

Ref: https://github.com/woocommerce/woocommerce-ios/issues/3944

Currently login flow replaces VC titles on back buttons with "Back" text. This:
1. differs from WC general back buttons treatment (only minimal arrow)
2. breaks (shows "back" for every view) navigation history that can be displayed by long press on a back button.

## Screenshots

/ | before | after
--|--|--
button|![before_button](https://user-images.githubusercontent.com/3132438/128240076-632ee015-cf54-4cba-9c67-74502881bc11.png)|![after_button](https://user-images.githubusercontent.com/3132438/128240101-66e99c01-1b86-4c72-b3ba-a4ce23bcf64d.png)
history|![before_history](https://user-images.githubusercontent.com/3132438/128240229-59ba7e90-e1bc-49ce-a839-061ffd0a2f90.png)|![after_history](https://user-images.githubusercontent.com/3132438/128240227-2fe87644-80b0-48ff-90e9-e6b9b2b39df1.png)

## Test

Checkout https://github.com/woocommerce/woocommerce-ios/pull/4726 in WC-iOS to test this change on WC.
Or switch Pod dependency on a branch (like in PR above) and do the same test in WP-iOS.

1. Go through login flow and verify that back buttons have only arrow on them, without text (`<`)
2. Go deep in login flow and long press on back button to see navigation history. Verify that it shows correct titles for previous views (unfortunately now we have similar "Log In" for most of them).
