### PR TITLE
[Sign in with site address] - Introduce verify email instructions screen.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.1.0-beta.6'
+  s.version       = '2.1.0-beta.7'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -165,6 +165,8 @@
 		D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
 		EE633D02287560E50002DE03 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE633D01287560E50002DE03 /* UITableView+Helpers.swift */; };
+		EEEAC912289272F20066D419 /* VerifyEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEAC911289272F20066D419 /* VerifyEmailViewController.swift */; };
+		EEEAC9142892731E0066D419 /* VerifyEmail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EEEAC9132892731E0066D419 /* VerifyEmail.storyboard */; };
 		F11448EC258B827B0048203D /* URL+JetpackConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11448EB258B827B0048203D /* URL+JetpackConnect.swift */; };
 		F12F9FB424D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */; };
 		F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */; };
@@ -376,6 +378,8 @@
 		D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterAccount.swift; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
 		EE633D01287560E50002DE03 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
+		EEEAC911289272F20066D419 /* VerifyEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyEmailViewController.swift; sourceTree = "<group>"; };
+		EEEAC9132892731E0066D419 /* VerifyEmail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = VerifyEmail.storyboard; sourceTree = "<group>"; };
 		F11448EB258B827B0048203D /* URL+JetpackConnect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+JetpackConnect.swift"; sourceTree = "<group>"; };
 		F12F9FB324D8A68E00771BCE /* AuthenticatorAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatorAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F12F9FB724D8A7FC00771BCE /* AnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTrackerTests.swift; sourceTree = "<group>"; };
@@ -848,6 +852,7 @@
 		CEC77C6424854EE400FB9050 /* View Related */ = {
 			isa = PBXGroup;
 			children = (
+				EEEAC91028926F7D0066D419 /* VerifyEmail */,
 				98BC47E124F5B959000275AD /* Get Started */,
 				984D508024D4B1FD00251A63 /* Password */,
 				988AD89F24CB820200BD045E /* 2FA */,
@@ -908,6 +913,15 @@
 				D8611A62257622ED00A5DF27 /* NavigateBack.swift */,
 			);
 			path = Navigation;
+			sourceTree = "<group>";
+		};
+		EEEAC91028926F7D0066D419 /* VerifyEmail */ = {
+			isa = PBXGroup;
+			children = (
+				EEEAC911289272F20066D419 /* VerifyEmailViewController.swift */,
+				EEEAC9132892731E0066D419 /* VerifyEmail.storyboard */,
+			);
+			path = VerifyEmail;
 			sourceTree = "<group>";
 		};
 		F12F9FB524D8A7DB00771BCE /* Analytics */ = {
@@ -1057,6 +1071,7 @@
 				984D508424D4B24500251A63 /* Password.storyboard in Resources */,
 				CE811D6924EDC14A00F4CCD6 /* LoginMagicLink.storyboard in Resources */,
 				98ED48392480300500992B2D /* GoogleAuth.storyboard in Resources */,
+				EEEAC9142892731E0066D419 /* VerifyEmail.storyboard in Resources */,
 				CE1BBF8D24D48580001D2E3E /* GravatarEmailTableViewCell.xib in Resources */,
 				B560913F208A563800399AE4 /* Login.storyboard in Resources */,
 				CE6BCD3924A3CB5E001BCDC5 /* TextLinkButtonTableViewCell.xib in Resources */,
@@ -1222,6 +1237,7 @@
 				B5ED7920207E993E00A8FD8C /* WPAuthenticatorLogging.m in Sources */,
 				B5609138208A563800399AE4 /* LoginSiteAddressViewController.swift in Sources */,
 				B560910B208A54F800399AE4 /* LoginFacade.m in Sources */,
+				EEEAC912289272F20066D419 /* VerifyEmailViewController.swift in Sources */,
 				CE30A2AD2257CECC00DF3CDA /* AuthenticatorCredentials.swift in Sources */,
 				B5609145208A563800399AE4 /* LoginViewController.swift in Sources */,
 				B5609139208A563800399AE4 /* LoginEmailViewController.swift in Sources */,

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -242,9 +242,9 @@ public class AuthenticatorAnalyticsTracker {
         ///
         case signInWithSiteCredentials = "sign_in_with_site_credentials"
 
-        /// When the user clicks on “Or type your password” on `VerifyEmailViewController`
+        /// When the user clicks on “Login with account password” on `VerifyEmailViewController`
         ///
-        case orTypeYourPassword = "login_with_password"
+        case loginWithAccountPassword = "login_with_password"
     }
 
     /// Shared Instance.

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -121,6 +121,10 @@ public class AuthenticatorAnalyticsTracker {
 
         /// When we ask user to input the code from the 2 factor authentication
         case twoFactorAuthentication = "2fa"
+
+        /// Triggered when a user enters site credentials and sees the screen with instructions to verify email. (`VerifyEmailViewController`)
+        ///
+        case verifyEmailInstructions = "instructions_to_verify_email"
     }
 
     public enum ClickTarget: String {
@@ -237,6 +241,10 @@ public class AuthenticatorAnalyticsTracker {
         /// When the user taps of "Sign in with site credentials" button in `GetStartedViewController`
         ///
         case signInWithSiteCredentials = "sign_in_with_site_credentials"
+
+        /// When the user clicks on “Or type your password” on `VerifyEmailViewController`
+        ///
+        case orTypeYourPassword = "login_with_password"
     }
 
     /// Shared Instance.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -15,6 +15,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let magicLinkSignupInstructions: String
     public let openMailSignupInstructions: String
     public let openMailLoginInstructions: String
+    public let verifyMailLoginInstructions: String
     public let checkSpamInstructions: String
     public let oopsInstructions: String
     public let googleSignupInstructions: String
@@ -47,6 +48,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let loginTermsOfService: String
     public let signupTermsOfService: String
     public let whatIsWPComLinkTitle: String
+    public let typePasswordButtonTitle: String
 
 	/// Placeholder text for textfields.
 	///
@@ -68,6 +70,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 magicLinkSignupInstructions: String = defaultStrings.magicLinkSignupInstructions,
                 openMailSignupInstructions: String = defaultStrings.openMailSignupInstructions,
                 openMailLoginInstructions: String = defaultStrings.openMailLoginInstructions,
+                verifyMailLoginInstructions: String = defaultStrings.verifyMailLoginInstructions,
                 checkSpamInstructions: String = defaultStrings.checkSpamInstructions,
                 oopsInstructions: String = defaultStrings.oopsInstructions,
                 googleSignupInstructions: String = defaultStrings.googleSignupInstructions,
@@ -81,6 +84,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 enterYourSiteAddressButtonTitle: String = defaultStrings.enterYourSiteAddressButtonTitle,
                 signInWithSiteCredentialsButtonTitle: String = defaultStrings.signInWithSiteCredentialsButtonTitle,
                 findSiteButtonTitle: String = defaultStrings.findSiteButtonTitle,
+                typePasswordButtonTitle: String = defaultStrings.typePasswordButtonTitle,
                 resetPasswordButtonTitle: String = defaultStrings.resetPasswordButtonTitle,
                 getLoginLinkButtonTitle: String = defaultStrings.getLoginLinkButtonTitle,
                 textCodeButtonTitle: String = defaultStrings.textCodeButtonTitle,
@@ -106,6 +110,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.magicLinkSignupInstructions = magicLinkSignupInstructions
         self.openMailSignupInstructions = openMailSignupInstructions
         self.openMailLoginInstructions = openMailLoginInstructions
+        self.verifyMailLoginInstructions = verifyMailLoginInstructions
         self.checkSpamInstructions = checkSpamInstructions
         self.oopsInstructions = oopsInstructions
         self.googleSignupInstructions = googleSignupInstructions
@@ -119,6 +124,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.enterYourSiteAddressButtonTitle = enterYourSiteAddressButtonTitle
         self.signInWithSiteCredentialsButtonTitle = signInWithSiteCredentialsButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
+        self.typePasswordButtonTitle = typePasswordButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
         self.getLoginLinkButtonTitle = getLoginLinkButtonTitle
         self.textCodeButtonTitle = textCodeButtonTitle
@@ -160,6 +166,8 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                           comment: "Instruction text after a signup Magic Link was requested."),
             openMailLoginInstructions: NSLocalizedString("Check your email on this device, and tap the link in the email you receive from WordPress.com.",
                                                          comment: "Instruction text after a login Magic Link was requested."),
+            verifyMailLoginInstructions: NSLocalizedString("Almost there! We just need to verify your Jetpack connected email address",
+                                                         comment: "Instruction text to explain magic link login step."),
             checkSpamInstructions: NSLocalizedString("Not seeing the email? Check your Spam or Junk Mail folder.", comment: "Instructions after a Magic Link was sent, but the email can't be found in their inbox."),
             oopsInstructions: NSLocalizedString("Didn't mean to create a new account? Go back to re-enter your email address.", comment: "Instructions after a Magic Link was sent, but email is incorrect."),
             googleSignupInstructions: NSLocalizedString("We'll use this email address to create your new WordPress.com account.", comment: "Text confirming email address to be used for new account."),
@@ -183,6 +191,8 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                                    comment: "Button title. Takes the user the Enter site credentials screen."),
             findSiteButtonTitle: NSLocalizedString("Find your site address",
                                                    comment: "The hint button's title text to help users find their site address."),
