### PR TITLE
Show magic link login option as a secondary CTA instead of a table view row under a configuration

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.0'
+  s.version       = '2.2.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		020BE74A23B0BD2E007FE54C /* WordPressAuthenticatorDisplayImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE74923B0BD2E007FE54C /* WordPressAuthenticatorDisplayImages.swift */; };
+		020DEF6428AA091100C85D51 /* MagicLinkRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DEF6328AA091100C85D51 /* MagicLinkRequester.swift */; };
 		02A526CA28A3499C00FD1812 /* MagicLinkRequestedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A526C828A3499C00FD1812 /* MagicLinkRequestedViewController.swift */; };
 		02A526CB28A3499C00FD1812 /* MagicLinkRequestedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02A526C928A3499C00FD1812 /* MagicLinkRequestedViewController.xib */; };
 		02A526CD28A3A23900FD1812 /* UIButton+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A526CC28A3A23900FD1812 /* UIButton+Styles.swift */; };
@@ -213,6 +214,7 @@
 
 /* Begin PBXFileReference section */
 		020BE74923B0BD2E007FE54C /* WordPressAuthenticatorDisplayImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDisplayImages.swift; sourceTree = "<group>"; };
+		020DEF6328AA091100C85D51 /* MagicLinkRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicLinkRequester.swift; sourceTree = "<group>"; };
 		02A526C828A3499C00FD1812 /* MagicLinkRequestedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicLinkRequestedViewController.swift; sourceTree = "<group>"; };
 		02A526C928A3499C00FD1812 /* MagicLinkRequestedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MagicLinkRequestedViewController.xib; sourceTree = "<group>"; };
 		02A526CC28A3A23900FD1812 /* UIButton+Styles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Styles.swift"; sourceTree = "<group>"; };
@@ -861,6 +863,7 @@
 				CE811D6824EDC14A00F4CCD6 /* LoginMagicLink.storyboard */,
 				02A526C828A3499C00FD1812 /* MagicLinkRequestedViewController.swift */,
 				02A526C928A3499C00FD1812 /* MagicLinkRequestedViewController.xib */,
+				020DEF6328AA091100C85D51 /* MagicLinkRequester.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -1272,6 +1275,7 @@
 				98C9195B2308E3DA00A90E12 /* AppleAuthenticator.swift in Sources */,
 				B56090F9208A533200399AE4 /* WordPressAuthenticator+Events.swift in Sources */,
 				CEDE0D93242011E000CB3345 /* NSObject+Helpers.swift in Sources */,
