### PR TITLE
Bump pod version to `2.0.1-beta.2`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.0.1-beta.1'
+  s.version       = '2.0.1-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This PR bumps the pod version from `2.0.1-beta.1` to `2.0.1-beta.2`. 

For releasing a new pod version for changes from PR - https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/646