### PR TITLE
Bump pod version to '2.1.0-beta.3'

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.1.0-beta.2'
+  s.version       = '2.1.0-beta.3'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This PR bumps the pod version from '2.1.0-beta.2' to '2.1.0-beta.3'

For releasing a new pod version for changes from PR - https://github.com/woocommerce/woocommerce-ios/pull/7320