### PR TITLE
[Tooling/CI] Fix Publish step

### DIFF
--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -6,7 +6,7 @@ SLACK_WEBHOOK=$PODS_SLACK_WEBHOOK
 
 echo "--- :rubygems: Setting up Gems"
 # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-gem install bundler:2.3.4
+gem install bundler
 
 install_gems
 


### PR DESCRIPTION
With the newer Xcode CI image introduced in #654, we need to install an even newer version of bundler to work around https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16.

This was fixed by @mokagio in various places in the `pipeline.yml` back when he worked on #654, but the `publish-pod.sh` file was missed in this update of the workaround, so we're patching this here
