### PR TITLE
Use `Follow Readable Width` for views

### DIFF
--- a/WordPressAuthenticator/NUX/NUXButtonView.storyboard
+++ b/WordPressAuthenticator/NUX/NUXButtonView.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,13 +22,14 @@
                                     <constraint firstAttribute="height" constant="10" id="cjP-3n-4DS"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xzf-f5-7zQ" userLabel="Button Stack View">
+                            <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xzf-f5-7zQ" userLabel="Button Stack View">
                                 <rect key="frame" x="16" y="16" width="343" height="104"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="knN-O6-M86" customClass="NUXButton" customModule="WordPressAuthenticator">
                                         <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectSite"/>
                                         <constraints>
+                                            <constraint firstAttribute="height" priority="750" constant="44" id="F0e-cq-D6K"/>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="YB6-LI-NGI"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
@@ -44,6 +45,7 @@
                                         <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="SiB-Xy-stR"/>
+                                            <constraint firstAttribute="height" priority="750" constant="44" id="e6s-PZ-lUj"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <state key="normal" title="Primary Button">
@@ -82,8 +84,9 @@
                             <constraint firstItem="RrB-Aa-ADd" firstAttribute="leading" secondItem="vC0-ge-46d" secondAttribute="leading" id="29Q-jd-hiu"/>
                             <constraint firstItem="xzf-f5-7zQ" firstAttribute="top" secondItem="RrB-Aa-ADd" secondAttribute="bottom" constant="16" id="86p-bn-8hO"/>
                             <constraint firstItem="RrB-Aa-ADd" firstAttribute="trailing" secondItem="vC0-ge-46d" secondAttribute="trailing" id="APL-hI-Fg5"/>
-                            <constraint firstItem="vC0-ge-46d" firstAttribute="bottom" secondItem="xzf-f5-7zQ" secondAttribute="bottom" constant="16" id="Pdr-ac-zdu"/>
+                            <constraint firstItem="vC0-ge-46d" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="xzf-f5-7zQ" secondAttribute="bottom" constant="16" id="Pdr-ac-zdu"/>
                             <constraint firstItem="xzf-f5-7zQ" firstAttribute="leading" secondItem="vC0-ge-46d" secondAttribute="leading" constant="16" id="VYB-ut-UCK"/>
+                            <constraint firstItem="vC0-ge-46d" firstAttribute="bottom" secondItem="xzf-f5-7zQ" secondAttribute="bottom" priority="250" constant="16" id="hIf-qK-jj7"/>
                             <constraint firstItem="vC0-ge-46d" firstAttribute="trailing" secondItem="xzf-f5-7zQ" secondAttribute="trailing" constant="16" id="pdk-yI-G0O"/>
                             <constraint firstItem="RrB-Aa-ADd" firstAttribute="top" secondItem="vC0-ge-46d" secondAttribute="top" constant="-10" id="qZc-jk-YRs"/>
                         </constraints>

--- a/WordPressAuthenticator/NUX/NUXButtonViewController.swift
+++ b/WordPressAuthenticator/NUX/NUXButtonViewController.swift
@@ -7,7 +7,6 @@ import WordPressKit
     @objc optional func tertiaryButtonPressed()
 }
 
