### PR TITLE
Remove unreachable code related to 1Password

### DIFF
--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -86,28 +86,6 @@ extension WPStyleGuide {
         onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
     }
 
-    /// Adds a 1password button to a UITextField, if available
-    /// - Note: this is for the Unified styles.
-	///
-	class func configureOnePasswordButtonForTextfield(_ textField: UITextField?, tintColor: UIColor?, target: NSObject, selector: Selector) {
-        guard OnePasswordFacade.isOnePasswordEnabled else {
-            return
-        }
-
-        let onePasswordButton = UIButton(type: .custom)
-        onePasswordButton.setImage(.onePasswordImage, for: .normal)
-		onePasswordButton.tintColor = tintColor
-        onePasswordButton.sizeToFit()
-
-        onePasswordButton.accessibilityLabel =
-            NSLocalizedString("Fill with password manager", comment: "The password manager button in login pages. The button opens a dialog showing which password manager to use (e.g. 1Password, LastPass). ")
-
-        textField?.rightView = onePasswordButton
-        textField?.rightViewMode = .always
-
-        onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
-    }
-
     /// Configures a plain text button with default styles.
     ///
     class func configureTextButton(_ button: UIButton) {

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -11,7 +11,6 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
     @IBOutlet var forgotPasswordButton: WPNUXSecondaryButton!
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     @IBOutlet var verticalCenterConstraint: NSLayoutConstraint?
-    @objc var onePasswordButton: UIButton!
     override var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginUsernamePassword

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -11,7 +11,6 @@ class LoginUsernamePasswordViewController: LoginViewController, NUXKeyboardRespo
     @IBOutlet var forgotPasswordButton: WPNUXSecondaryButton!
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     @IBOutlet var verticalCenterConstraint: NSLayoutConstraint?
-    @objc var onePasswordButton: UIButton!
     override var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginWPComUsernamePassword

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -9,7 +9,6 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     @IBOutlet weak var forgotPasswordButton: UIButton?
     @IBOutlet weak var bottomContentConstraint: NSLayoutConstraint?
     @IBOutlet weak var verticalCenterConstraint: NSLayoutConstraint?
-    @objc var onePasswordButton: UIButton!
     @IBOutlet var emailIcon: UIImageView?
     @IBOutlet var emailLabel: UITextField?
     @IBOutlet var emailStackView: UIStackView?

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -259,20 +259,6 @@ private extension GetStartedViewController {
             self?.configureContinueButton(animating: false)
         }
 
-        cell.onePasswordHandler = { [weak self] in
-            guard let self = self,
-            let sourceView = self.emailField else {
-                return
-            }
-
-            self.view.endEditing(true)
-
-            WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sourceView, loginFields: self.loginFields) { [weak self] (loginFields) in
-                self?.emailField?.text = loginFields.username
-                self?.validateFormAndLogin()
-            }
-        }
-
         if UIAccessibility.isVoiceOverRunning {
             // Quiet repetitive elements in VoiceOver.
             emailField?.placeholder = nil

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -315,24 +315,6 @@ private extension PasswordViewController {
 
             self?.configureSubmitButton(animating: false)
         }
-
-        cell.onePasswordHandler = { [weak self] sourceView in
-            guard let self = self else {
-                return
-            }
-
-            self.view.endEditing(true)
-
-            // Don't update username for social accounts.
-            // This prevents inadvertent account linking.
-            let allowUsernameChange = (self.loginFields.meta.socialService == nil)
-
-            WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sourceView, loginFields: self.loginFields, allowUsernameChange: allowUsernameChange) { [weak self] (loginFields) in
-                cell.updateEmailAddress(loginFields.username)
-                self?.passwordField?.text = loginFields.password
-                self?.validateForm()
-            }
-        }
     }
 
     /// Configure the instruction cell.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -7,21 +7,13 @@ class GravatarEmailTableViewCell: UITableViewCell {
     /// Private properties
     ///
     @IBOutlet private weak var gravatarImageView: UIImageView?
-
-    // The email field is a UITextField so we can listen for changes when using a password manager.
-    // It is disabled so the user cannot edit it.
-    // This results in the 1Password button being disabled as well.
-    // So we add the 1Password button to a stack view instead of the email field.
-    // When iOS12 support is removed, the emailStackView can be removed as it only facilitates 1Password.
     @IBOutlet private weak var emailLabel: UITextField?
-    @IBOutlet private weak var emailStackView: UIStackView?
 
     private let gridiconSize = CGSize(width: 48, height: 48)
 
     /// Public properties
     ///
     public static let reuseIdentifier = "GravatarEmailTableViewCell"
-    public var onePasswordHandler: ((_ sourceView: UITextField) -> Void)?
     public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
 
     /// Public Methods