+				020DEF6428AA091100C85D51 /* MagicLinkRequester.swift in Sources */,
 				020BE74A23B0BD2E007FE54C /* WordPressAuthenticatorDisplayImages.swift in Sources */,
 				B560913A208A563800399AE4 /* LoginLinkRequestViewController.swift in Sources */,
 				B560910C208A54F800399AE4 /* WordPressComOAuthClientFacade.m in Sources */,

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -74,6 +74,11 @@ public class AuthenticatorAnalyticsTracker {
         ///
         case loginWithPassword = "login_password"
 
+        /// This flow starts when the user decides to login with a password instead, with magic link logic emphasis
+        /// where the CTA is a secondary CTA instead of a table view row
+        ///
+        case loginWithPasswordWithMagicLinkEmphasis = "login_password_magic_link_emphasis"
+
         /// This flow starts when the user decides to log in with their site address
         ///
         case loginWithSiteAddress = "login_site_address"

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -108,6 +108,10 @@ public struct WordPressAuthenticatorConfiguration {
     /// If disabled, password is shown by default with an option to send a magic link.
     let isWPComMagicLinkPreferredToPassword: Bool
 
+    /// If enabled, the alternative magic link action on the password screen is shown as a secondary call-to-action at the bottom.
+    /// If disabled, the alternative magic link action on the password screen is shown below the reset password action.
+    let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -131,7 +135,8 @@ public struct WordPressAuthenticatorConfiguration {
                  continueWithSiteAddressFirst: Bool = false,
                  enableSiteCredentialsLoginForSelfHostedSites: Bool = false,
                  isWPComLoginRequiredForSiteCredentialsLogin: Bool = false,
-                 isWPComMagicLinkPreferredToPassword: Bool = false) {
+                 isWPComMagicLinkPreferredToPassword: Bool = false,
+                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -155,5 +160,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableSiteCredentialsLoginForSelfHostedSites = enableSiteCredentialsLoginForSelfHostedSites
         self.isWPComLoginRequiredForSiteCredentialsLogin = isWPComLoginRequiredForSiteCredentialsLogin
         self.isWPComMagicLinkPreferredToPassword = isWPComMagicLinkPreferredToPassword
+        self.isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequester.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequester.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Encapsulates the async request for a magic link and email validation for use cases that send a magic link.
+struct MagicLinkRequester {
+    /// Makes the call to request a magic authentication link be emailed to the user if possible.
+    func requestMagicLink(email: String, jetpackLogin: Bool) async -> Result<Void, Error> {
+        await withCheckedContinuation { continuation in
+            guard email.isValidEmail() else {
+                return continuation.resume(returning: .failure(MagicLinkRequestError.invalidEmail))
+            }
+
+            let service = WordPressComAccountService()
+            service.requestAuthenticationLink(for: email,
+                                              jetpackLogin: jetpackLogin,
+                                              success: {
+                continuation.resume(returning: .success(()))
+            }, failure: { error in
+                continuation.resume(returning: .failure(error))
+            })
+        }
+    }
+}
+
+extension MagicLinkRequester {
+    enum MagicLinkRequestError: Error {
+        case invalidEmail
+    }
+}

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/Password.storyboard
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/Password.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21179.7" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aQT-Gx-U3x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21169.4"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" bounces="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="KLl-Uz-wEP">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="561"/>
                                         <sections/>
                                         <connections>
                                             <outlet property="dataSource" destination="aQT-Gx-U3x" id="Sct-0G-HTk"/>
@@ -28,42 +29,56 @@
                                         </connections>
                                     </tableView>
                                     <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xwA-rd-6jO" userLabel="Button background view">
-                                        <rect key="frame" x="0.0" y="591" width="375" height="76"/>
+                                        <rect key="frame" x="0.0" y="561" width="375" height="106"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
-                                                <rect key="frame" x="16" y="16" width="343" height="44"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
-                                                </constraints>
-                                                <state key="normal" title="Button"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="handleContinueButtonTapped:" destination="aQT-Gx-U3x" eventType="touchUpInside" id="Yeh-8i-cow"/>
-                                                </connections>
-                                            </button>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="RjB-bg-t6D">
+                                                <rect key="frame" x="16" y="8" width="343" height="90"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ClH-Cn-49d" userLabel="Primary Button" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="44" id="iBk-Pi-8cv"/>
+                                                        </constraints>
+                                                        <state key="normal" title="Button"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleContinueButtonTapped:" destination="aQT-Gx-U3x" eventType="touchUpInside" id="Yeh-8i-cow"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IAk-wS-Gex" customClass="NUXButton" customModule="WordPressAuthenticatorResources" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="60" width="343" height="30"/>
+                                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottomMargin" secondItem="ClH-Cn-49d" secondAttribute="bottom" constant="8" id="3Ba-yg-JKx"/>
-                                            <constraint firstItem="ClH-Cn-49d" firstAttribute="top" secondItem="xwA-rd-6jO" secondAttribute="topMargin" constant="8" id="GgD-0x-Aud"/>
-                                        </constraints>
                                         <viewLayoutGuide key="safeArea" id="VfW-kE-aWC"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="RjB-bg-t6D" firstAttribute="top" secondItem="xwA-rd-6jO" secondAttribute="top" constant="8" id="oia-aR-q8U"/>
+                                            <constraint firstAttribute="bottom" secondItem="RjB-bg-t6D" secondAttribute="bottom" constant="8" id="rCm-Sg-bhf"/>
+                                        </constraints>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="bottom" secondItem="dFS-Ic-byk" secondAttribute="bottomMargin" constant="8" id="85d-XY-Mr8"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="trailing" secondItem="dFS-Ic-byk" secondAttribute="trailing" id="Bkw-QJ-Tbe"/>
-                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="ClH-Cn-49d" secondAttribute="trailing" constant="16" id="Bpv-qx-bHc"/>
-                                    <constraint firstItem="ClH-Cn-49d" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" constant="16" id="Rnp-SF-SGh"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="top" secondItem="KLl-Uz-wEP" secondAttribute="bottom" id="gkZ-OV-HMi"/>
+                                    <constraint firstItem="RjB-bg-t6D" firstAttribute="leading" secondItem="KLl-Uz-wEP" secondAttribute="leading" constant="16" id="kXv-Ig-Ty3"/>
                                     <constraint firstItem="xwA-rd-6jO" firstAttribute="leading" secondItem="dFS-Ic-byk" secondAttribute="leading" id="wBE-xi-42q"/>
+                                    <constraint firstItem="KLl-Uz-wEP" firstAttribute="trailing" secondItem="RjB-bg-t6D" secondAttribute="trailing" constant="16" id="wPg-N4-vkn"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="KLl-Uz-wEP" firstAttribute="leading" secondItem="ihD-pY-rg9" secondAttribute="leading" id="7Fn-Eh-Xx9"/>
                             <constraint firstItem="ihD-pY-rg9" firstAttribute="trailing" secondItem="KLl-Uz-wEP" secondAttribute="trailing" id="7MD-ux-8i0"/>
@@ -73,10 +88,10 @@
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="leading" secondItem="ljV-kF-TaY" secondAttribute="leading" id="msS-7X-Za9"/>
                             <constraint firstItem="dFS-Ic-byk" firstAttribute="trailing" secondItem="ljV-kF-TaY" secondAttribute="trailing" id="zY1-Yz-kTf"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ihD-pY-rg9"/>
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="Dva-c1-u2U" id="Mq1-PI-MuN"/>
+                        <outlet property="secondaryButton" destination="IAk-wS-Gex" id="psV-zJ-3Yd"/>
                         <outlet property="submitButton" destination="ClH-Cn-49d" id="kBa-QN-0oH"/>
                         <outlet property="tableView" destination="KLl-Uz-wEP" id="MGk-sG-xGv"/>
                         <outlet property="tableViewLeadingConstraint" destination="7Fn-Eh-Xx9" id="yKO-sE-7mh"/>
@@ -88,4 +103,9 @@
             <point key="canvasLocation" x="-162.40000000000001" y="20.239880059970016"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -79,7 +79,7 @@ class PasswordViewController: LoginViewController {
                 tracker.set(step: .passwordChallenge)
             }
         } else {
-            tracker.set(flow: .loginWithPassword)
+            tracker.set(flow: isMagicLinkShownAsSecondaryAction ? .loginWithPasswordWithMagicLinkEmphasis : .loginWithPassword)
 
             if isMovingToParent {
                 tracker.track(step: .start)

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -276,7 +276,7 @@ private extension PasswordViewController {
         tracker.track(click: .requestMagicLink)
         loginFields.meta.emailMagicLinkSource = .login
 
-        configureViewLoading(true)
+        updateLoadingUI(isRequestingMagicLink: true)
         let result = await MagicLinkRequester().requestMagicLink(email: loginFields.username, jetpackLogin: loginFields.meta.jetpackLogin)
         switch result {
         case .success:
@@ -292,7 +292,25 @@ private extension PasswordViewController {
                 displayError(error as NSError, sourceTag: sourceTag)
             }
         }
-        configureViewLoading(false)
+        updateLoadingUI(isRequestingMagicLink: false)
+    }
+
+    func updateLoadingUI(isRequestingMagicLink: Bool) {
+        if isRequestingMagicLink {
+            if isMagicLinkShownAsSecondaryAction {
+                submitButton?.isEnabled = false
+                secondaryButton.showActivityIndicator(true)
+            } else {
+                configureViewLoading(true)
+            }
+        } else {
+            if isMagicLinkShownAsSecondaryAction {
+                submitButton?.isEnabled = true
+                secondaryButton.showActivityIndicator(false)
+            } else {
+                configureViewLoading(false)
+            }
+        }
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -9,12 +9,15 @@ class PasswordViewController: LoginViewController {
 
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
+    @IBOutlet private weak var secondaryButton: NUXButton!
 
     private weak var passwordField: UITextField?
     private var rows = [Row]()
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
     private var loginLinkCell: TextLinkButtonTableViewCell?
+
+    private let isMagicLinkShownAsSecondaryAction: Bool = WordPressAuthenticator.shared.configuration.isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen
 
     /// Depending on where we're coming from, this screen needs to track a password challenge
     /// (if logging on with a Social account) or not (if logging in through WP.com).
@@ -51,6 +54,7 @@ class PasswordViewController: LoginViewController {
         defaultTableViewMargin = tableViewLeadingConstraint?.constant ?? 0
         setTableViewMargins(forWidth: view.frame.width)
 
+        configureLoginWithMagicLinkButton()
         localizePrimaryButton()
         registerTableViewCells()
         loadRows()
@@ -174,7 +178,7 @@ class PasswordViewController: LoginViewController {
 
         // Is everything filled out?
         if !loginFields.validateFieldsPopulatedForSignin() {
-            let errorMsg = Constants.missingInfoError
+            let errorMsg = Localization.missingInfoError
             displayError(message: errorMsg, moveVoiceOverFocus: true)
 
             return
@@ -248,6 +252,50 @@ extension PasswordViewController: NUXKeyboardResponder {
 
 }
 
+// MARK: - Magic Link
+
+private extension PasswordViewController {
+    func configureLoginWithMagicLinkButton() {
+        if isMagicLinkShownAsSecondaryAction {
+            secondaryButton.setTitle(Localization.loginWithMagicLink, for: .normal)
+            secondaryButton.accessibilityIdentifier = AccessibilityIdentifier.loginWithMagicLink
+            secondaryButton.on(.touchUpInside) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    guard let self = self else { return }
+                    self.secondaryButton.isEnabled = false
+                    await self.loginWithMagicLink()
+                    self.secondaryButton.isEnabled = true
+                }
+            }
+        } else {
+            secondaryButton.isHidden = true
+        }
+    }
+
+    func loginWithMagicLink() async {
+        tracker.track(click: .requestMagicLink)
+        loginFields.meta.emailMagicLinkSource = .login
+
+        configureViewLoading(true)
+        let result = await MagicLinkRequester().requestMagicLink(email: loginFields.username, jetpackLogin: loginFields.meta.jetpackLogin)
+        switch result {
+        case .success:
+            didRequestAuthenticationLink()
+        case .failure(let error):
+            switch error {
+            case MagicLinkRequester.MagicLinkRequestError.invalidEmail:
+                DDLogError("Attempted to request authentication link, but the email address did not appear valid.")
+                let alert = buildInvalidEmailAlert()
+                present(alert, animated: true, completion: nil)
+            default:
+                tracker.track(failure: error.localizedDescription)
+                displayError(error as NSError, sourceTag: sourceTag)
+            }
+        }
+        configureViewLoading(false)
+    }
+}
+
 // MARK: - Table Management
 
 private extension PasswordViewController {
@@ -284,7 +332,10 @@ private extension PasswordViewController {
         }
 
         rows.append(.forgotPassword)
-        rows.append(.sendMagicLink)
+
+        if !isMagicLinkShownAsSecondaryAction {
+            rows.append(.sendMagicLink)
+        }
     }
 
     /// Configure cells.
@@ -394,7 +445,7 @@ private extension PasswordViewController {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.getLoginLinkButtonTitle,
                              accessibilityTrait: .link,
                              showBorder: true)
-        cell.accessibilityIdentifier = "Get Login Link Button"
+        cell.accessibilityIdentifier = AccessibilityIdentifier.loginWithMagicLink
 
         // Save reference to the login link cell so it can be enabled/disabled.
         loginLinkCell = cell
@@ -406,8 +457,9 @@ private extension PasswordViewController {
 
             cell.enableButton(false)
 
-            self.tracker.track(click: .requestMagicLink)
-            self.requestAuthenticationLink()
+            Task { @MainActor [weak self] in
+                await self?.loginWithMagicLink()
+            }
         }
     }
 
@@ -441,40 +493,11 @@ private extension PasswordViewController {
             submitButton as Any
         ]
 
-        UIAccessibility.post(notification: .screenChanged, argument: passwordField)
-    }
-
-    /// Makes the call to request a magic authentication link be emailed to the user.
-    ///
-    func requestAuthenticationLink() {
-        loginFields.meta.emailMagicLinkSource = .login
-
-        let email = loginFields.username
-        guard email.isValidEmail() else {
-            DDLogError("Attempted to request authentication link, but the email address did not appear valid.")
-            let alert = buildInvalidEmailAlert()
-            present(alert, animated: true, completion: nil)
-            return
+        if isMagicLinkShownAsSecondaryAction {
+            view.accessibilityElements?.append(secondaryButton as Any)
         }
 
-        configureViewLoading(true)
-        let service = WordPressComAccountService()
-        service.requestAuthenticationLink(for: email,
-                                          jetpackLogin: loginFields.meta.jetpackLogin,
-                                          success: { [weak self] in
-                                            self?.didRequestAuthenticationLink()
-                                            self?.configureViewLoading(false)
-
-            }, failure: { [weak self] (error: Error) in
-                guard let self = self else {
-                    return
-                }
-
-                self.tracker.track(failure: error.localizedDescription)
-
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
-                self.configureViewLoading(false)
-        })
+        UIAccessibility.post(notification: .screenChanged, argument: passwordField)
     }
 
     /// When a magic link successfully sends, navigate the user to the next step.
@@ -541,11 +564,19 @@ private extension PasswordViewController {
             }
         }
     }
+}
 
-    /// Constants
+private extension PasswordViewController {
+    /// Localization constants
     ///
-    struct Constants {
+    enum Localization {
         static let missingInfoError = NSLocalizedString("Please fill out all the fields",
                                                         comment: "A short prompt asking the user to properly fill out all login fields.")
+        static let loginWithMagicLink = NSLocalizedString("Or log in with magic link",
+                                                          comment: "The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password.")
+    }
+
+    enum AccessibilityIdentifier {
+        static let loginWithMagicLink = "Get Login Link Button"
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Iteration 2 for https://github.com/woocommerce/woocommerce-ios/issues/7437
<!-- Id number of the GitHub issue this PR addresses. -->

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For Iteration 2 of the [Magic Link Emphasis experiment in WCiOS](https://github.com/woocommerce/woocommerce-ios/issues/7437), we want to emphasize the magic link login option more on the password screen by moving the pre-existing table view cell to a new secondary CTA at the bottom (design at hHmVq03kKpvTDzV3uV4wqw-fi-14%3A2092).

The struggles I ran into were mostly on how the existing "Continue" CTA is implemented in the password screen. In a previous screen I worked on, the "Continue" CTA was implemented as a `NUXButtonViewController` configured in the storyboard. However, the password screen uses a different approach by just having a `NUXButton` in its `Password.storyboard` at the bottom of the view. Eventually, I implemented the optional secondary CTA under the "Continue" CTA by adding a `UIStackView`to the bottom of the view. The "Continue" CTA is now in the stack view along with a new secondary `NUXButton` below. This secondary CTA is hidden if the new configuration `isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen` is `false` to maintain the pre-existing UX.

In order to reuse the magic link async request logic better, I also extracted the async logic to a new struct `MagicLinkRequester` which is used in both `PasswordCoordinator` and `PasswordViewController`. It makes the UI updates in `PasswordViewController` more clear, since we're disabling the CTAs when requesting a magic link async and then enabling them afterward. There were also updates on the accessibility elements and the string/accessibility constants.

#### Analytics

The `flow` event property is set to `login_password_magic_link_emphasis` instead of `login_password` when the configuration is enabled.

### Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Accounts eligible for magic links

- Launch the app
- Log out if needed, and skip onboarding if needed
- Tap "Continue With WordPress.com"
- Enter a valid non-A8C WP.com email and tap "Continue" --> after a little bit (requesting magic link), a new magic link requested screen should be shown with two CTAs at the bottom
- Tap on "Use password to sign in" --> the password screen should be shown, and a "Or log in with magic link" CTA should be shown below the Continue CTA at the bottom. in the console, an event should be logged `🔵 Tracked unified_login_step, properties: [AnyHashable("step"): "start", AnyHashable("flow"): "login_password_magic_link_emphasis", AnyHashable("source"): "default"]`
- Tap "Or log in with magic link" CTA --> the critical CTAs should be disabled while a magic link is requested (again)
- Continue with the password flow or tap on the magic link in the email to log in to the app

#### Accounts not eligible for magic links (e.g. A8C email)

- Launch the app
- Log out if needed, and skip onboarding if needed
- Tap "Continue With WordPress.com"
- Enter an A8C WP.com email and tap "Continue" --> after a little bit (requesting magic link), the password screen should be shown, and a "Or log in with magic link" CTA should be shown below the Continue CTA at the bottom. in the console, an event should be logged `🔵 Tracked unified_login_step, properties: [AnyHashable("step"): "start", AnyHashable("flow"): "login_password", AnyHashable("source"): "default"]`
- Tap "Or log in with magic link" CTA --> the critical CTAs should be disabled while a magic link is requested, and an error alert should be shown
- Dismiss the alert --> the CTAs should be enabled again

#### Confidence check when the configuration is disabled

- [x] @jaclync tested this case


### Screenshots
<!-- Include before and after images or gifs when appropriate. -->

\ | light | dark
-- | -- | --
after | ![Simulator Screen Shot - iPhone 13 - 2022-08-15 at 15 03 43](https://user-images.githubusercontent.com/1945542/184598126-5a23e378-b074-4673-8b92-27deb889de67.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-15 at 15 04 10](https://user-images.githubusercontent.com/1945542/184598132-ecec3bcf-0be1-47e7-82ce-9e97c921d0c2.png)
before | ![Simulator Screen Shot - iPhone 13 - 2022-08-15 at 15 06 20](https://user-images.githubusercontent.com/1945542/184598143-db3bea8d-506d-4715-84d2-03b6934cd93f.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-15 at 15 06 09](https://user-images.githubusercontent.com/1945542/184598138-aaf67da2-b3cf-4dbc-bf8b-1c24310b9465.png)