### PR TITLE
Pass a custom error for invalid WP.com email errors

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.1.0-beta.3'
+  s.version       = '2.1.0-beta.4'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -15,6 +15,7 @@ private extension NavigateToEnterAccount {
             DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
             return
         }
+        vc.source = .wpCom
 
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -397,6 +397,7 @@ class LoginPrologueViewController: LoginViewController {
             DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
             return
         }
+        vc.source = .wpCom
 
         navigationController?.pushViewController(vc, animated: true)
     }
@@ -430,15 +431,6 @@ class LoginPrologueViewController: LoginViewController {
     private func presentLoginEmailView() {
         guard let toVC = LoginEmailViewController.instantiate(from: .login) else {
             DDLogError("Failed to navigate to LoginEmailVC from LoginPrologueVC")
-            return
-        }
-
-        navigationController?.pushViewController(toVC, animated: true)
-    }
-
-    private func presentGetStartedView() {
-        guard let toVC = GetStartedViewController.instantiate(from: .getStarted) else {
-            DDLogError("Failed to navigate to GetStartedViewController")
             return
         }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -2,6 +2,37 @@ import UIKit
 import SafariServices
 import WordPressKit
 
+/// The source for the sign in flow for external tracking.
+public enum SignInSource {
+    /// Initiated from the WP.com login CTA.
+    case wpCom
+    /// Initiated from the WP.com login flow that starts with site address.
+    case wpComSiteAddress
+    /// Other unspecified sources.
+    case other
+}
+
+/// The error during the sign in flow.
+public enum SignInError: Error {
+    case invalidWPComEmail(source: SignInSource)
+
+    init?(error: Error, source: SignInSource) {
+        let error = error as NSError
+
+        switch error.code {
+        case WordPressComRestApiError.unknown.rawValue:
+            let restAPIErrorCode = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
+            if restAPIErrorCode == "unknown_user" {
+                self = .invalidWPComEmail(source: source)
+            } else {
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
+}
+
 class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
 
     private enum ScreenMode {
@@ -35,6 +66,8 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
 
     // This is public so it can be set from StoredCredentialsAuthenticator.
     var errorMessage: String?
+
+    var source: SignInSource = .other
 
     private var rows = [Row]()
     private var buttonViewController: NUXButtonViewController?
@@ -509,14 +542,15 @@ private extension GetStartedViewController {
                 // username instead.
                 self.showSelfHostedWithError(error)
         } else {
+            let signInError = SignInError(error: error, source: source) ?? error
             guard let authenticationDelegate = WordPressAuthenticator.shared.delegate,
-                  authenticationDelegate.shouldHandleError(error) else {
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                  authenticationDelegate.shouldHandleError(signInError) else {
+                displayError(error as NSError, sourceTag: sourceTag)
                 return
             }
 
             /// Hand over control to the host app.
-            authenticationDelegate.handleError(error) { customUI in
+            authenticationDelegate.handleError(signInError) { customUI in
                 // Setting the rightBarButtonItems of the custom UI before pushing the view controller
                 // and resetting the navigationController's navigationItem after the push seems to be the
                 // only combination that gets the Help button to show up.

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -8,21 +8,19 @@ public enum SignInSource {
     case wpCom
     /// Initiated from the WP.com login flow that starts with site address.
     case wpComSiteAddress
-    /// Other unspecified sources.
-    case other
 }
 
 /// The error during the sign in flow.
 public enum SignInError: Error {
     case invalidWPComEmail(source: SignInSource)
 
-    init?(error: Error, source: SignInSource) {
+    init?(error: Error, source: SignInSource?) {
         let error = error as NSError
 
         switch error.code {
         case WordPressComRestApiError.unknown.rawValue:
             let restAPIErrorCode = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
-            if restAPIErrorCode == "unknown_user" {
+            if let source = source, restAPIErrorCode == "unknown_user" {
                 self = .invalidWPComEmail(source: source)
             } else {
                 return nil
@@ -67,7 +65,7 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
     // This is public so it can be set from StoredCredentialsAuthenticator.
     var errorMessage: String?
 
-    var source: SignInSource = .other
+    var source: SignInSource?
 
     private var rows = [Row]()
     private var buttonViewController: NUXButtonViewController?

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -588,6 +588,7 @@ private extension SiteAddressViewController {
             DDLogError("Failed to navigate from SiteAddressViewController to GetStartedViewController")
             return
         }
+        vc.source = .wpComSiteAddress
 
         vc.loginFields = loginFields
         vc.dismissBlock = dismissBlock


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/issues/7318

## Description

In order to track the source of invalid email errors for WCiOS local notifications experiment, we need a way to differentiate the two flows - "Enter Your Store Address" or "Continue With WordPress.com". This PR added a new `SignInError` and `SignInSource` and parsed the error for invalid email based on the [WCiOS implementation](https://github.com/woocommerce/woocommerce-ios/blob/eec2b2178aff5694294d5bd6848df0bb88524a1b/WooCommerce/Classes/Authentication/AuthenticationManager.swift#L492).

WPiOS [does not handle errors in a custom way](https://github.com/wordpress-mobile/WordPress-iOS/blob/d6b813b903c34d4d66ac07c5e452b378fd952e63/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift#L487-L490) like WCiOS.

## Testing steps

Please refer to the WCiOS draft PR to test the integration.