### PR TITLE
Bump pod spec version from '2.2.0-beta.1' to '2.2.0-beta.2'

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.0-beta.1'
+  s.version       = '2.2.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
Bumping pod version to create a new release after merging https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/660 CI fix.