### PR TITLE
Allow setting the loading / enabled states of NUXButtonViewController button

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.42.0'
+  s.version       = '1.42.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -177,6 +177,21 @@ open class NUXButtonViewController: UIViewController {
         shadowView?.isHidden = true
     }
 
+    public func setTopButtonState(isLoading: Bool, isEnabled: Bool) {
+        topButton?.showActivityIndicator(isLoading)
+        topButton?.isEnabled = isEnabled
+    }
+
+    public func setBottomButtonState(isLoading: Bool, isEnabled: Bool) {
+        bottomButton?.showActivityIndicator(isLoading)
+        bottomButton?.isEnabled = isEnabled
+    }
+
+    public func setTertiaryButtonState(isLoading: Bool, isEnabled: Bool) {
+        tertiaryButton?.showActivityIndicator(isLoading)
+        tertiaryButton?.isEnabled = isEnabled
+    }
+
     // MARK: - Helpers
 
     private func buttonConfigFor(socialService: SocialServiceName, onTap callback: @escaping CallBackType) -> NUXButtonConfig {


### PR DESCRIPTION
This PR adds a few methods to allow setting the loading and enabled state of each of the buttons in NUXButtonViewController. These are used in [associated WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17256) to show a loading indicator while we prepare to display a webview.

See [associated PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17256) for full testing steps.