@@ -31,8 +23,6 @@ class GravatarEmailTableViewCell: UITableViewCell {
         emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         emailLabel?.text = email
-
-        setupOnePasswordButtonIfNeeded()
 
         let gridicon = UIImage.gridicon(.userCircle, size: gridiconSize)
 
@@ -54,34 +44,6 @@ class GravatarEmailTableViewCell: UITableViewCell {
 // MARK: - Password Manager Handling
 
 private extension GravatarEmailTableViewCell {
-
-    // MARK: - 1Password
-
-    /// Sets up a 1Password button if 1Password is available and user is on iOS 12.
-    ///
-    func setupOnePasswordButtonIfNeeded() {
-
-        if #available(iOS 13, *) {
-            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
-        } else {
-            guard let emailStackView = emailStackView,
-                !(emailStackView.arrangedSubviews.last is UIButton) else {
-                return
-            }
-
-            WPStyleGuide.configureOnePasswordButtonForStackView(emailStackView,
-                                                                target: self,
-                                                                selector: #selector(onePasswordTapped(_:)))
-        }
-    }
-
-    @objc func onePasswordTapped(_ sender: UIButton) {
-        guard let emailTextField = emailLabel else {
-            return
-        }
-
-        onePasswordHandler?(emailTextField)
-    }
 
     // MARK: - All Password Managers
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -25,39 +25,33 @@
                             <constraint firstAttribute="width" constant="48" id="oKU-lB-dYx"/>
                         </constraints>
                     </imageView>
-                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rp0-GT-dO4" userLabel="Email Stack View">
+                    <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
                         <rect key="frame" x="70" y="13" width="239" height="44"/>
-                        <subviews>
-                            <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
-                                <rect key="frame" x="0.0" y="0.0" width="239" height="44"/>
-                                <accessibility key="accessibilityConfiguration">
-                                    <accessibilityTraits key="traits" staticText="YES"/>
-                                </accessibility>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="axC-0i-jGu"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <textInputTraits key="textInputTraits" textContentType="username"/>
-                                <connections>
-                                    <action selector="textFieldDidChangeSelection" destination="KGk-i7-Jjw" eventType="editingChanged" id="CBE-yc-dqf"/>
-                                </connections>
-                            </textField>
-                        </subviews>
-                    </stackView>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" staticText="YES"/>
+                        </accessibility>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="axC-0i-jGu"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <textInputTraits key="textInputTraits" textContentType="username"/>
+                        <connections>
+                            <action selector="textFieldDidChangeSelection" destination="KGk-i7-Jjw" eventType="editingChanged" id="CBE-yc-dqf"/>
+                        </connections>
+                    </textField>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Rp0-GT-dO4" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="OXm-Es-lay"/>
+                    <constraint firstItem="3kD-7a-MeN" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="11" id="M5P-4D-Dig"/>
+                    <constraint firstAttribute="trailing" secondItem="3kD-7a-MeN" secondAttribute="trailing" constant="11" id="Uu4-bo-sjK"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" constant="-2" id="YZD-yX-ic3"/>
+                    <constraint firstItem="3kD-7a-MeN" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="guc-Ls-SYV"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="hPB-Uy-lLS"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="11" id="kVa-7e-I73"/>
-                    <constraint firstItem="Rp0-GT-dO4" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="11" id="txL-rW-VDL"/>
-                    <constraint firstAttribute="trailing" secondItem="Rp0-GT-dO4" secondAttribute="trailing" constant="11" id="zFn-2O-cyr"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="emailLabel" destination="3kD-7a-MeN" id="8Ck-Rg-3Cw"/>
-                <outlet property="emailStackView" destination="Rp0-GT-dO4" id="E8B-ds-K8H"/>
                 <outlet property="gravatarImageView" destination="odI-Gb-fXa" id="eHP-78-0Fg"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -37,7 +37,6 @@ final class TextFieldTableViewCell: UITableViewCell {
     }
 
     public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
-    public var onePasswordHandler: (() -> Void)?
     public static let reuseIdentifier = "TextFieldTableViewCell"
 
     override func awakeFromNib() {
@@ -91,7 +90,6 @@ private extension TextFieldTableViewCell {
         case .username:
             textField.keyboardType = .default
             textField.returnKeyType = .next
-            setupOnePasswordButtonIfNeeded()
             textField.accessibilityLabel = Constants.username
             textField.accessibilityIdentifier = Constants.usernameID
         case .password:
@@ -111,7 +109,6 @@ private extension TextFieldTableViewCell {
             textField.keyboardType = .emailAddress
             textField.returnKeyType = .continue
             textField.textContentType = .username // So the password autofill appears on the keyboard
-            setupOnePasswordButtonIfNeeded()
             textField.accessibilityLabel = Constants.email
             textField.accessibilityIdentifier = Constants.emailID
         }
@@ -121,25 +118,6 @@ private extension TextFieldTableViewCell {
     ///
     @objc func textFieldDidChangeSelection() {
         onChangeSelectionHandler?(textField)
-    }
-
-    /// Sets up a 1Password button if 1Password is available and user is on iOS 12.
-    ///
-    @objc func setupOnePasswordButtonIfNeeded() {
-        if #available(iOS 13, *) {
-            // no-op, we rely on the key icon in the keyboard to initiate a password manager.
-        } else {
-            let tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
-            // iOS 12 and lower, display the OnePassword button.
-            WPStyleGuide.configureOnePasswordButtonForTextfield(textField,
-                                                                tintColor: tintColor,
-                                                                target: self,
-                                                                selector: #selector(onePasswordTapped(_:)))
-        }
-    }
-
-    @objc func onePasswordTapped(_ sender: UIButton) {
-        onePasswordHandler?()
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -23,10 +23,6 @@ final class TextFieldTableViewCell: UITableViewCell {
         onChangeSelectionHandler?(textField)
     }
 
-    /// Internal properties.
-    ///
-    @objc var onePasswordButton: UIButton!
-
     /// Public properties.
     ///
     @IBOutlet public weak var textField: UITextField! // public so it can be the first responder

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -284,23 +284,6 @@ private extension SiteCredentialsViewController {
         // Save a reference to the textField so it can becomeFirstResponder.
         usernameField = cell.textField
         cell.textField.delegate = self
-        cell.onePasswordHandler = { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            guard let sourceView = self.usernameField else {
-                return
-            }
-
-            self.view.endEditing(true)
-
-            WordPressAuthenticator.fetchOnePasswordCredentials(self, sourceView: sourceView, loginFields: self.loginFields) { [unowned self] loginFields in
-                self.usernameField?.text = loginFields.username
-                self.passwordField?.text = loginFields.password
-                self.validateForm()
-            }
-        }
 
         cell.onChangeSelectionHandler = { [weak self] textfield in
             self?.loginFields.username = textfield.nonNilTrimmedText()

--- a/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
+++ b/WordPressAuthenticatorTests/Mocks/WordpressAuthenticatorProvider.swift
@@ -13,7 +13,7 @@ public class WordpressAuthenticatorProvider: NSObject {
                                                    userAgent: "")
     }
 
-    static func wordPressAuthenticatorStyle(_ style: AuthenticatorStyeType) -> WordPressAuthenticatorStyle {
+    static func wordPressAuthenticatorStyle(_ style: AuthenticatorStyleType) -> WordPressAuthenticatorStyle {
         var wpAuthStyle: WordPressAuthenticatorStyle!
 
         switch style {
@@ -48,7 +48,7 @@ public class WordpressAuthenticatorProvider: NSObject {
         }
     }
 
-    static func wordPressAuthenticatorUnifiedStyle(_ style: AuthenticatorStyeType) -> WordPressAuthenticatorUnifiedStyle {
+    static func wordPressAuthenticatorUnifiedStyle(_ style: AuthenticatorStyleType) -> WordPressAuthenticatorUnifiedStyle {
         var wpUnifiedAuthStyle: WordPressAuthenticatorUnifiedStyle!
 
         switch style {
@@ -89,7 +89,7 @@ public class WordpressAuthenticatorProvider: NSObject {
     }
 }
 
-enum AuthenticatorStyeType {
+enum AuthenticatorStyleType {
     case random
 }
 


### PR DESCRIPTION
## Description
This PR removes some unneeded/unreachable code related to 1Password integration. The changes in this PR introduces no visible changes, it's more of a cleanup.
The biggest change is the removal of the `emailStackView` in `GravatarEmailTableViewCell`, which encapsulated the `emailLabel`. Now we add the `emailLabel` directly.

References: https://github.com/wordpress-mobile/WordPress-iOS/issues/17516
This is the first PR that tackles this issue. Planned PRs:

- [x] Cleanup unreachable code (This PR)
- [ ] Remove 1Password button from UI when corresponding config is disabled
- [ ] Configure all textfields to display Apple's native Password Autofill.

## Testing
To test this use the WordPress iOS App, but make sure to replace this line in the Podfile
`pod 'WordPressAuthenticator', '~> 1.42.1'`
With this
`pod 'WordPressAuthenticator', :git => 'https://github.com/hassaansaleh/WordPressAuthenticator-iOS.git', :branch => 'issue/17516-remove-unreachable-code'`

You need to test on a real device that has 1Password installed.
### What to test
1. Check that the Gravatar cell in PasswordViewController is displayed correctly
2. Check that the unified flow is unaffected. The screens that were touched are the following:
    1. GetStartedViewControler
    2. PasswordViewController
    3. SiteCredentialsViewController 
