### PR TITLE
Send `siteURL` to `showLoginForJustWPCom`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.1.0-beta.4'
+  s.version       = '2.1.0-beta.5'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -182,11 +182,10 @@ import WordPressKit
     }
 
     /// Used to present the new wpcom-only login flow from the app delegate
-    @objc public class func showLoginForJustWPCom(from presenter: UIViewController, jetpackLogin: Bool = false, connectedEmail: String? = nil) {
+    @objc public class func showLoginForJustWPCom(from presenter: UIViewController, jetpackLogin: Bool = false, connectedEmail: String? = nil, siteURL: String? = nil) {
         defer {
             trackOpenedLogin()
         }
-
         guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
             showEmailLogin(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail)
             return
@@ -197,7 +196,7 @@ import WordPressKit
 
     /// Shows the unified Login/Signup flow.
     ///
-    private class func showGetStarted(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil) {
+    private class func showGetStarted(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil, siteURL: String? = nil) {
         guard let controller = GetStartedViewController.instantiate(from: .getStarted) else {
             DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
             return
@@ -206,6 +205,9 @@ import WordPressKit
         controller.loginFields.restrictToWPCom = true
         controller.loginFields.username = connectedEmail ?? String()
         controller.loginFields.meta.jetpackLogin = jetpackLogin
+        if let siteURL = siteURL {
+            controller.loginFields.siteAddress = siteURL
+        }
 
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen
@@ -214,13 +216,16 @@ import WordPressKit
 
     /// Shows the Email Login view with Signup option.
     ///
-    private class func showEmailLogin(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil) {
+    private class func showEmailLogin(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil, siteURL: String? = nil) {
         guard let controller = LoginEmailViewController.instantiate(from: .login) else {
             return
         }
 
         controller.loginFields.restrictToWPCom = true
         controller.loginFields.meta.jetpackLogin = jetpackLogin
+        if let siteURL = siteURL {
+            controller.loginFields.siteAddress = siteURL
+        }
 
         if let email = connectedEmail {
             controller.loginFields.username = email

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -187,11 +187,11 @@ import WordPressKit
             trackOpenedLogin()
         }
         guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth else {
-            showEmailLogin(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail)
+            showEmailLogin(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail, siteURL: siteURL)
             return
         }
 
-        showGetStarted(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail)
+        showGetStarted(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail, siteURL: siteURL)
     }
 
     /// Shows the unified Login/Signup flow.


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/pull/7373/

# Description

On WCiOS we want to show the login flow for WP.com authentication manually - but when the `presentLoginEpilogue` delegate method is called, the `wpcom` credentials return https://wordpress.com for `siteURL`. 

This PR fixes that by sending `siteURL` to the `showLoginForJustWPCom` method, which will be saved in `loginFields` and returned in the result credentials after authentication succeeds.

# Testing steps

Please refer to the relating WCiOS PR to test the integration.