### PR TITLE
Bump Podspec to beta 2.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.43.0-beta.1'
+  s.version       = '1.43.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This bumps the Podspec to `1.43.0-beta.2` so that we don't need to yank the already published `beta.1` pod, which CI somehow pushed even though the [validation failed](https://buildkite.com/wordpress-mobile/wordpress-authenticator-ios/builds/73#412ad1b4-4b54-4ec7-8c24-81af261e5ac4).