### PR TITLE
Fix CircularImageView so both apps (WooCommerce & WordPress) have a circular image in the password screen

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.42.1'
+  s.version       = '1.42.2-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPress">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPressAuthenticator">
                         <rect key="frame" x="11" y="11" width="48" height="48"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="48" id="RU3-mW-PAl"/>


### PR DESCRIPTION
### Description

This PR fixes the issue that describes it [here](https://github.com/woocommerce/woocommerce-ios/issues/3366).
In the `GravatarEmailTableViewCell.xib` file, the `UIImageView` uses a `CircularImageView` class with `WordPress` as a module. 

This makes the image circular only in the **WordPress** app and not in the **WooCommerce** app.

Changing it to `WordPressAuthanticator` module will make the image circular in both apps.


### Screenshots

**Before:**

<img src="https://user-images.githubusercontent.com/11445928/145067364-9dc98261-b810-445c-9243-288884c4ceb1.png" width="300px" height="100%">

**After:**

<img src="https://user-images.githubusercontent.com/11445928/145067321-9474a3bc-9d63-4a65-a2b6-8a5c573c8ad5.png" width="300px" height="100%">
