### PR TITLE
Remove unnecessary `NSLocalizedString` call(the text is already localized)

### DIFF
--- a/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -153,8 +153,7 @@ extension WPStyleGuide {
     /// - Returns: A properly styled NSAttributedString to be displayed on a NUXButton.
     ///
     class func formattedSignInWithSiteCredentialsString() -> NSAttributedString {
-        let title = NSLocalizedString(WordPressAuthenticator.shared.displayStrings.signInWithSiteCredentialsButtonTitle,
-                                      comment: "Button title. Tapping opens the site credentials screen.")
+        let title = WordPressAuthenticator.shared.displayStrings.signInWithSiteCredentialsButtonTitle
         let globe = UIImage.gridicon(.globe)
         let image = globe.imageWithTintColor(WordPressAuthenticator.shared.style.placeholderColor) ?? globe
         return attributedStringwithLogo(image,


### PR DESCRIPTION
The removed line caused a failure on `genstrings`: "Argument is not a literal string." Also, the argument `signInWithSiteCredentialsButtonTitle` is [already localized](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/8036b3b199ed40d1d97846e179148a09083de677/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift#L182).

I'm not sure what's the proper way to make this patch on top of 2.1.0 release. This PR goes to the trunk branch, which is same as "2.1.0" tag at the moment. If this PR is merged before any other PRs, then this will be the only change added on top of 2.1.0. I guess we could create a dedicate 2.1.1 branch just to be safe?

cc @oguzkocer 