-
 private struct NUXButtonConfig {
     typealias CallBackType = () -> Void
 
@@ -120,7 +119,7 @@ open class NUXButtonViewController: UIViewController {
 
         shadowViewEdgeConstraints = [
             layoutGuide.leadingAnchor.constraint(equalTo: shadowView.leadingAnchor),
-            layoutGuide.trailingAnchor.constraint(equalTo: shadowView.trailingAnchor),
+            layoutGuide.trailingAnchor.constraint(equalTo: shadowView.trailingAnchor)
         ]
 
         NSLayoutConstraint.activate(shadowViewEdgeConstraints)

--- a/WordPressAuthenticator/Signin/Login.storyboard
+++ b/WordPressAuthenticator/Signin/Login.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -49,11 +49,11 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="gpM-nW-lFQ" secondAttribute="trailing" id="2id-by-lnA"/>
-                            <constraint firstItem="V2N-XU-yx0" firstAttribute="leading" secondItem="1bR-Uc-YPO" secondAttribute="leading" id="3e9-yc-R9r"/>
+                            <constraint firstItem="V2N-XU-yx0" firstAttribute="leading" secondItem="1bR-Uc-YPO" secondAttribute="leadingMargin" constant="-16" id="3e9-yc-R9r"/>
                             <constraint firstItem="NZ0-gC-OHl" firstAttribute="top" secondItem="gpM-nW-lFQ" secondAttribute="bottom" id="Fiw-SH-C5m"/>
                             <constraint firstItem="gpM-nW-lFQ" firstAttribute="top" secondItem="1bR-Uc-YPO" secondAttribute="top" id="Ivq-bt-puo"/>
                             <constraint firstItem="gpM-nW-lFQ" firstAttribute="leading" secondItem="1bR-Uc-YPO" secondAttribute="leading" id="QDG-Ta-wW5"/>
-                            <constraint firstAttribute="trailing" secondItem="V2N-XU-yx0" secondAttribute="trailing" id="goV-pb-UDh"/>
+                            <constraint firstItem="V2N-XU-yx0" firstAttribute="trailing" secondItem="1bR-Uc-YPO" secondAttribute="trailingMargin" constant="16" id="goV-pb-UDh"/>
                             <constraint firstAttribute="bottom" secondItem="V2N-XU-yx0" secondAttribute="bottom" id="y2t-8w-Bh7"/>
                         </constraints>
                     </view>
@@ -73,7 +73,7 @@
                         <viewControllerLayoutGuide type="top" id="bfJ-T5-JnD"/>
                         <viewControllerLayoutGuide type="bottom" id="dPr-Tg-feW"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="EnO-7f-1yO">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="EnO-7f-1yO">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -106,7 +106,7 @@
                         </subviews>
                         <constraints>
                             <constraint firstItem="6cw-FO-hjb" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="7Z8-mD-FWN"/>
-                            <constraint firstAttribute="trailing" secondItem="G3G-Ap-6ix" secondAttribute="trailing" id="96a-eB-JlD"/>
+                            <constraint firstItem="G3G-Ap-6ix" firstAttribute="trailing" secondItem="EnO-7f-1yO" secondAttribute="trailingMargin" constant="16" id="96a-eB-JlD"/>
                             <constraint firstItem="G3G-Ap-6ix" firstAttribute="top" secondItem="6cw-FO-hjb" secondAttribute="bottom" id="Cuw-sd-C5k"/>
                             <constraint firstAttribute="trailing" secondItem="6cw-FO-hjb" secondAttribute="trailing" id="Hgo-qC-AqF"/>
                             <constraint firstItem="s7U-M4-ZVd" firstAttribute="top" secondItem="G3G-Ap-6ix" secondAttribute="top" id="ISb-cY-EO1"/>
@@ -115,7 +115,7 @@
                             <constraint firstItem="s7U-M4-ZVd" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="fqH-CW-3Ry"/>
                             <constraint firstAttribute="bottom" secondItem="G3G-Ap-6ix" secondAttribute="bottom" id="lOP-Up-00c"/>
                             <constraint firstItem="s7U-M4-ZVd" firstAttribute="bottom" secondItem="G3G-Ap-6ix" secondAttribute="bottom" id="qfx-iK-Dth"/>
-                            <constraint firstItem="G3G-Ap-6ix" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="uzT-mw-eJq"/>
+                            <constraint firstItem="G3G-Ap-6ix" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leadingMargin" constant="-16" id="uzT-mw-eJq"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>
@@ -202,23 +202,23 @@
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="626"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-yW-tzf">
-                                                <rect key="frame" x="0.0" y="233" width="383" height="167"/>
+                                                <rect key="frame" x="0.0" y="240.5" width="383" height="159.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in to your WordPress.com account with your email address." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
-                                                        <rect key="frame" x="20" y="0.0" width="343" height="38"/>
+                                                        <rect key="frame" x="20" y="0.0" width="343" height="30.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WRS-Yr-gSS">
-                                                        <rect key="frame" x="0.0" y="38" width="383" height="20"/>
+                                                        <rect key="frame" x="0.0" y="30.5" width="383" height="20"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="20" id="nUZ-Ew-0l4"/>
                                                         </constraints>
                                                     </view>
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                                                        <rect key="frame" x="0.0" y="58" width="383" height="44"/>
+                                                        <rect key="frame" x="0.0" y="50.5" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
                                                         <constraints>
@@ -238,14 +238,14 @@
                                                         </connections>
                                                     </textField>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NpA-7J-3I6">
-                                                        <rect key="frame" x="0.0" y="102" width="383" height="10"/>
+                                                        <rect key="frame" x="0.0" y="94.5" width="383" height="10"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="10" id="qDu-yk-MtX"/>
                                                         </constraints>
                                                     </view>
                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qqt-eq-gac">
-                                                        <rect key="frame" x="20" y="112" width="343" height="40"/>
+                                                        <rect key="frame" x="20" y="104.5" width="343" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="40" placeholder="YES" id="0GR-cF-ntU"/>
                                                         </constraints>
@@ -254,14 +254,14 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Eo-Qo-jYK">
-                                                        <rect key="frame" x="0.0" y="112" width="383" height="10"/>
+                                                        <rect key="frame" x="0.0" y="104.5" width="383" height="10"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="10" id="gcY-gc-aTL"/>
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Alternatively:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lMs-zS-N5u">
-                                                        <rect key="frame" x="20" y="122" width="343" height="40"/>
+                                                        <rect key="frame" x="20" y="114.5" width="343" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="40" placeholder="YES" id="Myo-Zc-avd"/>
                                                         </constraints>
@@ -270,7 +270,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xz2-9h-d3M">
-                                                        <rect key="frame" x="0.0" y="162" width="383" height="5"/>
+                                                        <rect key="frame" x="0.0" y="154.5" width="383" height="5"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="5" id="VbY-AO-ioI"/>
@@ -377,29 +377,29 @@
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="603"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wnq-Hk-jIw" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="20" y="223.5" width="343" height="36"/>
+                                                <rect key="frame" x="20" y="230.5" width="343" height="29"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="29"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf" userLabel="Icon">
-                                                                <rect key="frame" x="0.0" y="7" width="18" height="22"/>
+                                                                <rect key="frame" x="0.0" y="3.5" width="18" height="22"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="40" id="F6S-wN-1Jp"/>
                                                                     <constraint firstAttribute="height" relation="lessThanOrEqual" constant="40" id="Z7H-Ud-llZ"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uN1-Al-ygf">
-                                                                <rect key="frame" x="28" y="0.0" width="315" height="36"/>
+                                                                <rect key="frame" x="28" y="0.0" width="315" height="29"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehh-92-XG8" userLabel="Title">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="315" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="315" height="14.5"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6" userLabel="Subtitle">
-                                                                        <rect key="frame" x="0.0" y="18" width="315" height="18"/>
+                                                                        <rect key="frame" x="0.0" y="14.5" width="315" height="14.5"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                                         <nil key="highlightedColor"/>
@@ -486,7 +486,7 @@
                                         <rect key="frame" x="20" y="603" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="0.0" y="7" width="141" height="30"/>
+                                                <rect key="frame" x="0.0" y="8.5" width="117" height="27"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Lost your password?">
                                                     <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -496,7 +496,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SBB-7Z-qWs" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="311" y="0.0" width="32" height="44"/>
+                                                <rect key="frame" x="313" y="0.0" width="30" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="NKL-1C-mN4"/>
@@ -568,7 +568,7 @@
         <!--LoginWPComViewController-->
         <scene sceneID="brQ-1M-iPT">
             <objects>
-                <viewController storyboardIdentifier="LoginWPComViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="lmD-c6-SLs" userLabel="LoginWPComViewController" customClass="LoginWPComViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginWPComViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="lmD-c6-SLs" userLabel="LoginWPComViewController" customClass="LoginWPComViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="dAs-4b-ACP"/>
                         <viewControllerLayoutGuide type="bottom" id="kOH-fr-1L0"/>
@@ -584,22 +584,22 @@
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="603"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
-                                                <rect key="frame" x="20" y="198.5" width="343" height="48"/>
+                                                <rect key="frame" x="20" y="200.5" width="343" height="48"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3be-99-g62">
-                                                <rect key="frame" x="0.0" y="278.5" width="383" height="74"/>
+                                                <rect key="frame" x="0.0" y="280.5" width="383" height="70.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
-                                                        <rect key="frame" x="20" y="0.0" width="343" height="22"/>
+                                                        <rect key="frame" x="20" y="0.0" width="343" height="18.5"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
-                                                                <rect key="frame" x="0.0" y="2" width="18" height="18"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
                                                             </imageView>
                                                             <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sx0-OR-XAf">
-                                                                <rect key="frame" x="28" y="0.0" width="315" height="22"/>
+                                                                <rect key="frame" x="28" y="0.0" width="315" height="18.5"/>
                                                                 <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <textInputTraits key="textInputTraits" textContentType="username"/>
@@ -610,7 +610,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                                                        <rect key="frame" x="0.0" y="30" width="383" height="44"/>
+                                                        <rect key="frame" x="0.0" y="26.5" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
                                                         <constraints>
@@ -634,7 +634,7 @@
                                                 </constraints>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                                <rect key="frame" x="20" y="372.5" width="343" height="18"/>
+                                                <rect key="frame" x="20" y="371" width="343" height="14.5"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="pswdErrorLabel"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
@@ -660,7 +660,7 @@
                                         <rect key="frame" x="20" y="603" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="0.0" y="7" width="141" height="30"/>
+                                                <rect key="frame" x="0.0" y="8.5" width="117" height="27"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Lost your password?">
                                                     <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -761,7 +761,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="595"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
-                                                <rect key="frame" x="20" y="237.5" width="343" height="18"/>
+                                                <rect key="frame" x="20" y="241" width="343" height="14.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -820,7 +820,7 @@
                                         <rect key="frame" x="20" y="595" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="309-z3-fPx" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="0.0" y="0.0" width="131" height="44"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="108" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="fzI-rH-0f8"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="tFG-e2-XN2"/>
@@ -906,7 +906,7 @@
         <!--Login Link Request View Controller-->
         <scene sceneID="lHx-fY-p45">
             <objects>
-                <viewController storyboardIdentifier="LoginLinkRequestViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Kvo-Y2-yhG" customClass="LoginLinkRequestViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginLinkRequestViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Kvo-Y2-yhG" customClass="LoginLinkRequestViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="q8R-wf-TMO"/>
                         <viewControllerLayoutGuide type="bottom" id="h4a-j8-84P"/>
@@ -916,7 +916,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Mq6-n0-6iO">
-                                <rect key="frame" x="36" y="184.5" width="303" height="258.5"/>
+                                <rect key="frame" x="36" y="189" width="303" height="249"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ukv-qo-ql4" customClass="CircularImageView" customModule="WordPressAuthenticator">
                                         <rect key="frame" x="101.5" y="0.0" width="100" height="100"/>
@@ -926,13 +926,13 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CmN-ir-1YK">
-                                        <rect key="frame" x="0.0" y="130" width="303" height="64.5"/>
+                                        <rect key="frame" x="0.0" y="130" width="303" height="55"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iIy-Sm-1r0" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="115.5" y="224.5" width="72" height="34"/>
+                                        <rect key="frame" x="115.5" y="215" width="72" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="GRI-y6-q3i"/>
                                         </constraints>
@@ -964,7 +964,7 @@
                                 </variation>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6x-b7-hU9" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
-                                <rect key="frame" x="0.0" y="617" width="375" height="30"/>
+                                <rect key="frame" x="0.0" y="620" width="375" height="27"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <state key="normal" title="Enter your password instead"/>
                                 <connections>
@@ -1018,7 +1018,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="600"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
-                                                <rect key="frame" x="20" y="220" width="351" height="38"/>
+                                                <rect key="frame" x="20" y="243.5" width="351" height="14.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -1067,7 +1067,7 @@
                                         <rect key="frame" x="20" y="600" width="351" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="0.0" y="7" width="250" height="30"/>
+                                                <rect key="frame" x="0.0" y="8.5" width="207" height="27"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Need help finding your site address?">
@@ -1169,7 +1169,7 @@
                                         <rect key="frame" x="20" y="603" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XI0-rr-yUh" customClass="SubheadlineButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="0.0" y="7" width="141" height="30"/>
+                                                <rect key="frame" x="0.0" y="8.5" width="117" height="27"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Lost your password?">
                                                     <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1179,7 +1179,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YGE-OB-HmV" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="311" y="0.0" width="32" height="44"/>
+                                                <rect key="frame" x="313" y="0.0" width="30" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="6WB-XE-dy4"/>
@@ -1219,19 +1219,19 @@
                                 <rect key="frame" x="-4" y="64" width="383" height="539"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-HN-aFE" userLabel="Header" customClass="SiteInfoHeaderView" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="20" y="27" width="343" height="200.5"/>
+                                        <rect key="frame" x="20" y="34.5" width="343" height="193"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ak2-b4-JSG">
-                                                <rect key="frame" x="8" y="98.5" width="327" height="94"/>
+                                                <rect key="frame" x="8" y="98.5" width="327" height="86.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in with your WordPress.com account to manage your WooCommerce stores" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au1-mY-r58">
-                                                        <rect key="frame" x="0.0" y="0.0" width="327" height="38"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="327" height="30.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="IMk-aA-1GF" userLabel="Header Stack View">
-                                                        <rect key="frame" x="0.0" y="58" width="327" height="36"/>
+                                                        <rect key="frame" x="0.0" y="50.5" width="327" height="36"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Gak-2q-wul" userLabel="Icon">
                                                                 <rect key="frame" x="0.0" y="7" width="36" height="22"/>
@@ -1385,12 +1385,12 @@
         <!--Login Prologue Login Method View Controller-->
         <scene sceneID="4ov-Vw-tga">
             <objects>
-                <viewController storyboardIdentifier="LoginPrologueLoginMethodViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hed-vB-osh" customClass="LoginPrologueLoginMethodViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginPrologueLoginMethodViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hed-vB-osh" customClass="LoginPrologueLoginMethodViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="EBT-D5-afP"/>
                         <viewControllerLayoutGuide type="bottom" id="wML-ff-0Cg"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="wXg-v5-bOP">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="wXg-v5-bOP">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -1415,9 +1415,9 @@
                             <constraint firstItem="Ueg-Bw-KU6" firstAttribute="leading" secondItem="wXg-v5-bOP" secondAttribute="leading" id="1ij-WA-P2a"/>
                             <constraint firstItem="Ueg-Bw-KU6" firstAttribute="top" secondItem="wXg-v5-bOP" secondAttribute="top" id="6IS-ac-cPS"/>
                             <constraint firstAttribute="bottom" secondItem="bzm-5r-Auq" secondAttribute="bottom" id="BJR-kq-SdS"/>
-                            <constraint firstAttribute="trailing" secondItem="bzm-5r-Auq" secondAttribute="trailing" id="BQt-L9-x3v"/>
+                            <constraint firstItem="bzm-5r-Auq" firstAttribute="trailing" secondItem="wXg-v5-bOP" secondAttribute="trailingMargin" constant="16" id="BQt-L9-x3v"/>
                             <constraint firstItem="wML-ff-0Cg" firstAttribute="top" secondItem="Ueg-Bw-KU6" secondAttribute="bottom" id="iDD-6r-6FS"/>
-                            <constraint firstItem="bzm-5r-Auq" firstAttribute="leading" secondItem="wXg-v5-bOP" secondAttribute="leading" id="l7C-5C-4Hq"/>
+                            <constraint firstItem="bzm-5r-Auq" firstAttribute="leading" secondItem="wXg-v5-bOP" secondAttribute="leadingMargin" constant="-16" id="l7C-5C-4Hq"/>
                             <constraint firstAttribute="trailing" secondItem="Ueg-Bw-KU6" secondAttribute="trailing" id="nXh-Tu-veg"/>
                         </constraints>
                     </view>
@@ -1441,13 +1441,13 @@
             <size key="intrinsicContentSize" width="112.5" height="18.5"/>
         </designable>
         <designable name="XXO-aV-keK">
-            <size key="intrinsicContentSize" width="106" height="22"/>
+            <size key="intrinsicContentSize" width="90" height="18.5"/>
         </designable>
         <designable name="ZUH-Y9-OaY">
             <size key="intrinsicContentSize" width="112.5" height="18.5"/>
         </designable>
         <designable name="ZrT-CY-qD7">
-            <size key="intrinsicContentSize" width="155" height="22"/>
+            <size key="intrinsicContentSize" width="131.5" height="18.5"/>
         </designable>
         <designable name="oi5-Kd-TEW">
             <size key="intrinsicContentSize" width="62.5" height="17"/>

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -113,16 +113,6 @@ class LoginPrologueViewController: LoginViewController {
         return UIDevice.isPad() ? .all : .portrait
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        setButtonViewMargins(forWidth: view.frame.width)
-    }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        setButtonViewMargins(forWidth: size.width)
-    }
-
     // MARK: - iCloud Keychain Login
 
     /// Starts the iCloud Keychain login flow if the conditions are given.
@@ -207,9 +197,6 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func buildDefaultUnifiedPrologueButtons(_ buttonViewController: NUXButtonViewController, loginTitle: String, siteAddressTitle: String) {
-
-        setButtonViewMargins(forWidth: view.frame.width)
-
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, configureBodyFontForTitle: true, accessibilityIdentifier: "Prologue Continue Button", onTap: loginTapCallback())
 
         if configuration.enableUnifiedAuth {
@@ -225,8 +212,6 @@ class LoginPrologueViewController: LoginViewController {
         guard configuration.enableUnifiedAuth == true else {
             return
         }
-
-        setButtonViewMargins(forWidth: view.frame.width)
 
         buttonViewController.setupTopButton(title: siteAddressTitle, isPrimary: true, accessibilityIdentifier: "Prologue Self Hosted Button", onTap: siteAddressTapCallback())
 
@@ -578,43 +563,6 @@ extension LoginPrologueViewController: GoogleAuthenticatorLoginDelegate {
         socialErrorVC.loginFields = loginFields
         socialErrorVC.modalPresentationStyle = .fullScreen
         present(socialErrorNav, animated: true)
-    }
-
-}
-
-// MARK: - Button View Sizing
-
-private extension LoginPrologueViewController {
-
-    /// Resize the button view based on trait collection.
-    /// Used only in unified views.
-    ///
-    func setButtonViewMargins(forWidth viewWidth: CGFloat) {
-
-        guard configuration.enableUnifiedAuth else {
-            return
-        }
-
-        guard traitCollection.horizontalSizeClass == .regular &&
-            traitCollection.verticalSizeClass == .regular else {
-                buttonViewLeadingConstraint?.constant = defaultButtonViewMargin
-                buttonViewTrailingConstraint?.constant = defaultButtonViewMargin
-                return
-        }
-
-        let marginMultiplier = UIDevice.current.orientation.isLandscape ?
-            ButtonViewMarginMultipliers.ipadLandscape :
-            ButtonViewMarginMultipliers.ipadPortrait
-
-        let margin = viewWidth * marginMultiplier
-
-        buttonViewLeadingConstraint?.constant = margin
-        buttonViewTrailingConstraint?.constant = margin
-    }
-
-    private enum ButtonViewMarginMultipliers {
-        static let ipadPortrait: CGFloat = 0.1667
-        static let ipadLandscape: CGFloat = 0.25
     }
 
 }

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -9,12 +9,6 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
 
     let tracker = AuthenticatorAnalyticsTracker.shared
 
-    /// Constraints on the table view container.
-    /// Used to adjust the table width in unified views.
-    @IBOutlet var tableViewLeadingConstraint: NSLayoutConstraint?
-    @IBOutlet var tableViewTrailingConstraint: NSLayoutConstraint?
-    var defaultTableViewMargin: CGFloat = 0
-
     lazy var loginFacade: LoginFacade = {
         let configuration = WordPressAuthenticator.shared.configuration
         let facade = LoginFacade(dotcomClientID: configuration.wpcomClientId,
@@ -358,45 +352,6 @@ extension LoginViewController {
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             didChangePreferredContentSize()
         }
-
-        // Update Table View size
-        setTableViewMargins(forWidth: view.frame.width)
-    }
-
-    open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        setTableViewMargins(forWidth: size.width)
-    }
-
-    /// Resize the table view based on trait collection.
-    /// Used only in unified views.
-    ///
-    func setTableViewMargins(forWidth viewWidth: CGFloat) {
-        guard let tableViewLeadingConstraint = tableViewLeadingConstraint,
-            let tableViewTrailingConstraint = tableViewTrailingConstraint else {
-                return
-        }
-
-        guard traitCollection.horizontalSizeClass == .regular &&
-            traitCollection.verticalSizeClass == .regular else {
-                tableViewLeadingConstraint.constant = defaultTableViewMargin
-                tableViewTrailingConstraint.constant = defaultTableViewMargin
-                return
-        }
-
-        let marginMultiplier = UIDevice.current.orientation.isLandscape ?
-            TableViewMarginMultipliers.ipadLandscape :
-            TableViewMarginMultipliers.ipadPortrait
-
-        let margin = viewWidth * marginMultiplier
-
-        tableViewLeadingConstraint.constant = margin
-        tableViewTrailingConstraint.constant = margin
-    }
-
-    private enum TableViewMarginMultipliers {
-        static let ipadPortrait: CGFloat = 0.1667
-        static let ipadLandscape: CGFloat = 0.25
     }
 
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFA.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFA.storyboard
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--TwoFA View Controller-->
         <scene sceneID="7Rf-Qz-qsw">
             <objects>
-                <viewController storyboardIdentifier="TwoFAViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="TwoFAViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
+                <viewController storyboardIdentifier="TwoFAViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="TwoFAViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="ljV-kF-TaY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFS-Ic-byk" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="591"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
@@ -28,10 +29,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xwA-rd-6jO" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="591" width="343" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
@@ -45,43 +46,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="bottomMargin" secondItem="ClH-Cn-49d" secondAttribute="bottom" constant="8" id="3Ba-yg-JKx"/>
                                             <constraint firstItem="ClH-Cn-49d" firstAttribute="top" secondItem="xwA-rd-6jO" secondAttribute="topMargin" constant="8" id="GgD-0x-Aud"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottomMargin" constant="8" id="85d-XY-Mr8"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="Bkw-QJ-Tbe"/>
-                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" constant="16" id="Bpv-qx-bHc"/>
-                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" constant="16" id="Rnp-SF-SGh"/>
+                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" id="Bpv-qx-bHc"/>
+                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" id="Rnp-SF-SGh"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="gkZ-OV-HMi"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="wBE-xi-42q"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
-                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="7MD-ux-8i0"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leadingMargin" id="msS-7X-Za9"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailingMargin" id="zY1-Yz-kTf"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="Dva-c1-u2U" id="Mq1-PI-MuN"/>
                         <outlet property="submitButton" destination="ClH-Cn-49d" id="kBa-QN-0oH"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="MGk-sG-xGv"/>
-                        <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
-                        <outlet property="tableViewTrailingConstraint" destination="7MD-ux-8i0" id="jbD-Z7-rAn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ipm-G3-kY7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -89,4 +88,9 @@
             <point key="canvasLocation" x="-162.40000000000001" y="20.239880059970016"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -36,9 +36,6 @@ final class TwoFAViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStarted.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStarted.storyboard
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Get Started View Controller-->
         <scene sceneID="7Rf-Qz-qsw">
             <objects>
-                <viewController storyboardIdentifier="GetStartedViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="GetStartedViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
+                <viewController storyboardIdentifier="GetStartedViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="GetStartedViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="ljV-kF-TaY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFS-Ic-byk" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <textField opaque="NO" alpha="0.10000000149011612" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cym-N3-RXL" userLabel="Hidden Password Field">
-                                        <rect key="frame" x="187" y="333" width="1" height="1"/>
+                                        <rect key="frame" x="171" y="333" width="1" height="1"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="1" id="Lbt-lI-oSV"/>
                                             <constraint firstAttribute="height" constant="1" id="h4g-fQ-WSb"/>
@@ -32,7 +33,7 @@
                                         </connections>
                                     </textField>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="451"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="451"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
@@ -40,23 +41,23 @@
                                         </connections>
                                     </tableView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="f1j-fj-w73" userLabel="Divider Stack View">
-                                        <rect key="frame" x="0.0" y="451" width="375" height="16"/>
+                                        <rect key="frame" x="-16" y="451" width="375" height="16"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Lc-Sw-Jlx" userLabel="Leading LIne">
-                                                <rect key="frame" x="0.0" y="7.5" width="173.5" height="1"/>
+                                                <rect key="frame" x="0.0" y="7.5" width="174" height="1"/>
                                                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Z6B-bC-BjQ"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OR" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QDu-95-gF8" userLabel="Divider Label">
-                                                <rect key="frame" x="178.5" y="0.0" width="18.5" height="16"/>
+                                                <rect key="frame" x="179" y="1" width="17.5" height="14.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GHG-oC-OAf" userLabel="Trailing LIne">
-                                                <rect key="frame" x="202" y="7.5" width="173" height="1"/>
+                                                <rect key="frame" x="201.5" y="7.5" width="173.5" height="1"/>
                                                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="2ZE-YT-ZFH"/>
@@ -68,7 +69,7 @@
                                         </constraints>
                                     </stackView>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cn0-53-fHS">
-                                        <rect key="frame" x="0.0" y="467" width="375" height="200"/>
+                                        <rect key="frame" x="-16" y="467" width="375" height="200"/>
                                         <subviews>
                                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c0A-wK-EYS" userLabel="Button Container View">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
@@ -79,7 +80,7 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="c0A-wK-EYS" firstAttribute="top" secondItem="Cn0-53-fHS" secondAttribute="top" id="KGY-Ol-Fv0"/>
-                                            <constraint firstAttribute="trailing" secondItem="c0A-wK-EYS" secondAttribute="trailing" id="Mih-IE-tDp"/>
+                                            <constraint firstItem="c0A-wK-EYS" firstAttribute="trailing" secondItem="Cn0-53-fHS" secondAttribute="trailing" id="Mih-IE-tDp"/>
                                             <constraint firstAttribute="bottom" secondItem="c0A-wK-EYS" secondAttribute="bottom" id="fBY-mz-gIs"/>
                                             <constraint firstItem="c0A-wK-EYS" firstAttribute="width" secondItem="Cn0-53-fHS" secondAttribute="width" id="fzv-K8-wr1"/>
                                             <constraint firstItem="c0A-wK-EYS" firstAttribute="height" secondItem="Cn0-53-fHS" secondAttribute="height" priority="250" id="juC-C0-Nkd"/>
@@ -87,7 +88,7 @@
                                         </constraints>
                                     </scrollView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="Cn0-53-fHS" firstAttribute="top" secondItem="f1j-fj-w73" secondAttribute="bottom" id="840-2J-2hS"/>
                                     <constraint firstItem="Cn0-53-fHS" firstAttribute="height" secondItem="dFS-Ic-byk" secondAttribute="height" multiplier="0.29985" id="Ffj-Ox-t77"/>
@@ -96,24 +97,24 @@
                                     <constraint firstItem="KLl-Uz-wEP" firstAttribute="height" relation="lessThanOrEqual" secondItem="dFS-Ic-byk" secondAttribute="height" multiplier="0.676162" id="UHX-ff-unr"/>
                                     <constraint firstItem="cym-N3-RXL" firstAttribute="centerY" secondItem="dFS-Ic-byk" secondAttribute="centerY" id="VNM-Yh-kiW"/>
                                     <constraint firstAttribute="bottom" secondItem="Cn0-53-fHS" secondAttribute="bottom" id="aYz-Gd-qyC"/>
-                                    <constraint firstItem="Cn0-53-fHS" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="lg0-jE-8Iw"/>
-                                    <constraint firstAttribute="trailing" secondItem="Cn0-53-fHS" secondAttribute="trailing" id="pgS-wZ-oFg"/>
+                                    <constraint firstItem="Cn0-53-fHS" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" constant="-16" id="lg0-jE-8Iw"/>
+                                    <constraint firstItem="Cn0-53-fHS" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" constant="16" id="pgS-wZ-oFg"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
-                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="7MD-ux-8i0"/>
                             <constraint firstItem="f1j-fj-w73" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="DU0-wo-2QI"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="f1j-fj-w73" secondAttribute="trailing" id="ir4-hA-zeL"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leadingMargin" id="msS-7X-Za9"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailingMargin" id="zY1-Yz-kTf"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
                     </view>
                     <connections>
                         <outlet property="dividerLabel" destination="QDu-95-gF8" id="Mjt-XK-h7a"/>
@@ -121,8 +122,6 @@
                         <outlet property="leadingDividerLine" destination="8Lc-Sw-Jlx" id="EVQ-Jg-oKZ"/>
                         <outlet property="leadingDividerLineWidth" destination="Z6B-bC-BjQ" id="Tor-0G-bt8"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="MGk-sG-xGv"/>
-                        <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
-                        <outlet property="tableViewTrailingConstraint" destination="7MD-ux-8i0" id="jbD-Z7-rAn"/>
                         <outlet property="trailingDividerLine" destination="GHG-oC-OAf" id="ObM-ec-SqR"/>
                         <outlet property="trailingDividerLineWidth" destination="2ZE-YT-ZFH" id="Dul-FQ-qlg"/>
                     </connections>
@@ -142,4 +141,9 @@
             <point key="canvasLocation" x="-163" y="518"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -50,7 +50,6 @@ class GetStartedViewController: LoginViewController {
         super.viewDidLoad()
 
         configureNavBar()
-        setupTable()
         registerTableViewCells()
         loadRows()
         setupContinueButton()
@@ -153,11 +152,6 @@ private extension GetStartedViewController {
     func configureNavBar() {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.getStartedTitle
         styleNavigationBar(forUnified: true)
-    }
-
-    func setupTable() {
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
     }
 
     func setupContinueButton() {

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmation.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmation.storyboard
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Google Signup Confirmation View Controller-->
         <scene sceneID="Xgu-uV-BzP">
             <objects>
-                <viewController storyboardIdentifier="GoogleSignupConfirmationViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="FHW-Ob-CNF" customClass="GoogleSignupConfirmationViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="faN-C4-7Mo">
+                <viewController storyboardIdentifier="GoogleSignupConfirmationViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="FHW-Ob-CNF" customClass="GoogleSignupConfirmationViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="faN-C4-7Mo">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SWG-5C-7n1" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="20" y="44" width="374" height="818"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-xv-8jt">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="742"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="742"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="FHW-Ob-CNF" id="87y-LX-Hli"/>
@@ -28,10 +29,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qzz-Hh-CjL" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="742" width="414" height="76"/>
+                                        <rect key="frame" x="0.0" y="742" width="374" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dym-5Q-67i" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="382" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dym-5Q-67i" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="374" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="Rli-Ca-yRL"/>
@@ -45,43 +46,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="FYE-Xz-8tr"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="bottomMargin" secondItem="dym-5Q-67i" secondAttribute="bottom" constant="8" id="7xe-sU-u4a"/>
                                             <constraint firstItem="dym-5Q-67i" firstAttribute="top" secondItem="qzz-Hh-CjL" secondAttribute="topMargin" constant="8" id="MeQ-dV-vHc"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="FYE-Xz-8tr"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="qzz-Hh-CjL" firstAttribute="top" secondItem="ZWc-xv-8jt" secondAttribute="bottom" id="KtR-9p-VJv"/>
-                                    <constraint firstItem="ZWc-xv-8jt" firstAttribute="trailing" secondItem="dym-5Q-67i" secondAttribute="trailing" constant="16" id="N6d-01-WPV"/>
+                                    <constraint firstItem="ZWc-xv-8jt" firstAttribute="trailing" secondItem="dym-5Q-67i" secondAttribute="trailing" id="N6d-01-WPV"/>
                                     <constraint firstItem="qzz-Hh-CjL" firstAttribute="bottom" secondItem="SWG-5C-7n1" secondAttribute="bottomMargin" constant="8" id="PsK-5r-0H1"/>
                                     <constraint firstItem="qzz-Hh-CjL" firstAttribute="leading" secondItem="SWG-5C-7n1" secondAttribute="leading" id="Xi9-bz-sba"/>
-                                    <constraint firstItem="dym-5Q-67i" firstAttribute="leading" secondItem="ZWc-xv-8jt" secondAttribute="leading" constant="16" id="b3B-7z-9p0"/>
+                                    <constraint firstItem="dym-5Q-67i" firstAttribute="leading" secondItem="ZWc-xv-8jt" secondAttribute="leading" id="b3B-7z-9p0"/>
                                     <constraint firstItem="qzz-Hh-CjL" firstAttribute="trailing" secondItem="SWG-5C-7n1" secondAttribute="trailing" id="bc6-d0-fEF"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Qp3-BR-gKF"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="ZWc-xv-8jt" firstAttribute="top" secondItem="Qp3-BR-gKF" secondAttribute="top" id="8Gf-kn-zlv"/>
                             <constraint firstItem="SWG-5C-7n1" firstAttribute="top" secondItem="Qp3-BR-gKF" secondAttribute="top" id="9eM-zq-ABr"/>
                             <constraint firstItem="Qp3-BR-gKF" firstAttribute="bottom" secondItem="SWG-5C-7n1" secondAttribute="bottom" id="IFj-d3-X0s"/>
-                            <constraint firstItem="SWG-5C-7n1" firstAttribute="trailing" secondItem="faN-C4-7Mo" secondAttribute="trailing" id="P9X-e8-JeC"/>
-                            <constraint firstItem="SWG-5C-7n1" firstAttribute="leading" secondItem="faN-C4-7Mo" secondAttribute="leading" id="Xek-2B-EU5"/>
-                            <constraint firstItem="ZWc-xv-8jt" firstAttribute="leading" secondItem="Qp3-BR-gKF" secondAttribute="leading" id="qsV-MZ-Mch"/>
-                            <constraint firstItem="Qp3-BR-gKF" firstAttribute="trailing" secondItem="ZWc-xv-8jt" secondAttribute="trailing" id="yx6-RZ-tqZ"/>
+                            <constraint firstItem="SWG-5C-7n1" firstAttribute="trailing" secondItem="faN-C4-7Mo" secondAttribute="trailingMargin" id="P9X-e8-JeC"/>
+                            <constraint firstItem="SWG-5C-7n1" firstAttribute="leading" secondItem="faN-C4-7Mo" secondAttribute="leadingMargin" id="Xek-2B-EU5"/>
+                            <constraint firstItem="ZWc-xv-8jt" firstAttribute="leading" secondItem="SWG-5C-7n1" secondAttribute="leading" id="qsV-MZ-Mch"/>
+                            <constraint firstItem="ZWc-xv-8jt" firstAttribute="trailing" secondItem="SWG-5C-7n1" secondAttribute="trailing" id="yx6-RZ-tqZ"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Qp3-BR-gKF"/>
                     </view>
                     <navigationItem key="navigationItem" id="9jh-WE-43v"/>
                     <connections>
                         <outlet property="submitButton" destination="dym-5Q-67i" id="zN7-PD-0HU"/>
                         <outlet property="tableView" destination="ZWc-xv-8jt" id="pgu-rC-q21"/>
-                        <outlet property="tableViewLeadingConstraint" destination="qsV-MZ-Mch" id="Vo0-tX-jz3"/>
-                        <outlet property="tableViewTrailingConstraint" destination="yx6-RZ-tqZ" id="q7A-OH-Fo5"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="EXH-O5-0Ao" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -89,4 +88,9 @@
             <point key="canvasLocation" x="904.79999999999995" y="-33.733133433283363"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleSignupConfirmationViewController.swift
@@ -25,9 +25,6 @@ class GoogleSignupConfirmationViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)
 
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLink.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLink.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dyg-ql-Edz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dyg-ql-Edz">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -12,15 +13,15 @@
         <scene sceneID="LD3-s3-Lka">
             <objects>
                 <viewController storyboardIdentifier="LoginMagicLinkViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Dyg-ql-Edz" customClass="LoginMagicLinkViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="CcR-fX-Brd">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="CcR-fX-Brd">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Eu-5g-JoU" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="yHt-Yf-OV2">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="591"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="Dyg-ql-Edz" id="hrG-Ah-EXE"/>
@@ -28,10 +29,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Yt-VF-fQg" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="591" width="343" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bef-xW-2AD" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bef-xW-2AD" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="afi-cL-xcn"/>
@@ -45,43 +46,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="fp4-3S-Qlt"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="bef-xW-2AD" firstAttribute="top" secondItem="6Yt-VF-fQg" secondAttribute="topMargin" constant="8" id="43B-zJ-99J"/>
                                             <constraint firstAttribute="bottomMargin" secondItem="bef-xW-2AD" secondAttribute="bottom" constant="8" id="N8q-WT-GLw"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="fp4-3S-Qlt"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="6Yt-VF-fQg" firstAttribute="leading" secondItem="0Eu-5g-JoU" secondAttribute="leading" id="1Rs-AA-lVQ"/>
                                     <constraint firstItem="6Yt-VF-fQg" firstAttribute="trailing" secondItem="0Eu-5g-JoU" secondAttribute="trailing" id="JRx-iz-jt2"/>
-                                    <constraint firstItem="yHt-Yf-OV2" firstAttribute="trailing" secondItem="bef-xW-2AD" secondAttribute="trailing" constant="16" id="LIG-Te-2df"/>
+                                    <constraint firstItem="yHt-Yf-OV2" firstAttribute="trailing" secondItem="bef-xW-2AD" secondAttribute="trailing" id="LIG-Te-2df"/>
                                     <constraint firstItem="6Yt-VF-fQg" firstAttribute="top" secondItem="yHt-Yf-OV2" secondAttribute="bottom" id="SsX-fk-SxJ"/>
-                                    <constraint firstItem="bef-xW-2AD" firstAttribute="leading" secondItem="yHt-Yf-OV2" secondAttribute="leading" constant="16" id="fKw-Hj-rtc"/>
+                                    <constraint firstItem="bef-xW-2AD" firstAttribute="leading" secondItem="yHt-Yf-OV2" secondAttribute="leading" id="fKw-Hj-rtc"/>
                                     <constraint firstItem="6Yt-VF-fQg" firstAttribute="bottom" secondItem="0Eu-5g-JoU" secondAttribute="bottomMargin" constant="8" id="k3A-b5-dL6"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="NgA-0I-Qui"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="yHt-Yf-OV2" firstAttribute="leading" secondItem="NgA-0I-Qui" secondAttribute="leading" id="4PC-tW-YHf"/>
+                            <constraint firstItem="yHt-Yf-OV2" firstAttribute="leading" secondItem="0Eu-5g-JoU" secondAttribute="leading" id="4PC-tW-YHf"/>
                             <constraint firstItem="yHt-Yf-OV2" firstAttribute="top" secondItem="NgA-0I-Qui" secondAttribute="top" id="82m-P2-rrC"/>
-                            <constraint firstItem="0Eu-5g-JoU" firstAttribute="trailing" secondItem="CcR-fX-Brd" secondAttribute="trailing" id="PHF-7z-YqC"/>
+                            <constraint firstItem="0Eu-5g-JoU" firstAttribute="trailing" secondItem="CcR-fX-Brd" secondAttribute="trailingMargin" id="PHF-7z-YqC"/>
                             <constraint firstItem="NgA-0I-Qui" firstAttribute="bottom" secondItem="0Eu-5g-JoU" secondAttribute="bottom" id="ZKE-1T-Eaq"/>
                             <constraint firstItem="0Eu-5g-JoU" firstAttribute="top" secondItem="NgA-0I-Qui" secondAttribute="top" id="eZZ-fR-B64"/>
-                            <constraint firstItem="0Eu-5g-JoU" firstAttribute="leading" secondItem="CcR-fX-Brd" secondAttribute="leading" id="ohn-lO-uLL"/>
-                            <constraint firstItem="NgA-0I-Qui" firstAttribute="trailing" secondItem="yHt-Yf-OV2" secondAttribute="trailing" id="py6-FE-7DV"/>
+                            <constraint firstItem="0Eu-5g-JoU" firstAttribute="leading" secondItem="CcR-fX-Brd" secondAttribute="leadingMargin" id="ohn-lO-uLL"/>
+                            <constraint firstItem="yHt-Yf-OV2" firstAttribute="trailing" secondItem="0Eu-5g-JoU" secondAttribute="trailing" id="py6-FE-7DV"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="NgA-0I-Qui"/>
                     </view>
                     <navigationItem key="navigationItem" id="bi9-Rl-H1t"/>
                     <connections>
                         <outlet property="submitButton" destination="bef-xW-2AD" id="jbL-o3-Gjw"/>
                         <outlet property="tableView" destination="yHt-Yf-OV2" id="C2H-QM-M4K"/>
-                        <outlet property="tableViewLeadingConstraint" destination="4PC-tW-YHf" id="2qd-Jt-tbE"/>
-                        <outlet property="tableViewTrailingConstraint" destination="py6-FE-7DV" id="B8D-Ca-sOH"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="epU-uu-8WD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -89,4 +88,9 @@
             <point key="canvasLocation" x="1702" y="-34"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/LoginMagicLinkViewController.swift
@@ -34,10 +34,6 @@ final class LoginMagicLinkViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 
-        // Store default margin, and size table for the view.
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/Password.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/Password.storyboard
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Password View Controller-->
         <scene sceneID="7Rf-Qz-qsw">
             <objects>
-                <viewController storyboardIdentifier="PasswordViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="PasswordViewController" customModule="WordPressAuthenticatorResources" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
+                <viewController storyboardIdentifier="PasswordViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="PasswordViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="ljV-kF-TaY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFS-Ic-byk" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="591"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
@@ -28,10 +29,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xwA-rd-6jO" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="591" width="343" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="343" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
                                                 </constraints>
@@ -44,43 +45,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="bottomMargin" secondItem="ClH-Cn-49d" secondAttribute="bottom" constant="8" id="3Ba-yg-JKx"/>
                                             <constraint firstItem="ClH-Cn-49d" firstAttribute="top" secondItem="xwA-rd-6jO" secondAttribute="topMargin" constant="8" id="GgD-0x-Aud"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottomMargin" constant="8" id="85d-XY-Mr8"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="Bkw-QJ-Tbe"/>
-                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" constant="16" id="Bpv-qx-bHc"/>
-                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" constant="16" id="Rnp-SF-SGh"/>
+                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" id="Bpv-qx-bHc"/>
+                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" id="Rnp-SF-SGh"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="gkZ-OV-HMi"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="wBE-xi-42q"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
-                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="7MD-ux-8i0"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leadingMargin" id="msS-7X-Za9"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailingMargin" id="zY1-Yz-kTf"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="Dva-c1-u2U" id="Mq1-PI-MuN"/>
                         <outlet property="submitButton" destination="ClH-Cn-49d" id="kBa-QN-0oH"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="MGk-sG-xGv"/>
-                        <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
-                        <outlet property="tableViewTrailingConstraint" destination="7MD-ux-8i0" id="jbD-Z7-rAn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ipm-G3-kY7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -88,4 +87,9 @@
             <point key="canvasLocation" x="-162.40000000000001" y="20.239880059970016"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -46,9 +46,6 @@ class PasswordViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/SignupMagicLinkViewController.swift
@@ -38,10 +38,6 @@ final class SignupMagicLinkViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)
 
-        // Store default margin, and size table for the view.
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignup.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignup.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eEV-Dl-qyz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eEV-Dl-qyz">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -12,15 +13,15 @@
         <scene sceneID="tlG-zZ-6we">
             <objects>
                 <viewController storyboardIdentifier="UnifiedSignupViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="eEV-Dl-qyz" customClass="UnifiedSignupViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="48f-x8-Uiu">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="48f-x8-Uiu">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vrC-wY-7gH" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uMq-La-HEm">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="591"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="eEV-Dl-qyz" id="Kql-sH-scf"/>
@@ -28,10 +29,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UFq-9y-0cn" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="591" width="343" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4e9-BU-PNb" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4e9-BU-PNb" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="bK8-Nz-TAg"/>
@@ -45,43 +46,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="ggX-Oc-Xox"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="4e9-BU-PNb" firstAttribute="top" secondItem="UFq-9y-0cn" secondAttribute="topMargin" constant="8" id="HBB-yb-lJS"/>
                                             <constraint firstAttribute="bottomMargin" secondItem="4e9-BU-PNb" secondAttribute="bottom" constant="8" id="cns-b6-V0y"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="ggX-Oc-Xox"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="UFq-9y-0cn" firstAttribute="bottom" secondItem="vrC-wY-7gH" secondAttribute="bottomMargin" constant="8" id="9wB-kg-uNd"/>
-                                    <constraint firstItem="4e9-BU-PNb" firstAttribute="leading" secondItem="uMq-La-HEm" secondAttribute="leading" constant="16" id="BVd-do-zae"/>
+                                    <constraint firstItem="4e9-BU-PNb" firstAttribute="leading" secondItem="uMq-La-HEm" secondAttribute="leading" id="BVd-do-zae"/>
                                     <constraint firstItem="UFq-9y-0cn" firstAttribute="leading" secondItem="vrC-wY-7gH" secondAttribute="leading" id="Jcq-T2-uPZ"/>
-                                    <constraint firstItem="uMq-La-HEm" firstAttribute="trailing" secondItem="4e9-BU-PNb" secondAttribute="trailing" constant="16" id="Zyc-DP-C03"/>
+                                    <constraint firstItem="uMq-La-HEm" firstAttribute="trailing" secondItem="4e9-BU-PNb" secondAttribute="trailing" id="Zyc-DP-C03"/>
                                     <constraint firstItem="UFq-9y-0cn" firstAttribute="trailing" secondItem="vrC-wY-7gH" secondAttribute="trailing" id="ceu-5F-NZe"/>
                                     <constraint firstItem="UFq-9y-0cn" firstAttribute="top" secondItem="uMq-La-HEm" secondAttribute="bottom" id="rqC-0L-jbi"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="7D5-97-8zD"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="7D5-97-8zD" firstAttribute="trailing" secondItem="uMq-La-HEm" secondAttribute="trailing" id="6hE-qE-zLF"/>
+                            <constraint firstItem="uMq-La-HEm" firstAttribute="trailing" secondItem="vrC-wY-7gH" secondAttribute="trailing" id="6hE-qE-zLF"/>
                             <constraint firstItem="7D5-97-8zD" firstAttribute="bottom" secondItem="vrC-wY-7gH" secondAttribute="bottom" id="A5i-l6-R2a"/>
                             <constraint firstItem="vrC-wY-7gH" firstAttribute="top" secondItem="7D5-97-8zD" secondAttribute="top" id="R2Z-E0-wqG"/>
-                            <constraint firstItem="vrC-wY-7gH" firstAttribute="trailing" secondItem="48f-x8-Uiu" secondAttribute="trailing" id="R6b-Gs-GDz"/>
-                            <constraint firstItem="vrC-wY-7gH" firstAttribute="leading" secondItem="48f-x8-Uiu" secondAttribute="leading" id="aM7-4X-zWN"/>
+                            <constraint firstItem="vrC-wY-7gH" firstAttribute="trailing" secondItem="48f-x8-Uiu" secondAttribute="trailingMargin" id="R6b-Gs-GDz"/>
+                            <constraint firstItem="vrC-wY-7gH" firstAttribute="leading" secondItem="48f-x8-Uiu" secondAttribute="leadingMargin" id="aM7-4X-zWN"/>
                             <constraint firstItem="uMq-La-HEm" firstAttribute="top" secondItem="7D5-97-8zD" secondAttribute="top" id="azl-B9-x80"/>
-                            <constraint firstItem="uMq-La-HEm" firstAttribute="leading" secondItem="7D5-97-8zD" secondAttribute="leading" id="xs1-4O-GeZ"/>
+                            <constraint firstItem="uMq-La-HEm" firstAttribute="leading" secondItem="vrC-wY-7gH" secondAttribute="leading" id="xs1-4O-GeZ"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="7D5-97-8zD"/>
                     </view>
                     <navigationItem key="navigationItem" id="5lc-hf-cia"/>
                     <connections>
                         <outlet property="submitButton" destination="4e9-BU-PNb" id="GSH-Hx-8G0"/>
                         <outlet property="tableView" destination="uMq-La-HEm" id="uaR-Kf-8hW"/>
-                        <outlet property="tableViewLeadingConstraint" destination="xs1-4O-GeZ" id="hDa-A6-doE"/>
-                        <outlet property="tableViewTrailingConstraint" destination="6hE-qE-zLF" id="mUc-ix-0ws"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xaV-I9-fiG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -92,15 +91,15 @@
         <scene sceneID="wC4-bu-Drv">
             <objects>
                 <viewController storyboardIdentifier="SignupMagicLinkViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="XmN-dr-9CJ" customClass="SignupMagicLinkViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="Mfx-ev-teh">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="Mfx-ev-teh">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xra-W4-ZE5" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ENM-ow-V9N">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="591"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="XmN-dr-9CJ" id="DdS-Hm-4G4"/>
@@ -108,10 +107,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ip0-bN-Hx1" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="591" width="343" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CrF-zC-jXz" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CrF-zC-jXz" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="lFG-K5-twQ"/>
@@ -125,43 +124,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="Twj-up-Pl8"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="bottomMargin" secondItem="CrF-zC-jXz" secondAttribute="bottom" constant="8" id="5EM-ip-9xE"/>
                                             <constraint firstItem="CrF-zC-jXz" firstAttribute="top" secondItem="ip0-bN-Hx1" secondAttribute="topMargin" constant="8" id="oDN-pR-K7w"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="Twj-up-Pl8"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="ip0-bN-Hx1" firstAttribute="leading" secondItem="xra-W4-ZE5" secondAttribute="leading" id="GrI-Cg-S11"/>
                                     <constraint firstItem="ip0-bN-Hx1" firstAttribute="top" secondItem="ENM-ow-V9N" secondAttribute="bottom" id="eFD-Ly-Sp9"/>
                                     <constraint firstItem="ip0-bN-Hx1" firstAttribute="trailing" secondItem="xra-W4-ZE5" secondAttribute="trailing" id="fNA-XH-11n"/>
-                                    <constraint firstItem="CrF-zC-jXz" firstAttribute="leading" secondItem="ENM-ow-V9N" secondAttribute="leading" constant="16" id="hhO-WG-Xci"/>
-                                    <constraint firstItem="ENM-ow-V9N" firstAttribute="trailing" secondItem="CrF-zC-jXz" secondAttribute="trailing" constant="16" id="moM-Fh-P8a"/>
+                                    <constraint firstItem="CrF-zC-jXz" firstAttribute="leading" secondItem="ENM-ow-V9N" secondAttribute="leading" id="hhO-WG-Xci"/>
+                                    <constraint firstItem="ENM-ow-V9N" firstAttribute="trailing" secondItem="CrF-zC-jXz" secondAttribute="trailing" id="moM-Fh-P8a"/>
                                     <constraint firstItem="ip0-bN-Hx1" firstAttribute="bottom" secondItem="xra-W4-ZE5" secondAttribute="bottomMargin" constant="8" id="qIT-dZ-yaP"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="9WS-Pn-DU7"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="ENM-ow-V9N" firstAttribute="leading" secondItem="9WS-Pn-DU7" secondAttribute="leading" id="Etd-5H-u0b"/>
+                            <constraint firstItem="ENM-ow-V9N" firstAttribute="leading" secondItem="xra-W4-ZE5" secondAttribute="leading" id="Etd-5H-u0b"/>
                             <constraint firstItem="9WS-Pn-DU7" firstAttribute="bottom" secondItem="xra-W4-ZE5" secondAttribute="bottom" id="Gaf-bD-fan"/>
-                            <constraint firstItem="xra-W4-ZE5" firstAttribute="trailing" secondItem="Mfx-ev-teh" secondAttribute="trailing" id="OXX-AQ-oJw"/>
+                            <constraint firstItem="xra-W4-ZE5" firstAttribute="trailing" secondItem="Mfx-ev-teh" secondAttribute="trailingMargin" id="OXX-AQ-oJw"/>
                             <constraint firstItem="ENM-ow-V9N" firstAttribute="top" secondItem="9WS-Pn-DU7" secondAttribute="top" id="Ofs-47-IhL"/>
                             <constraint firstItem="xra-W4-ZE5" firstAttribute="top" secondItem="9WS-Pn-DU7" secondAttribute="top" id="Ojd-jN-fOY"/>
-                            <constraint firstItem="9WS-Pn-DU7" firstAttribute="trailing" secondItem="ENM-ow-V9N" secondAttribute="trailing" id="PLQ-gW-0QM"/>
-                            <constraint firstItem="xra-W4-ZE5" firstAttribute="leading" secondItem="Mfx-ev-teh" secondAttribute="leading" id="ddR-fd-wIp"/>
+                            <constraint firstItem="ENM-ow-V9N" firstAttribute="trailing" secondItem="xra-W4-ZE5" secondAttribute="trailing" id="PLQ-gW-0QM"/>
+                            <constraint firstItem="xra-W4-ZE5" firstAttribute="leading" secondItem="Mfx-ev-teh" secondAttribute="leadingMargin" id="ddR-fd-wIp"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="9WS-Pn-DU7"/>
                     </view>
                     <navigationItem key="navigationItem" id="AON-RJ-6DJ"/>
                     <connections>
                         <outlet property="submitButton" destination="CrF-zC-jXz" id="zZy-2v-8kS"/>
                         <outlet property="tableView" destination="ENM-ow-V9N" id="N0t-yM-rVd"/>
-                        <outlet property="tableViewLeadingConstraint" destination="Etd-5H-u0b" id="f0p-Yl-M0Q"/>
-                        <outlet property="tableViewTrailingConstraint" destination="PLQ-gW-0QM" id="2Wk-Fe-Ig1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5tI-BM-UnB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -169,4 +166,9 @@
             <point key="canvasLocation" x="1702" y="-34"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -25,10 +25,6 @@ class UnifiedSignupViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.signUpTitle
         styleNavigationBar(forUnified: true)
 
-        // Store default margin, and size table for the view.
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddress.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddress.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -12,15 +13,15 @@
         <scene sceneID="7Rf-Qz-qsw">
             <objects>
                 <viewController storyboardIdentifier="SiteAddressViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aQT-Gx-U3x" customClass="SiteAddressViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="ljV-kF-TaY">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="ljV-kF-TaY">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dFS-Ic-byk" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="591"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
@@ -28,10 +29,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xwA-rd-6jO" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="591" width="343" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
@@ -45,43 +46,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="bottomMargin" secondItem="ClH-Cn-49d" secondAttribute="bottom" constant="8" id="3Ba-yg-JKx"/>
                                             <constraint firstItem="ClH-Cn-49d" firstAttribute="top" secondItem="xwA-rd-6jO" secondAttribute="topMargin" constant="8" id="GgD-0x-Aud"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottomMargin" constant="8" id="85d-XY-Mr8"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="Bkw-QJ-Tbe"/>
-                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" constant="16" id="Bpv-qx-bHc"/>
-                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" constant="16" id="Rnp-SF-SGh"/>
+                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" id="Bpv-qx-bHc"/>
+                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" id="Rnp-SF-SGh"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="gkZ-OV-HMi"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="wBE-xi-42q"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
-                            <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
+                            <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="7MD-ux-8i0"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottom" id="Dva-c1-u2U"/>
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="R3r-wt-ya5"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="top" secondItem="ihD-pY-rg9" secondAttribute="top" id="YEy-EW-XmD"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
-                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leadingMargin" id="msS-7X-Za9"/>
+                            <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailingMargin" id="zY1-Yz-kTf"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="Dva-c1-u2U" id="cA6-Wt-5oj"/>
                         <outlet property="submitButton" destination="ClH-Cn-49d" id="kBa-QN-0oH"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="ntt-cX-m20"/>
-                        <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
-                        <outlet property="tableViewTrailingConstraint" destination="7MD-ux-8i0" id="jbD-Z7-rAn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ipm-G3-kY7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -92,15 +91,15 @@
         <scene sceneID="SNM-jM-Hwx">
             <objects>
                 <viewController storyboardIdentifier="SiteCredentialsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="y6V-vh-KSr" customClass="SiteCredentialsViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="rzp-ZY-4sV">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="rzp-ZY-4sV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HOD-IX-jQc" userLabel="Containing View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="msV-bz-Sqp">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="591"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="y6V-vh-KSr" id="Jh2-5j-HIR"/>
@@ -108,10 +107,10 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YGp-eK-oRp" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="591" width="343" height="76"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bUY-a5-oHJ" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bUY-a5-oHJ" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="16" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="v9D-Cw-nFD"/>
@@ -125,43 +124,41 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <viewLayoutGuide key="safeArea" id="Hd0-aR-a4s"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="bUY-a5-oHJ" firstAttribute="top" secondItem="YGp-eK-oRp" secondAttribute="topMargin" constant="8" id="7ST-0h-lCv"/>
                                             <constraint firstAttribute="bottomMargin" secondItem="bUY-a5-oHJ" secondAttribute="bottom" constant="8" id="CIb-xr-SzK"/>
                                         </constraints>
-                                        <viewLayoutGuide key="safeArea" id="Hd0-aR-a4s"/>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="bottom" secondItem="HOD-IX-jQc" secondAttribute="bottomMargin" constant="8" id="AHZ-rn-MEN"/>
-                                    <constraint firstItem="bUY-a5-oHJ" firstAttribute="leading" secondItem="msV-bz-Sqp" secondAttribute="leading" constant="16" id="EOR-16-rjC"/>
+                                    <constraint firstItem="bUY-a5-oHJ" firstAttribute="leading" secondItem="msV-bz-Sqp" secondAttribute="leading" id="EOR-16-rjC"/>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="trailing" secondItem="HOD-IX-jQc" secondAttribute="trailing" id="FKm-da-ANZ"/>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="top" secondItem="msV-bz-Sqp" secondAttribute="bottom" id="Wt7-Vo-sCx"/>
-                                    <constraint firstItem="msV-bz-Sqp" firstAttribute="trailing" secondItem="bUY-a5-oHJ" secondAttribute="trailing" constant="16" id="Yeq-i8-mJg"/>
+                                    <constraint firstItem="msV-bz-Sqp" firstAttribute="trailing" secondItem="bUY-a5-oHJ" secondAttribute="trailing" id="Yeq-i8-mJg"/>
                                     <constraint firstItem="YGp-eK-oRp" firstAttribute="leading" secondItem="HOD-IX-jQc" secondAttribute="leading" id="piw-Hs-lPT"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="5Dn-ej-Nhp"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="HOD-IX-jQc" firstAttribute="top" secondItem="5Dn-ej-Nhp" secondAttribute="top" id="Iud-8M-zpD"/>
                             <constraint firstItem="5Dn-ej-Nhp" firstAttribute="bottom" secondItem="HOD-IX-jQc" secondAttribute="bottom" id="Qxf-z0-9lF"/>
                             <constraint firstItem="msV-bz-Sqp" firstAttribute="top" secondItem="5Dn-ej-Nhp" secondAttribute="top" id="Wxv-oA-2Kw"/>
-                            <constraint firstItem="msV-bz-Sqp" firstAttribute="leading" secondItem="5Dn-ej-Nhp" secondAttribute="leading" id="XJE-JH-rvO"/>
-                            <constraint firstItem="HOD-IX-jQc" firstAttribute="trailing" secondItem="rzp-ZY-4sV" secondAttribute="trailing" id="bF4-se-bcv"/>
-                            <constraint firstItem="5Dn-ej-Nhp" firstAttribute="trailing" secondItem="msV-bz-Sqp" secondAttribute="trailing" id="odn-ry-dZH"/>
-                            <constraint firstItem="HOD-IX-jQc" firstAttribute="leading" secondItem="rzp-ZY-4sV" secondAttribute="leading" id="txP-xH-B39"/>
+                            <constraint firstItem="msV-bz-Sqp" firstAttribute="leading" secondItem="HOD-IX-jQc" secondAttribute="leading" id="XJE-JH-rvO"/>
+                            <constraint firstItem="HOD-IX-jQc" firstAttribute="trailing" secondItem="rzp-ZY-4sV" secondAttribute="trailingMargin" id="bF4-se-bcv"/>
+                            <constraint firstItem="msV-bz-Sqp" firstAttribute="trailing" secondItem="HOD-IX-jQc" secondAttribute="trailing" id="odn-ry-dZH"/>
+                            <constraint firstItem="HOD-IX-jQc" firstAttribute="leading" secondItem="rzp-ZY-4sV" secondAttribute="leadingMargin" id="txP-xH-B39"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="5Dn-ej-Nhp"/>
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="Qxf-z0-9lF" id="QCJ-ks-Lz9"/>
                         <outlet property="submitButton" destination="bUY-a5-oHJ" id="AyH-o7-6z2"/>
                         <outlet property="tableView" destination="msV-bz-Sqp" id="UhW-BX-cA3"/>
-                        <outlet property="tableViewLeadingConstraint" destination="XJE-JH-rvO" id="KKt-z5-KD9"/>
-                        <outlet property="tableViewTrailingConstraint" destination="odn-ry-dZH" id="JKu-G5-4Jr"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pmu-qI-bIl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -169,4 +166,9 @@
             <point key="canvasLocation" x="561" y="20"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -41,7 +41,6 @@ final class SiteAddressViewController: LoginViewController {
 
         removeGoogleWaitingView()
         configureNavBar()
-        setupTable()
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()
@@ -239,11 +238,6 @@ private extension SiteAddressViewController {
 
         // Nav bar could be hidden from the host app, so reshow it.
         navigationController?.setNavigationBarHidden(false, animated: false)
-    }
-
-    func setupTable() {
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
     }
 
     // MARK: - Table Management

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -48,10 +48,6 @@ final class SiteCredentialsViewController: LoginViewController {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
 
-        // Store default margin, and size table for the view.
-        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
-        setTableViewMargins(forWidth: view.frame.width)
-
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()


### PR DESCRIPTION
Related PR: wordpress-mobile/WordPress-iOS#17870

## Description

Currently the margins for iPad are being manually calculated based on the view's width. This change removes that calculation and uses the readable content guide.

Additionally, there were some constraints breaking on the button view when it was embedded into a view which was larger than itself. I added some constraints to this view with lower priorities so that it breaks the correct constraints and does not mess up the buttons.

## Screenshots - iPhone

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660046-aa323335-7624-4b85-8714-d8629ae4e080.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660051-7d4ad51a-221a-425a-8342-a497f8c47f33.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660047-170d82bb-256e-4f2b-ab3e-a71c8c63e3f0.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660052-c9c6b08c-f594-4a8a-8098-a34e8692ed96.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660048-68a6c6de-74ce-447c-952f-88f5ffef93e2.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660054-69a6d3cf-a0df-4736-a513-1b5c5cfce5d1.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660049-7ed52715-a59d-43ea-a54c-ec2dfdc7ddba.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660055-20146393-2171-448f-a7d5-d8718a6fafce.png"> |

## Screenshots - iPad Portrait

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660193-737c842c-ce34-4bb4-8cf5-bfb1d7fc6d75.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660197-a351fa09-b2a8-4329-9df6-880d4a68c97b.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660194-5000cb0a-5097-4811-8a2e-771d587ed71f.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660200-7989be7f-8207-49e7-849c-0a15a5c01789.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660195-f72fd6ce-4716-4f72-8e2b-f88ede236208.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660202-727ac38e-df0d-4f77-90dd-765b9142a61f.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660196-f58a5c77-8ff5-4daf-b3aa-f7a23b341a79.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660206-ae7c3814-a3f3-4d6c-adf3-2ca2b699ef78.png"> |

## Screenshots - iPad Landscape

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660319-6fcb1582-fa1e-45b3-8e4c-2e211101506c.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660329-d1136d95-d384-481f-8db7-4742e3bfe4d2.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660320-e44c8645-4311-4e4f-bc32-affaffb373e5.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660333-d142ae6a-78dc-4449-922a-7cb5001c68df.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660321-0f393926-ed1f-42e8-a9aa-2136fcf3f318.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660337-3ce6d02f-032d-4f89-a5aa-9f74055ca5e4.png"> |

| Before | After |
|--------|------|
| <img src="https://user-images.githubusercontent.com/2454408/150660323-051e9ebb-61a1-40c1-85fc-152c49771ad4.png"> | <img src="https://user-images.githubusercontent.com/2454408/150660338-149c5178-b3dc-436c-ae12-866307e200e2.png"> |
