### PR TITLE
Improve error description

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.42.2'
+  s.version       = '1.43.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPressAuthenticator/Services/WordPressXMLRPCAPIFacade.m
@@ -76,7 +76,8 @@ NSString *const XMLRPCOriginalErrorKey = @"XMLRPCOriginalErrorKey";
         dispatch_async(dispatch_get_main_queue(), ^{
             if (![responseObject isKindOfClass:[NSDictionary class]]) {
                 if (failure) {
-                    NSError *error = [NSError errorWithDomain:WordPressOrgXMLRPCApiErrorDomain code:WordPressOrgXMLRPCApiErrorResponseSerializationFailed userInfo:nil];
+                    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to read the WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil)};
+                    NSError *error = [NSError errorWithDomain:WordPressOrgXMLRPCApiErrorDomain code:WordPressOrgXMLRPCApiErrorResponseSerializationFailed userInfo:userInfo];
                     failure(error);
                 }
                 return;


### PR DESCRIPTION
Related PR:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/17724

| Before | After |
| ------ | ----- |
| ![Mode 2 - Before](https://user-images.githubusercontent.com/2092798/149274320-952470e4-a09d-4d87-94f2-fc904d3599c9.png) | ![Mode 2 and 4](https://user-images.githubusercontent.com/2092798/149274370-949d5a8b-b31d-424b-b955-06d04470a845.png) |

Note: There's a [follow-up PR](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/631) to make the message match the button label.

Testing:
- See Test 2 in the [Wordpress-iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17724).