### PR TITLE
[Sign in with site credentials] - Don't clear username and password after an invalid login attempt.

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.1-beta.1'
+  s.version       = '2.2.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.0-beta.2'
+  s.version       = '2.2.0-beta.3'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.0-beta.2'
+  s.version       = '2.2.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -56,7 +56,13 @@ final class TextFieldTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
 
+        textField.keyboardType = .default
+        textField.returnKeyType = .default
+        setSecureTextEntry(false)
+        showSecureTextEntryToggle = false
         textField.rightView = nil
+        textField.accessibilityLabel = nil
+        textField.accessibilityIdentifier = nil
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -280,7 +280,8 @@ private extension SiteCredentialsViewController {
     ///
     func configureUsernameTextField(_ cell: TextFieldTableViewCell) {
         cell.configure(withStyle: .username,
-                       placeholder: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder)
+                       placeholder: WordPressAuthenticator.shared.displayStrings.usernamePlaceholder,
+                       text: loginFields.username)
 
         // Save a reference to the textField so it can becomeFirstResponder.
         usernameField = cell.textField

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -303,7 +303,8 @@ private extension SiteCredentialsViewController {
     ///
     func configurePasswordTextField(_ cell: TextFieldTableViewCell) {
         cell.configure(withStyle: .password,
-                       placeholder: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder)
+                       placeholder: WordPressAuthenticator.shared.displayStrings.passwordPlaceholder,
+                       text: loginFields.password)
         passwordField = cell.textField
         cell.textField.delegate = self
         cell.onChangeSelectionHandler = { [weak self] textfield in


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/pull/7444

# Description

In the sign-in with site credentials flow, in the Site credentials screen, if I enter an incorrect password, the username and password fields are emptied/cleared. This doesn't leave a chance for the user to edit and fix types.

This PR attempts to stop clearing the username and password when an error occurs. 

- The username/password is cleared when the tableView is reloaded after a failed signin attempt. We can configure the cells with the current username/password from `loginFields` property to fix this.
- We have also updated the `prepareForReuse` method to properly reset all the properties that are customised [here](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/440fc376cc6895deb5a10358bb3799573e0a1827/WordPressAuthenticator/Unified%20Auth/View%20Related/Reusable%20Views/TextFieldTableViewCell.swift#L90). Not preparing the cell for reusue properly has introduced issues like https://github.com/woocommerce/woocommerce-ios/issues/7403 in the past.

# Testing steps

Please refer to the relating WCiOS PR to test the integration.