### PR TITLE
Merge 1.43.0 stable release 

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.43.0-beta.3'
+  s.version       = '1.43.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze process for WordPress iOS 19.1 and is here to leave a breadcrumb in the release process. I will be admin-merge it and deploy the new version as soon as CI is green.