### PR TITLE
Make the domain searches instantaneous

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.42.1-beta.1'
+  s.version       = '1.42.1-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -98,12 +98,16 @@ extension SearchTableViewCell: UITextFieldDelegate {
         let hasValidEdits = sanitizedString.count > 0 || range.length > 0
 
         if hasValidEdits {
-            guard let currentText = (textField.text as? NSString) else {
+            guard let currentText = (textField.text as? NSString),
+                  let start = textField.position(from: textField.beginningOfDocument, offset: range.location),
+                  let end = textField.position(from: start, offset: range.length),
+                  let textRange = textField.textRange(from: start, to: end) else {
+
                 // This shouldn't really happen but if it does, let's at least let the edit go through
                 return true
             }
 
-            textField.text = currentText.replacingCharacters(in: range, with: sanitizedString)
+            textField.replace(textRange, withText: sanitizedString)
             startLiveSearchAfterEdit()
         }
 

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -29,6 +29,9 @@ open class SearchTableViewCell: UITableViewCell {
     ///
     open var liveSearch: Bool = false
 
+    /// If `true` then the user can type in spaces regularly.  If `false` the whitespaces will be
+    /// stripped before they're entered into the field.
+    ///
     open var allowSpaces: Bool = true
 
     /// Search UITextField's placeholder

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -110,18 +110,21 @@ extension SearchTableViewCell: UITextFieldDelegate {
             }
 
             textField.replace(textRange, withText: sanitizedString)
-            startLiveSearchAfterEdit()
+
+            if liveSearch {
+                startLiveSearchAfterEdit()
+            }
         }
 
         return false
     }
 
-    /// Convenience method to abstract the logic that tells the delegate to start a live search after the search text field
-    /// has been edited.
+    /// Convenience method to abstract the logic that tells the delegate to start a live search.
     ///
-    private func startLiveSearchAfterEdit() {
-        guard liveSearch,
-              let delegate = delegate,
+    /// - Precondition: make sure you check if `liveSearch` is enabled before calling this method.
+    ///
+    private func startLiveSearch() {
+        guard let delegate = delegate,
               let text = textField.text else {
             return
         }

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -101,8 +101,7 @@ extension SearchTableViewCell: UITextFieldDelegate {
         let hasValidEdits = sanitizedString.count > 0 || range.length > 0
 
         if hasValidEdits {
-            guard let currentText = (textField.text as? NSString),
-                  let start = textField.position(from: textField.beginningOfDocument, offset: range.location),
+            guard let start = textField.position(from: textField.beginningOfDocument, offset: range.location),
                   let end = textField.position(from: start, offset: range.length),
                   let textRange = textField.textRange(from: start, to: end) else {
 

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -112,7 +112,7 @@ extension SearchTableViewCell: UITextFieldDelegate {
             textField.replace(textRange, withText: sanitizedString)
 
             if liveSearch {
-                startLiveSearchAfterEdit()
+                startLiveSearch()
             }
         }
 

--- a/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -95,16 +95,18 @@ extension SearchTableViewCell: UITextFieldDelegate {
             sanitizedString = string.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
-        if sanitizedString.count > 0 || range.length > 0 {
+        let hasValidEdits = sanitizedString.count > 0 || range.length > 0
+
+        if hasValidEdits {
             guard let currentText = (textField.text as? NSString) else {
                 // This shouldn't really happen but if it does, let's at least let the edit go through
                 return true
             }
 
             textField.text = currentText.replacingCharacters(in: range, with: sanitizedString)
+            startLiveSearchAfterEdit()
         }
 
-        startLiveSearchAfterEdit()
         return false
     }
 


### PR DESCRIPTION
Improvements to `SearchTableViewCell.swift`:

- Adds a `liveSearch` property that adds support for immediate / live searches.  This property defaults to `false` to try to avoid affecting existing code.
- Adds an `allowSpaces` property that adds support for stripping whitespaces from the user's input.  This property defaults to `false` to try to avoid affecting existing code.

## Testing:

To test this, use the WordPress iOS PR.

1. Start the domain registration flow.
2. In the domain suggestions screen, start typing with the device keyboard.
3. Try typing spaces in different parts of the search text.
4. Try clearing the field.

Make sure you can't input whitespaces.  Make sure live searches work as expected.

## Associated PRs:

WordPress iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17266