### PR TITLE
Added new new methods to WordPressAuthenticatorDelegate to store site…

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '1.43.1'
+  s.version       = '1.44.0-beta-1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -69,6 +69,14 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// - Parameter isJetpackLogin: Indicates if we've just logged into a WordPress.com account for Jetpack purposes!.
     ///
     func shouldPresentLoginEpilogue(isJetpackLogin: Bool) -> Bool
+    
+    /// Indicates the Host app wants to cache the site address entered during login.
+    ///
+    func shouldStoreLoginSiteAddress() -> Bool
+
+    /// Stores the site address from login to be used by the Host app.
+    ///
+    func storeLoginSiteAddress(_ siteAddress: String)
 
     /// Indicates the Host app wants to handle and display a given error.
     ///

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -69,7 +69,6 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// - Parameter isJetpackLogin: Indicates if we've just logged into a WordPress.com account for Jetpack purposes!.
     ///
     func shouldPresentLoginEpilogue(isJetpackLogin: Bool) -> Bool
-    
     /// Indicates the Host app wants to cache the site address entered during login.
     ///
     func shouldStoreLoginSiteAddress() -> Bool

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -514,6 +514,10 @@ private extension SiteAddressViewController {
         if let verifiedSiteAddress = siteInfo?.url {
             loginFields.siteAddress = verifiedSiteAddress
         }
+        
+        if (authenticationDelegate.shouldStoreLoginSiteAddress()) {
+            authenticationDelegate.storeLoginSiteAddress(loginFields.siteAddress)
+        }
 
         guard siteInfo?.isWPCom == false else {
             showGetStarted()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -514,8 +514,8 @@ private extension SiteAddressViewController {
         if let verifiedSiteAddress = siteInfo?.url {
             loginFields.siteAddress = verifiedSiteAddress
         }
-        
-        if (authenticationDelegate.shouldStoreLoginSiteAddress()) {
+
+        if authenticationDelegate.shouldStoreLoginSiteAddress() {
             authenticationDelegate.storeLoginSiteAddress(loginFields.siteAddress)
         }
 


### PR DESCRIPTION
Closes #641 
Ref: woocommerce/woocommerce-ios/issues/3571

## Changes
- Adds two new methods to `WordPressAuthenticatorDelegate`:
   - `shouldStoreLoginSiteAddress()` – This can be used by the host apps if we want to store the site address in `UserDefaults`, after the site address verification is successful.
   - `storeLoginSiteAddress()` – This method captures the site address and can be used by the Woo app to store this address in `UserDefaults`.
- This might require changes to the WordPress app too. I can open a PR in that repository once this PR has been approved.

## How to test
* The best way to test is testing the following PR in WooCommerce: woocommerce/woocommerce-ios#6404

## Disclaimer
This is my first time working on iOS and the WordPress Authenticator in a while so please feel free to leave any suggestions or improvements to the current code :) 