+            typePasswordButtonTitle: NSLocalizedString("Or type your password",
+                                                   comment: "The hint button's title text to help users type their password instead of using magic link login option."),
             resetPasswordButtonTitle: NSLocalizedString("Reset your password",
                                                         comment: "The button title for a secondary call-to-action button. When the user can't remember their password."),
             getLoginLinkButtonTitle: NSLocalizedString("Get a login link by email",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -16,6 +16,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let openMailSignupInstructions: String
     public let openMailLoginInstructions: String
     public let verifyMailLoginInstructions: String
+    public let alternativelyEnterPasswordInstructions: String
     public let checkSpamInstructions: String
     public let oopsInstructions: String
     public let googleSignupInstructions: String
@@ -31,6 +32,8 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let continueWithWPButtonTitle: String
     public let enterYourSiteAddressButtonTitle: String
     public let signInWithSiteCredentialsButtonTitle: String
+    public let sendEmailVerificationLinkButtonTitle: String
+    public let loginWithAccountPasswordButtonTitle: String
 
     /// Large titles displayed in unified auth flows.
     ///
@@ -48,7 +51,6 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let loginTermsOfService: String
     public let signupTermsOfService: String
     public let whatIsWPComLinkTitle: String
-    public let typePasswordButtonTitle: String
 
 	/// Placeholder text for textfields.
 	///
@@ -71,6 +73,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 openMailSignupInstructions: String = defaultStrings.openMailSignupInstructions,
                 openMailLoginInstructions: String = defaultStrings.openMailLoginInstructions,
                 verifyMailLoginInstructions: String = defaultStrings.verifyMailLoginInstructions,
+                alternativelyEnterPasswordInstructions: String = defaultStrings.alternativelyEnterPasswordInstructions,
                 checkSpamInstructions: String = defaultStrings.checkSpamInstructions,
                 oopsInstructions: String = defaultStrings.oopsInstructions,
                 googleSignupInstructions: String = defaultStrings.googleSignupInstructions,
@@ -83,8 +86,9 @@ public struct WordPressAuthenticatorDisplayStrings {
                 continueWithWPButtonTitle: String = defaultStrings.continueWithWPButtonTitle,
                 enterYourSiteAddressButtonTitle: String = defaultStrings.enterYourSiteAddressButtonTitle,
                 signInWithSiteCredentialsButtonTitle: String = defaultStrings.signInWithSiteCredentialsButtonTitle,
+                sendEmailVerificationLinkButtonTitle: String = defaultStrings.sendEmailVerificationLinkButtonTitle,
+                loginWithAccountPasswordButtonTitle: String = defaultStrings.loginWithAccountPasswordButtonTitle,
                 findSiteButtonTitle: String = defaultStrings.findSiteButtonTitle,
-                typePasswordButtonTitle: String = defaultStrings.typePasswordButtonTitle,
                 resetPasswordButtonTitle: String = defaultStrings.resetPasswordButtonTitle,
                 getLoginLinkButtonTitle: String = defaultStrings.getLoginLinkButtonTitle,
                 textCodeButtonTitle: String = defaultStrings.textCodeButtonTitle,
@@ -111,6 +115,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.openMailSignupInstructions = openMailSignupInstructions
         self.openMailLoginInstructions = openMailLoginInstructions
         self.verifyMailLoginInstructions = verifyMailLoginInstructions
+        self.alternativelyEnterPasswordInstructions = alternativelyEnterPasswordInstructions
         self.checkSpamInstructions = checkSpamInstructions
         self.oopsInstructions = oopsInstructions
         self.googleSignupInstructions = googleSignupInstructions
@@ -123,8 +128,9 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.continueWithWPButtonTitle = continueWithWPButtonTitle
         self.enterYourSiteAddressButtonTitle = enterYourSiteAddressButtonTitle
         self.signInWithSiteCredentialsButtonTitle = signInWithSiteCredentialsButtonTitle
+        self.sendEmailVerificationLinkButtonTitle = sendEmailVerificationLinkButtonTitle
+        self.loginWithAccountPasswordButtonTitle = loginWithAccountPasswordButtonTitle
         self.findSiteButtonTitle = findSiteButtonTitle
-        self.typePasswordButtonTitle = typePasswordButtonTitle
         self.resetPasswordButtonTitle = resetPasswordButtonTitle
         self.getLoginLinkButtonTitle = getLoginLinkButtonTitle
         self.textCodeButtonTitle = textCodeButtonTitle
@@ -166,8 +172,10 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                           comment: "Instruction text after a signup Magic Link was requested."),
             openMailLoginInstructions: NSLocalizedString("Check your email on this device, and tap the link in the email you receive from WordPress.com.",
                                                          comment: "Instruction text after a login Magic Link was requested."),
-            verifyMailLoginInstructions: NSLocalizedString("Almost there! We just need to verify your Jetpack connected email address",
+            verifyMailLoginInstructions: NSLocalizedString("A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above.",
                                                          comment: "Instruction text to explain magic link login step."),
+            alternativelyEnterPasswordInstructions: NSLocalizedString("Alternatively, you may enter the password for this account.",
+                                                                      comment: "Instruction text to explain to help users type their password instead of using magic link login option."),
             checkSpamInstructions: NSLocalizedString("Not seeing the email? Check your Spam or Junk Mail folder.", comment: "Instructions after a Magic Link was sent, but the email can't be found in their inbox."),
             oopsInstructions: NSLocalizedString("Didn't mean to create a new account? Go back to re-enter your email address.", comment: "Instructions after a Magic Link was sent, but email is incorrect."),
             googleSignupInstructions: NSLocalizedString("We'll use this email address to create your new WordPress.com account.", comment: "Text confirming email address to be used for new account."),
@@ -189,10 +197,12 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                                comment: "Button title. Takes the user to the login by site address flow."),
             signInWithSiteCredentialsButtonTitle: NSLocalizedString("Sign in with site credentials",
                                                                    comment: "Button title. Takes the user the Enter site credentials screen."),
+            sendEmailVerificationLinkButtonTitle: NSLocalizedString("Send email verification link",
+                                                                   comment: "Button title. Sends a email verification link (Magin link) for signing in."),
+            loginWithAccountPasswordButtonTitle: NSLocalizedString("Login with account password",
+                                                                   comment: "Button title. Takes the user to the Enter account password screen."),
             findSiteButtonTitle: NSLocalizedString("Find your site address",
                                                    comment: "The hint button's title text to help users find their site address."),
-            typePasswordButtonTitle: NSLocalizedString("Or type your password",
-                                                   comment: "The hint button's title text to help users type their password instead of using magic link login option."),
             resetPasswordButtonTitle: NSLocalizedString("Reset your password",
                                                         comment: "The button title for a secondary call-to-action button. When the user can't remember their password."),
             getLoginLinkButtonTitle: NSLocalizedString("Get a login link by email",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -230,6 +230,10 @@ public struct WordPressAuthenticatorUnifiedStyle {
     public let navButtonTextColor: UIColor
     public let navTitleTextColor: UIColor
 
+    /// Style: Text color to be used for email in `GravatarEmailTableViewCell`
+    ///
+    public let gravatarEmailTextColor: UIColor?
+
     /// Designated initializer
     ///
     public init(borderColor: UIColor,
@@ -244,7 +248,8 @@ public struct WordPressAuthenticatorUnifiedStyle {
                 statusBarStyle: UIStatusBarStyle = .default,
                 navBarBackgroundColor: UIColor,
                 navButtonTextColor: UIColor,
-                navTitleTextColor: UIColor) {
+                navTitleTextColor: UIColor,
+                gravatarEmailTextColor: UIColor? = nil) {
         self.borderColor = borderColor
         self.errorColor = errorColor
         self.textColor = textColor
@@ -258,5 +263,6 @@ public struct WordPressAuthenticatorUnifiedStyle {
         self.navBarBackgroundColor = navBarBackgroundColor
         self.navButtonTextColor = navButtonTextColor
         self.navTitleTextColor = navTitleTextColor
+        self.gravatarEmailTextColor = gravatarEmailTextColor
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
@@ -38,6 +38,12 @@ extension WordPressSupportSourceTag {
     public static var loginSiteAddress: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "loginSiteAddress", origin: "origin:login-site-address")
     }
+
+    /// For `VerifyEmailViewController`
+    public static var verifyEmailInstructions: WordPressSupportSourceTag {
+        WordPressSupportSourceTag(name: "verifyEmailInstructions", origin: "origin:login-site-address")
+    }
+
     public static var loginUsernamePassword: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "loginUsernamePassword", origin: "origin:login-username-password")
     }

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -13,6 +13,7 @@ enum Storyboard: String {
     case googleSignupConfirmation = "GoogleSignupConfirmation"
     case twoFA = "TwoFA"
     case password = "Password"
+    case verifyEmail = "VerifyEmail"
 
     var instance: UIStoryboard {
         return UIStoryboard(name: self.rawValue, bundle: WordPressAuthenticator.bundle)

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -20,7 +20,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     ///
     public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil) {
         gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
-        emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
+        emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         emailLabel?.text = email
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -20,8 +20,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     ///
     public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil) {
         gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
-        let emailTextColor = WordPressAuthenticator.shared.unifiedStyle?.gravatarEmailTextColor ?? WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
-        emailLabel?.textColor = emailTextColor
+        emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.gravatarEmailTextColor ?? WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         emailLabel?.text = email
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -20,7 +20,8 @@ class GravatarEmailTableViewCell: UITableViewCell {
     ///
     public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil) {
         gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
-        emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        let emailTextColor = WordPressAuthenticator.shared.unifiedStyle?.gravatarEmailTextColor ?? WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
+        emailLabel?.textColor = emailTextColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         emailLabel?.text = email
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,7 +18,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPressAuthenticator">
-                        <rect key="frame" x="11" y="11" width="48" height="48"/>
+                        <rect key="frame" x="16" y="11" width="48" height="48"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="48" id="RU3-mW-PAl"/>
                             <constraint firstAttribute="width" secondItem="odI-Gb-fXa" secondAttribute="height" multiplier="1:1" id="TSH-sA-5Pw"/>
@@ -26,7 +26,7 @@
                         </constraints>
                     </imageView>
                     <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
-                        <rect key="frame" x="70" y="13" width="239" height="44"/>
+                        <rect key="frame" x="75" y="13" width="229" height="44"/>
                         <accessibility key="accessibilityConfiguration">
                             <accessibilityTraits key="traits" staticText="YES"/>
                         </accessibility>
@@ -42,11 +42,11 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="3kD-7a-MeN" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="11" id="M5P-4D-Dig"/>
-                    <constraint firstAttribute="trailing" secondItem="3kD-7a-MeN" secondAttribute="trailing" constant="11" id="Uu4-bo-sjK"/>
+                    <constraint firstAttribute="trailing" secondItem="3kD-7a-MeN" secondAttribute="trailing" constant="16" id="Uu4-bo-sjK"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" constant="-2" id="YZD-yX-ic3"/>
                     <constraint firstItem="3kD-7a-MeN" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="guc-Ls-SYV"/>
                     <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="hPB-Uy-lLS"/>
-                    <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="11" id="kVa-7e-I73"/>
+                    <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="kVa-7e-I73"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -52,6 +52,12 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.placeholder = placeholder
         textField.text = text
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        textField.rightView = nil
+    }
 }
 
 // MARK: - Private methods

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
@@ -25,16 +25,11 @@ public final class TextLabelTableViewCell: UITableViewCell {
         }
     }
 
-    public func configureLabel(attributedText: NSAttributedString) {
-        label.attributedText = attributedText
-    }
-
     /// Override methods
     ///
     public override func prepareForReuse() {
         super.prepareForReuse()
         label.text = nil
-        label.attributedText = nil
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLabelTableViewCell.swift
@@ -25,10 +25,16 @@ public final class TextLabelTableViewCell: UITableViewCell {
         }
     }
 
+    public func configureLabel(attributedText: NSAttributedString) {
+        label.attributedText = attributedText
+    }
+
     /// Override methods
     ///
     public override func prepareForReuse() {
+        super.prepareForReuse()
         label.text = nil
+        label.attributedText = nil
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -360,7 +360,7 @@ private extension SiteCredentialsViewController {
     /// - Parameters:
     ///   - loginFields: `LoginFields` instance created using `makeLoginFieldsUsing` helper method
     ///
-    func presentVerifyEmailPage(loginFields: LoginFields) {
+    func presentVerifyEmail(loginFields: LoginFields) {
         guard let vc = VerifyEmailViewController.instantiate(from: .verifyEmail) else {
             DDLogError("Failed to navigate from SiteCredentialsViewController to VerifyEmailViewController")
             return
@@ -483,7 +483,7 @@ extension SiteCredentialsViewController {
 
         // Present verify email instructions screen. Passing loginFields will prefill the jetpack email in `VerifyEmailViewController`
         //
-        presentVerifyEmailPage(loginFields: loginFields)
+        presentVerifyEmail(loginFields: loginFields)
     }
 
     override func displayRemoteError(_ error: Error) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -355,16 +355,17 @@ private extension SiteCredentialsViewController {
         }
     }
 
-    /// Presents unified password screen
+    /// Presents verify email instructions screen
     ///
     /// - Parameters:
     ///   - loginFields: `LoginFields` instance created using `makeLoginFieldsUsing` helper method
     ///
-    func presentUnifiedPassword(loginFields: LoginFields) {
-        guard let vc = PasswordViewController.instantiate(from: .password) else {
-            DDLogError("Failed to navigate from SiteCredentialsViewController to PasswordViewController")
+    func presentVerifyEmailPage(loginFields: LoginFields) {
+        guard let vc = VerifyEmailViewController.instantiate(from: .verifyEmail) else {
+            DDLogError("Failed to navigate from SiteCredentialsViewController to VerifyEmailViewController")
             return
         }
+
         vc.loginFields = loginFields
         navigationController?.pushViewController(vc, animated: true)
     }
@@ -480,9 +481,9 @@ extension SiteCredentialsViewController {
             return
         }
 
-        // Present unified password screen. Passing loginFields will prefill the jetpack email in `PasswordViewController`
+        // Present verify email instructions screen. Passing loginFields will prefill the jetpack email in `VerifyEmailViewController`
         //
-        presentUnifiedPassword(loginFields: loginFields)
+        presentVerifyEmailPage(loginFields: loginFields)
     }
 
     override func displayRemoteError(_ error: Error) {

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmail.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmail.storyboard
@@ -21,47 +21,47 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pfu-Jh-ubT">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="742"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="768"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="Kyc-Xo-vx1" id="wYG-7B-H0U"/>
                                             <outlet property="delegate" destination="Kyc-Xo-vx1" id="fsd-qV-Pgj"/>
                                         </connections>
                                     </tableView>
-                                    <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="acY-8s-fU4" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="742" width="414" height="76"/>
+                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I1o-Lz-r19">
+                                        <rect key="frame" x="0.0" y="768" width="414" height="50"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8aU-U3-ges" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="382" height="44"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="oOi-bU-Xng">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
+                                                <subviews>
+                                                    <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LCc-0X-Ybb" userLabel="Button Container View">
+                                                        <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
+                                                        <connections>
+                                                            <segue destination="0f2-Vg-sfb" kind="embed" id="Ruh-yZ-gdI"/>
+                                                        </connections>
+                                                    </containerView>
+                                                </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="44" id="brU-Sp-bqC"/>
+                                                    <constraint firstAttribute="height" priority="250" constant="50" id="vZx-Lm-PLF"/>
                                                 </constraints>
-                                                <state key="normal" title="Button"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="handleSendLinkButtonTapped:" destination="Kyc-Xo-vx1" eventType="touchUpInside" id="p1D-H8-IjT"/>
-                                                </connections>
-                                            </button>
+                                            </stackView>
                                         </subviews>
-                                        <viewLayoutGuide key="safeArea" id="fke-hl-RqK"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="bottomMargin" secondItem="8aU-U3-ges" secondAttribute="bottom" constant="8" id="cFF-F8-XeD"/>
-                                            <constraint firstItem="8aU-U3-ges" firstAttribute="top" secondItem="acY-8s-fU4" secondAttribute="topMargin" constant="8" id="iAf-MX-VqG"/>
+                                            <constraint firstItem="oOi-bU-Xng" firstAttribute="height" secondItem="I1o-Lz-r19" secondAttribute="height" id="7El-NG-9aZ"/>
+                                            <constraint firstAttribute="bottom" secondItem="oOi-bU-Xng" secondAttribute="bottom" id="PbI-vK-NBT"/>
+                                            <constraint firstItem="oOi-bU-Xng" firstAttribute="top" secondItem="I1o-Lz-r19" secondAttribute="top" id="TA1-Pn-Wfn"/>
+                                            <constraint firstItem="oOi-bU-Xng" firstAttribute="width" secondItem="I1o-Lz-r19" secondAttribute="width" id="TIr-LJ-kq2"/>
+                                            <constraint firstAttribute="trailing" secondItem="oOi-bU-Xng" secondAttribute="trailing" id="dAw-Cz-gXs"/>
+                                            <constraint firstItem="oOi-bU-Xng" firstAttribute="leading" secondItem="I1o-Lz-r19" secondAttribute="leading" id="yuh-jz-Tun"/>
                                         </constraints>
-                                    </view>
+                                    </scrollView>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="acY-8s-fU4" firstAttribute="top" secondItem="pfu-Jh-ubT" secondAttribute="bottom" id="8ip-ju-lmM"/>
-                                    <constraint firstItem="acY-8s-fU4" firstAttribute="bottom" secondItem="E8K-Dx-YzL" secondAttribute="bottomMargin" constant="8" id="BDz-Tw-lI7"/>
-                                    <constraint firstItem="acY-8s-fU4" firstAttribute="trailing" secondItem="E8K-Dx-YzL" secondAttribute="trailing" id="NbW-zb-dB4"/>
-                                    <constraint firstItem="acY-8s-fU4" firstAttribute="leading" secondItem="E8K-Dx-YzL" secondAttribute="leading" id="Qd7-mb-zk6"/>
-                                    <constraint firstItem="pfu-Jh-ubT" firstAttribute="trailing" secondItem="8aU-U3-ges" secondAttribute="trailing" constant="16" id="rxl-c5-gog"/>
-                                    <constraint firstItem="8aU-U3-ges" firstAttribute="leading" secondItem="pfu-Jh-ubT" secondAttribute="leading" constant="16" id="wPq-gH-3RV"/>
+                                    <constraint firstItem="I1o-Lz-r19" firstAttribute="leading" secondItem="E8K-Dx-YzL" secondAttribute="leading" id="GiQ-Qs-gaK"/>
+                                    <constraint firstAttribute="trailing" secondItem="I1o-Lz-r19" secondAttribute="trailing" id="ejg-M4-Hcj"/>
+                                    <constraint firstAttribute="bottom" secondItem="I1o-Lz-r19" secondAttribute="bottom" id="fpd-Gc-kpQ"/>
+                                    <constraint firstItem="I1o-Lz-r19" firstAttribute="top" secondItem="pfu-Jh-ubT" secondAttribute="bottom" id="yGl-Zk-cTV"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -79,7 +79,6 @@
                     </view>
                     <navigationItem key="navigationItem" id="RXK-oM-uW0"/>
                     <connections>
-                        <outlet property="submitButton" destination="8aU-U3-ges" id="1ov-f4-aKA"/>
                         <outlet property="tableView" destination="pfu-Jh-ubT" id="iMn-f4-DOH"/>
                         <outlet property="tableViewLeadingConstraint" destination="H0g-kw-Qqv" id="lcz-Ci-CnX"/>
                         <outlet property="tableViewTrailingConstraint" destination="maJ-SL-tfy" id="Ytd-1o-EIc"/>
@@ -88,6 +87,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6j3-BE-46b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1702" y="-34"/>
+        </scene>
+        <!--ButtonView-->
+        <scene sceneID="fWW-cl-abG">
+            <objects>
+                <viewControllerPlaceholder storyboardName="NUXButtonView" referencedIdentifier="ButtonView" id="0f2-Vg-sfb" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="xKC-U7-C7l"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="58W-Tn-hrf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1701" y="390"/>
         </scene>
     </scenes>
     <resources>

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmail.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmail.storyboard
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Verify Email View Controller-->
+        <scene sceneID="Ord-z3-YaY">
+            <objects>
+                <viewController storyboardIdentifier="VerifyEmailViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Kyc-Xo-vx1" customClass="VerifyEmailViewController" customModule="WordPressAuthenticator" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="UpM-oD-mVG">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8K-Dx-YzL" userLabel="Containing View">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pfu-Jh-ubT">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="742"/>
+                                        <sections/>
+                                        <connections>
+                                            <outlet property="dataSource" destination="Kyc-Xo-vx1" id="wYG-7B-H0U"/>
+                                            <outlet property="delegate" destination="Kyc-Xo-vx1" id="fsd-qV-Pgj"/>
+                                        </connections>
+                                    </tableView>
+                                    <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="acY-8s-fU4" userLabel="Button background view">
+                                        <rect key="frame" x="0.0" y="742" width="414" height="76"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8aU-U3-ges" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticator" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="16" width="382" height="44"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="brU-Sp-bqC"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleSendLinkButtonTapped:" destination="Kyc-Xo-vx1" eventType="touchUpInside" id="p1D-H8-IjT"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <viewLayoutGuide key="safeArea" id="fke-hl-RqK"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottomMargin" secondItem="8aU-U3-ges" secondAttribute="bottom" constant="8" id="cFF-F8-XeD"/>
+                                            <constraint firstItem="8aU-U3-ges" firstAttribute="top" secondItem="acY-8s-fU4" secondAttribute="topMargin" constant="8" id="iAf-MX-VqG"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="acY-8s-fU4" firstAttribute="top" secondItem="pfu-Jh-ubT" secondAttribute="bottom" id="8ip-ju-lmM"/>
+                                    <constraint firstItem="acY-8s-fU4" firstAttribute="bottom" secondItem="E8K-Dx-YzL" secondAttribute="bottomMargin" constant="8" id="BDz-Tw-lI7"/>
+                                    <constraint firstItem="acY-8s-fU4" firstAttribute="trailing" secondItem="E8K-Dx-YzL" secondAttribute="trailing" id="NbW-zb-dB4"/>
+                                    <constraint firstItem="acY-8s-fU4" firstAttribute="leading" secondItem="E8K-Dx-YzL" secondAttribute="leading" id="Qd7-mb-zk6"/>
+                                    <constraint firstItem="pfu-Jh-ubT" firstAttribute="trailing" secondItem="8aU-U3-ges" secondAttribute="trailing" constant="16" id="rxl-c5-gog"/>
+                                    <constraint firstItem="8aU-U3-ges" firstAttribute="leading" secondItem="pfu-Jh-ubT" secondAttribute="leading" constant="16" id="wPq-gH-3RV"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Kul-tD-MQb"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="E8K-Dx-YzL" firstAttribute="top" secondItem="Kul-tD-MQb" secondAttribute="top" id="4Xl-Dg-iRo"/>
+                            <constraint firstItem="E8K-Dx-YzL" firstAttribute="leading" secondItem="UpM-oD-mVG" secondAttribute="leading" id="7rt-E0-Pss"/>
+                            <constraint firstItem="pfu-Jh-ubT" firstAttribute="leading" secondItem="Kul-tD-MQb" secondAttribute="leading" id="H0g-kw-Qqv"/>
+                            <constraint firstItem="E8K-Dx-YzL" firstAttribute="trailing" secondItem="UpM-oD-mVG" secondAttribute="trailing" id="XdS-2Z-lXC"/>
+                            <constraint firstItem="pfu-Jh-ubT" firstAttribute="top" secondItem="Kul-tD-MQb" secondAttribute="top" id="fwj-CH-HUR"/>
+                            <constraint firstItem="Kul-tD-MQb" firstAttribute="trailing" secondItem="pfu-Jh-ubT" secondAttribute="trailing" id="maJ-SL-tfy"/>
+                            <constraint firstItem="Kul-tD-MQb" firstAttribute="bottom" secondItem="E8K-Dx-YzL" secondAttribute="bottom" id="vVf-D6-spN"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="RXK-oM-uW0"/>
+                    <connections>
+                        <outlet property="submitButton" destination="8aU-U3-ges" id="1ov-f4-aKA"/>
+                        <outlet property="tableView" destination="pfu-Jh-ubT" id="iMn-f4-DOH"/>
+                        <outlet property="tableViewLeadingConstraint" destination="H0g-kw-Qqv" id="lcz-Ci-CnX"/>
+                        <outlet property="tableViewTrailingConstraint" destination="maJ-SL-tfy" id="Ytd-1o-EIc"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6j3-BE-46b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1702" y="-34"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -108,8 +108,29 @@ private extension VerifyEmailViewController {
     /// Configure cells.
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
-
+        switch cell {
+        case let cell as GravatarEmailTableViewCell where row == .persona:
+            configureGravatarEmail(cell)
+        case let cell as TextLabelTableViewCell where row == .instructions:
+            configureInstructionLabel(cell)
+        case let cell as TextLinkButtonTableViewCell where row == .typePassword:
+            configureTypePasswordButton(cell)
+        default:
+            DDLogError("Error: Unidentified tableViewCell type found.")
+        }
     }
+
+    /// Configure the gravatar + email cell.
+    ///
+    func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {}
+
+    /// Configure the instructions cell.
+    ///
+    func configureInstructionLabel(_ cell: TextLabelTableViewCell) {}
+
+    /// Configure the "Or type your password" cell.
+    ///
+    func configureTypePasswordButton(_ cell: TextLinkButtonTableViewCell) {}
 
     /// Makes the call to request a magic authentication link be emailed to the user.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -128,7 +128,16 @@ private extension VerifyEmailViewController {
 
     /// Configure the instructions cell.
     ///
-    func configureInstructionLabel(_ cell: TextLabelTableViewCell) {}
+    func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
+        let instructionColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
+        let emailColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
+        let font = WPStyleGuide.mediumWeightFont(forStyle: .body)
+
+        let instructions = NSMutableAttributedString(string: WordPressAuthenticator.shared.displayStrings.verifyMailLoginInstructions, attributes: [.foregroundColor: instructionColor, .font: font])
+        let email = NSAttributedString(string: " " + loginFields.username, attributes: [.font: font, .foregroundColor: emailColor])
+        instructions.append(email)
+        cell.configureLabel(attributedText: instructions)
+    }
 
     /// Configure the "Or type your password" cell.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 final class VerifyEmailViewController: LoginViewController {
 
-    // MARK: Properties
+    // MARK: - Properties
 
     @IBOutlet private weak var tableView: UITableView!
     private let rows = Row.allCases

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -141,7 +141,9 @@ private extension VerifyEmailViewController {
 
     /// Configure the "Or type your password" cell.
     ///
-    func configureTypePasswordButton(_ cell: TextLinkButtonTableViewCell) {}
+    func configureTypePasswordButton(_ cell: TextLinkButtonTableViewCell) {
+        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.typePasswordButtonTitle)
+    }
 
     /// Makes the call to request a magic authentication link be emailed to the user.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -122,7 +122,9 @@ private extension VerifyEmailViewController {
 
     /// Configure the gravatar + email cell.
     ///
-    func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {}
+    func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
+        cell.configure(withEmail: loginFields.username)
+    }
 
     /// Configure the instructions cell.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -7,10 +7,6 @@ final class VerifyEmailViewController: LoginViewController {
     @IBOutlet private weak var tableView: UITableView!
     private let rows = Row.allCases
 
-    override var sourceTag: WordPressSupportSourceTag {
-        .verifyEmailInstructions
-    }
-
     // MARK: - Actions
     @IBAction private func handleSendLinkButtonTapped(_ sender: NUXButton) {
         configureViewLoading(false)
@@ -44,6 +40,10 @@ final class VerifyEmailViewController: LoginViewController {
     }
 
     // MARK: - Overrides
+
+    override var sourceTag: WordPressSupportSourceTag {
+        .verifyEmailInstructions
+    }
 
     /// Style individual ViewController backgrounds, for now.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -6,4 +6,109 @@ final class VerifyEmailViewController: LoginViewController {
 
     @IBOutlet private weak var tableView: UITableView!
 
+    private let rows = Row.allCases
+
+    // MARK: - View lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
+        styleNavigationBar(forUnified: true)
+
+        // Store default margin, and size table for the view.
+        defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
+        setTableViewMargins(forWidth: view.frame.width)
+
+        localizePrimaryButton()
+        registerTableViewCells()
+    }
+
+    // MARK: - Overrides
+
+    /// Style individual ViewController backgrounds, for now.
+    ///
+    override func styleBackground() {
+        guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
+            super.styleBackground()
+            return
+        }
+
+        view.backgroundColor = unifiedBackgroundColor
+    }
+
+    /// Style individual ViewController status bars.
+    ///
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
+    }
+
+    /// Override the title on 'Send link by Email' button
+    ///
+    override func localizePrimaryButton() {
+        submitButton?.setTitle(WordPressAuthenticator.shared.displayStrings.magicLinkButtonTitle, for: .normal)
+        submitButton?.accessibilityIdentifier = "Send Link by Email Button"
+    }
+}
+
+// MARK: - UITableViewDataSource
+extension VerifyEmailViewController: UITableViewDataSource {
+    /// Returns the number of rows in a section.
+    ///
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        rows.count
+    }
+
+    /// Configure cells delegate method.
+    ///
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - Private Methods
+private extension VerifyEmailViewController {
+    /// Registers all of the available TableViewCells.
+    ///
+    func registerTableViewCells() {
+        let cells = [
+            GravatarEmailTableViewCell.reuseIdentifier: GravatarEmailTableViewCell.loadNib(),
+            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
+            TextLinkButtonTableViewCell.reuseIdentifier: TextLinkButtonTableViewCell.loadNib()
+        ]
+
+        for (reuseIdentifier, nib) in cells {
+            tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
+        }
+    }
+
+    /// Configure cells.
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+
+    }
+
+    // MARK: - Private Constants
+
+    /// Rows listed in the order they were created.
+    ///
+    enum Row: CaseIterable {
+        case persona
+        case instructions
+        case typePassword
+
+        var reuseIdentifier: String {
+            switch self {
+            case .persona:
+                return GravatarEmailTableViewCell.reuseIdentifier
+            case .instructions:
+                return TextLabelTableViewCell.reuseIdentifier
+            case .typePassword:
+                return TextLinkButtonTableViewCell.reuseIdentifier
+            }
+        }
+    }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -143,6 +143,12 @@ private extension VerifyEmailViewController {
     ///
     func configureTypePasswordButton(_ cell: TextLinkButtonTableViewCell) {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.typePasswordButtonTitle)
+
+        cell.actionHandler = { [weak self] in
+            guard let self = self else { return }
+
+            self.presentUnifiedPassword()
+        }
     }
 
     /// Makes the call to request a magic authentication link be emailed to the user.

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -181,6 +181,17 @@ private extension VerifyEmailViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
 
+    /// Presents unified password screen
+    ///
+    func presentUnifiedPassword() {
+        guard let vc = PasswordViewController.instantiate(from: .password) else {
+            DDLogError("Failed to navigate to PasswordViewController from VerifyEmailViewController")
+            return
+        }
+        vc.loginFields = loginFields
+        navigationController?.pushViewController(vc, animated: true)
+    }
+
     // MARK: - Private Constants
 
     /// Rows listed in the order they were created.

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -49,8 +49,7 @@ final class VerifyEmailViewController: LoginViewController {
     ///
     override func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
-            super.styleBackground()
-            return
+            return super.styleBackground()
         }
 
         view.backgroundColor = unifiedBackgroundColor

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -121,8 +121,7 @@ private extension VerifyEmailViewController {
     func registerTableViewCells() {
         let cells = [
             GravatarEmailTableViewCell.reuseIdentifier: GravatarEmailTableViewCell.loadNib(),
-            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib(),
-            TextLinkButtonTableViewCell.reuseIdentifier: TextLinkButtonTableViewCell.loadNib()
+            TextLabelTableViewCell.reuseIdentifier: TextLabelTableViewCell.loadNib()
         ]
 
         for (reuseIdentifier, nib) in cells {
@@ -138,7 +137,7 @@ private extension VerifyEmailViewController {
             configureGravatarEmail(cell)
         case let cell as TextLabelTableViewCell where row == .instructions:
             configureInstructionLabel(cell)
-        case let cell as TextLinkButtonTableViewCell where row == .typePassword:
+        case let cell as TextLabelTableViewCell where row == .typePassword:
             configureTypePasswordButton(cell)
         default:
             DDLogError("Error: Unidentified tableViewCell type found.")
@@ -154,27 +153,15 @@ private extension VerifyEmailViewController {
     /// Configure the instructions cell.
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
-        let instructionColor = WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
-        let emailColor = WordPressAuthenticator.shared.unifiedStyle?.textColor ?? WordPressAuthenticator.shared.style.instructionColor
-        let font = WPStyleGuide.mediumWeightFont(forStyle: .body)
-
-        let instructions = NSMutableAttributedString(string: WordPressAuthenticator.shared.displayStrings.verifyMailLoginInstructions, attributes: [.foregroundColor: instructionColor, .font: font])
-        let email = NSAttributedString(string: " " + loginFields.username, attributes: [.font: font, .foregroundColor: emailColor])
-        instructions.append(email)
-        cell.configureLabel(attributedText: instructions)
+        cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.verifyMailLoginInstructions,
+                            style: .body)
     }
 
-    /// Configure the "Or type your password" cell.
+    /// Configure the enter password instructions cell.
     ///
-    func configureTypePasswordButton(_ cell: TextLinkButtonTableViewCell) {
-        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.typePasswordButtonTitle)
-
-        cell.actionHandler = { [weak self] in
-            guard let self = self else { return }
-
-            self.tracker.track(click: .orTypeYourPassword)
-            self.presentUnifiedPassword()
-        }
+    func configureTypePasswordButton(_ cell: TextLabelTableViewCell) {
+        cell.configureLabel(text: WordPressAuthenticator.shared.displayStrings.alternativelyEnterPasswordInstructions,
+                            style: .body)
     }
 
     /// Makes the call to request a magic authentication link be emailed to the user.
@@ -239,10 +226,8 @@ private extension VerifyEmailViewController {
             switch self {
             case .persona:
                 return GravatarEmailTableViewCell.reuseIdentifier
-            case .instructions:
+            case .instructions, .typePassword:
                 return TextLabelTableViewCell.reuseIdentifier
-            case .typePassword:
-                return TextLinkButtonTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -8,6 +8,10 @@ final class VerifyEmailViewController: LoginViewController {
 
     private let rows = Row.allCases
 
+    override var sourceTag: WordPressSupportSourceTag {
+        .verifyEmailInstructions
+    }
+
     // MARK: - View lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -5,7 +5,6 @@ final class VerifyEmailViewController: LoginViewController {
     // MARK: Properties
 
     @IBOutlet private weak var tableView: UITableView!
-
     private let rows = Row.allCases
 
     override var sourceTag: WordPressSupportSourceTag {
@@ -32,6 +31,16 @@ final class VerifyEmailViewController: LoginViewController {
 
         localizePrimaryButton()
         registerTableViewCells()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if isBeingPresentedInAnyWay {
+            tracker.track(step: .verifyEmailInstructions)
+        } else {
+            tracker.set(step: .verifyEmailInstructions)
+        }
     }
 
     // MARK: - Overrides

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -62,6 +62,16 @@ final class VerifyEmailViewController: LoginViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle {
         WordPressAuthenticator.shared.unifiedStyle?.statusBarStyle ?? WordPressAuthenticator.shared.style.statusBarStyle
     }
+
+    /// Customise loading state of view.
+    ///
+    override func configureViewLoading(_ loading: Bool) {
+        buttonViewController?.setTopButtonState(isLoading: loading,
+                                                isEnabled: !loading)
+        buttonViewController?.setBottomButtonState(isLoading: false,
+                                                   isEnabled: !loading)
+        navigationItem.hidesBackButton = loading
+    }
 }
 
 // MARK: - UITableViewDataSource

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -147,6 +147,7 @@ private extension VerifyEmailViewController {
         cell.actionHandler = { [weak self] in
             guard let self = self else { return }
 
+            self.tracker.track(click: .orTypeYourPassword)
             self.presentUnifiedPassword()
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+final class VerifyEmailViewController: LoginViewController {
+
+    // MARK: Properties
+
+    @IBOutlet private weak var tableView: UITableView!
+
+}

--- a/WordPressAuthenticatorTests/Authenticator/WordPressSourceTagTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressSourceTagTests.swift
@@ -52,6 +52,13 @@ class WordPressSourceTagTests: XCTestCase {
         XCTAssertEqual(tag.origin, "origin:login-site-address")
     }
 
+    func testVerifyEmailInstructionsSourceTag() {
+        let tag = WordPressSupportSourceTag.verifyEmailInstructions
+
+        XCTAssertEqual(tag.name, "verifyEmailInstructions")
+        XCTAssertEqual(tag.origin, "origin:login-site-address")
+    }
+
     func testLoginUsernameSourceTag() {
         let tag = WordPressSupportSourceTag.loginUsernamePassword
 


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/pull/7424

# Description

On WCiOS we want to add a screen with instructions to verify the Jetpack email. This screen is already present in Android and we have decided to introduce the same in iOS.

Internal ref - pe5sF9-is-p2#iteration-3

This PR introduces `VerifyEmailViewController` and shows that screen after validating .org site credentials.

# Testing steps

Please refer to the relating WCiOS PR to test the integration.