### PR TITLE
Pass a custom error for invalid WP.com password errors

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.1.0-beta.5'
+  s.version       = '2.1.0-beta.6'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -13,6 +13,7 @@ public enum SignInSource {
 /// The error during the sign in flow.
 public enum SignInError: Error {
     case invalidWPComEmail(source: SignInSource)
+    case invalidWPComPassword(source: SignInSource)
 
     init?(error: Error, source: SignInSource?) {
         let error = error as NSError
@@ -520,6 +521,7 @@ private extension GetStartedViewController {
             return
         }
 
+        vc.source = source
         vc.loginFields = loginFields
         vc.trackAsPasswordChallenge = false
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -21,6 +21,8 @@ class PasswordViewController: LoginViewController {
     ///
     var trackAsPasswordChallenge = true
 
+    var source: SignInSource?
+
     override var loginFields: LoginFields {
         didSet {
             loginFields.password = ""
@@ -120,6 +122,15 @@ class PasswordViewController: LoginViewController {
         let nsError = error as NSError
         let errorCode = nsError.code
         let errorDomain = nsError.domain
+
+        if let source = source, loginFields.meta.userIsDotCom {
+            let passwordError = SignInError.invalidWPComPassword(source: source)
+            if authenticationDelegate.shouldHandleError(passwordError) {
+                authenticationDelegate.handleError(passwordError) { [weak self] _ in
+                    // No custom navigation is expected in this case.
+                }
+            }
+        }
 
         if errorDomain == WordPressComOAuthClient.WordPressComOAuthErrorDomain,
             errorCode == WordPressComOAuthError.invalidRequest.rawValue {

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -126,7 +126,7 @@ class PasswordViewController: LoginViewController {
         if let source = source, loginFields.meta.userIsDotCom {
             let passwordError = SignInError.invalidWPComPassword(source: source)
             if authenticationDelegate.shouldHandleError(passwordError) {
-                authenticationDelegate.handleError(passwordError) { [weak self] _ in
+                authenticationDelegate.handleError(passwordError) { _ in
                     // No custom navigation is expected in this case.
                 }
             }


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/issues/7318

## Description

In order to handle the invalid WP.com password errors for WCiOS local notifications experiment Iteration 3, a `source: SignInSource` is added to `PasswordViewController` and the remote error is passed to the delegate. No external navigation is expected at this point, so the completion block `authenticationDelegate.handleError` is a no-op now.

### Impact to WPiOS

WPiOS [does not handle errors in a custom way](https://github.com/wordpress-mobile/WordPress-iOS/blob/d6b813b903c34d4d66ac07c5e452b378fd952e63/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift#L487-L490) like WCiOS.

## Testing steps

Please refer to the WCiOS draft PR to test the integration: https://github.com/woocommerce/woocommerce-ios/pull/7422