### PR TITLE
Match "Need more help" language

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.43.0-beta.2'
+  s.version       = '1.43.0-beta.3'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
@@ -54,7 +54,7 @@ NSString *const XMLRPCOriginalErrorKey = @"XMLRPCOriginalErrorKey";
         return error;
     } else {
         NSDictionary *userInfo = @{
-                                   NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to read the WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil),
+                                   NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ.", nil),
                                    NSLocalizedFailureReasonErrorKey: error.localizedDescription,
                                    XMLRPCOriginalErrorKey: error
                                    };
@@ -76,7 +76,7 @@ NSString *const XMLRPCOriginalErrorKey = @"XMLRPCOriginalErrorKey";
         dispatch_async(dispatch_get_main_queue(), ^{
             if (![responseObject isKindOfClass:[NSDictionary class]]) {
                 if (failure) {
-                    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to read the WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil)};
+                    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ.", nil)};
                     NSError *error = [NSError errorWithDomain:WordPressOrgXMLRPCApiErrorDomain code:WordPressOrgXMLRPCApiErrorResponseSerializationFailed userInfo:userInfo];
                     failure(error);
                 }


### PR DESCRIPTION
This PR updates the error message "Unable to read the WordPress site at that URL. Tap 'Need Help?' to view the FAQ." to match the button label, which is "Need more help?"

| Before | After |
| ------  | ----- |
| ![Mode 2 and 4](https://user-images.githubusercontent.com/2092798/149272653-6e430ba3-3802-44cf-b393-55ba6adaa751.png) | ![Match Text](https://user-images.githubusercontent.com/2092798/149273037-3c96055c-7519-4664-86bc-48f3794fe9ed.png) |

**Testing:**

On a self-hosted site:

1. Install [XML-RPC Tweak](https://github.com/wordpress-mobile/WordPress-iOS/files/7860038/xml-rpc-tweak.zip) from [this PR](https://github.com/wordpress-mobile/WordPress-iOS/files/7860038/xml-rpc-tweak.zip)
2. Configure the plugin to run in Mode 4
3. Attempt to log into the self-hosted site