### PR TITLE
Site address discovery

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.0'
+  s.version       = '2.2.1-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.1-beta.2'
+  s.version       = '2.2.1-beta.3'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -78,6 +78,10 @@ public class AuthenticatorAnalyticsTracker {
         ///
         case loginWithSiteAddress = "login_site_address"
 
+        /// This flow starts when the user wants to troubleshoot their site by inputting its address 
+        ///
+        case siteDiscovery = "site_discovery"
+
         /// This flow represents the signup (when the user inputs an email that’s not registered with a .com account)
         ///
         case signup

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -268,9 +268,9 @@ import WordPressKit
 
     /// Returns a Site Address view controller and triggers the protocol method `troubleshootSite` after fetching the site info.
     ///
-    @objc public class func siteAddressInputUIForTroubleshooting() -> UIViewController? {
+    @objc public class func siteDiscoveryUI() -> UIViewController? {
         return SiteAddressViewController.instantiate(from: .siteAddress) { coder in
-            SiteAddressViewController(needsTroubleshooting: true, coder: coder)
+            SiteAddressViewController(isSiteDiscovery: true, coder: coder)
         }
     }
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -266,6 +266,14 @@ import WordPressKit
         return SiteAddressViewController.instantiate(from: .siteAddress)
     }
 
+    /// Returns a Site Address view controller and triggers the protocol method `troubleshootSite` after fetching the site info.
+    ///
+    @objc public class func siteAddressInputUIForTroubleshooting() -> UIViewController? {
+        return SiteAddressViewController.instantiate(from: .siteAddress) { coder in
+            SiteAddressViewController(needsTroubleshooting: true, coder: coder)
+        }
+    }
+
     // Helper used by WPAuthTokenIssueSolver
     @objc
     public class func signinForWPCom(dotcomEmailAddress: String?, dotcomUsername: String?, onDismissed: ((_ cancelled: Bool) -> Void)? = nil) -> UIViewController {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -90,6 +90,11 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     func sync(credentials: AuthenticatorCredentials, onCompletion: @escaping () -> Void)
 
+    /// Signals to the Host App that a WordPress site is available and needs validated.
+    /// This method is only triggered when the authenticator method `siteAddressUIForTroubleshooting` is called.
+    ///
+    func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController)
+
     /// Signals the Host App that a given Analytics Event has occurred.
     ///
     func track(event: WPAnalyticsStat)
@@ -101,4 +106,12 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// Signals the Host App that a given Analytics Event (with an associated Error) has occurred.
     ///
     func track(event: WPAnalyticsStat, error: Error)
+}
+
+/// Extension with default implementation for optional delegate methods.
+///
+extension WordPressAuthenticatorDelegate {
+    func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController) {
+        // No-op
+    }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -93,6 +93,10 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// Signals to the Host App that a WordPress site is available and needs validated.
     /// This method is only triggered in the site discovery flow.
     ///
+    /// - Parameters:
+    ///     - siteInfo: The fetched site information - can be nil the site doesn't exist or have WordPress
+    ///     - navigationController: the current navigation stack of the site discovery flow.
+    ///
     func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?)
 
     /// Signals the Host App that a given Analytics Event has occurred.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -110,7 +110,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
 
 /// Extension with default implementation for optional delegate methods.
 ///
-extension WordPressAuthenticatorDelegate {
+public extension WordPressAuthenticatorDelegate {
     func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?) {
         // No-op
     }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -93,7 +93,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// Signals to the Host App that a WordPress site is available and needs validated.
     /// This method is only triggered when the authenticator method `siteAddressUIForTroubleshooting` is called.
     ///
-    func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController)
+    func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?)
 
     /// Signals the Host App that a given Analytics Event has occurred.
     ///
@@ -111,7 +111,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
 /// Extension with default implementation for optional delegate methods.
 ///
 extension WordPressAuthenticatorDelegate {
-    func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController) {
+    func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -91,7 +91,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     func sync(credentials: AuthenticatorCredentials, onCompletion: @escaping () -> Void)
 
     /// Signals to the Host App that a WordPress site is available and needs validated.
-    /// This method is only triggered when the authenticator method `siteAddressUIForTroubleshooting` is called.
+    /// This method is only triggered in the site discovery flow.
     ///
     func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?)
 

--- a/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIStoryboard+Helpers.swift
@@ -22,8 +22,8 @@ enum Storyboard: String {
     /// Returns a view controller from a Storyboard
     /// assuming the identifier is the same as the class name.
     ///
-    func instantiateViewController<T: NSObject>(ofClass classType: T.Type) -> T? {
+    func instantiateViewController<T: NSObject>(ofClass classType: T.Type, creator: ((NSCoder) -> UIViewController?)? = nil) -> T? {
         let identifier = classType.classNameWithoutNamespaces
-        return instance.instantiateViewController(withIdentifier: identifier) as? T
+        return instance.instantiateViewController(identifier: identifier, creator: creator) as? T
     }
 }

--- a/WordPressAuthenticator/Extensions/UIViewController+Helpers.swift
+++ b/WordPressAuthenticator/Extensions/UIViewController+Helpers.swift
@@ -5,7 +5,7 @@ extension UIViewController {
 
     /// Convenience method to instantiate a view controller from a storyboard.
     ///
-    static func instantiate(from storyboard: Storyboard) -> Self? {
-        return storyboard.instantiateViewController(ofClass: self)
+    static func instantiate(from storyboard: Storyboard, creator: ((NSCoder) -> UIViewController?)? = nil) -> Self? {
+        return storyboard.instantiateViewController(ofClass: self, creator: creator)
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -442,7 +442,7 @@ private extension SiteAddressViewController {
         // Checks that the site exists
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
-        request.timeoutInterval = 1.0
+        request.timeoutInterval = 10.0 // waits for 10 seconds
         let task = URLSession.shared.dataTask(with: request) { [weak self] _, _, error in
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -675,7 +675,7 @@ private extension SiteAddressViewController {
             "Invalid URL. Please double-check and try again.",
             comment: "Error message shown when the input URL is invalid.")
         static let nonExistentSiteError = NSLocalizedString(
-            "The site at this address does not exist. Please double-check and try again.",
+            "Cannot access the site at this address. Please double-check and try again.",
             comment: "Error message shown when the input URL does not point to an existing site.")
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -443,21 +443,23 @@ private extension SiteAddressViewController {
         request.httpMethod = "HEAD"
         request.timeoutInterval = 1.0
         let task = URLSession.shared.dataTask(with: request) { [weak self] _, _, error in
-            guard let self = self else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
 
-            if let error = error {
-                if self.authenticationDelegate.shouldHandleError(error) {
-                    self.authenticationDelegate.handleError(error) { customUI in
-                        self.pushCustomUI(customUI)
+                if let error = error {
+                    if self.authenticationDelegate.shouldHandleError(error) {
+                        self.authenticationDelegate.handleError(error) { customUI in
+                            self.pushCustomUI(customUI)
+                        }
+                        return
                     }
-                    return
+
+                    return self.displayError(message: Localization.nonExistentSiteError, moveVoiceOverFocus: true)
                 }
 
-                return self.displayError(message: Localization.nonExistentSiteError, moveVoiceOverFocus: true)
+                // Proceeds to check for the site's WordPress
+                self.guessXMLRPCURL(for: self.loginFields.siteAddress)
             }
-
-            // Proceeds to check for the site's WordPress
-            self.guessXMLRPCURL(for: self.loginFields.siteAddress)
         }
         task.resume()
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -435,6 +435,7 @@ private extension SiteAddressViewController {
         configureViewLoading(true)
 
         guard let url = URL(string: loginFields.siteAddress) else {
+            configureViewLoading(false)
             return displayError(message: Localization.invalidURL, moveVoiceOverFocus: true)
         }
 
@@ -447,6 +448,8 @@ private extension SiteAddressViewController {
                 guard let self = self else { return }
 
                 if let error = error {
+                    self.configureViewLoading(false)
+
                     if self.authenticationDelegate.shouldHandleError(error) {
                         self.authenticationDelegate.handleError(error) { customUI in
                             self.pushCustomUI(customUI)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -491,6 +491,11 @@ private extension SiteAddressViewController {
                 // WordPressAuthenticator.track(.loginFailed, error: error)
                 self.configureViewLoading(false)
 
+                guard self.isSiteDiscovery == false else {
+                    WordPressAuthenticator.shared.delegate?.troubleshootSite(nil, in: self.navigationController)
+                    return
+                }
+
                 let err = self.originalErrorOrError(error: error as NSError)
 
                 /// Check if the host app wants to provide custom UI to handle the error.

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -30,15 +30,15 @@ final class SiteAddressViewController: LoginViewController {
 
     /// Whether the protocol method `troubleshootSite` should be triggered after site info is fetched.
     ///
-    private let needsTroubleshooting: Bool
+    private let isSiteDiscovery: Bool
 
-    init?(needsTroubleshooting: Bool, coder: NSCoder) {
-        self.needsTroubleshooting = needsTroubleshooting
+    init?(isSiteDiscovery: Bool, coder: NSCoder) {
+        self.isSiteDiscovery = isSiteDiscovery
         super.init(coder: coder)
     }
 
     required init?(coder: NSCoder) {
-        self.needsTroubleshooting = false
+        self.isSiteDiscovery = false
         super.init(coder: coder)
     }
 
@@ -73,7 +73,11 @@ final class SiteAddressViewController: LoginViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        tracker.set(flow: .loginWithSiteAddress)
+        if isSiteDiscovery {
+            tracker.set(flow: .siteDiscovery)
+        } else {
+            tracker.set(flow: .loginWithSiteAddress)
+        }
 
         if isMovingToParent {
             tracker.track(step: .start)
@@ -529,7 +533,7 @@ private extension SiteAddressViewController {
             loginFields.siteAddress = verifiedSiteAddress
         }
 
-        guard needsTroubleshooting == false else {
+        guard isSiteDiscovery == false else {
             WordPressAuthenticator.shared.delegate?.troubleshootSite(siteInfo, in: navigationController)
             return
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -28,6 +28,20 @@ final class SiteAddressViewController: LoginViewController {
     /// should show an activity indicator.
     private var viewIsLoading: Bool = false
 
+    /// Whether the protocol method `troubleshootSite` should be triggered after site info is fetched.
+    ///
+    private let needsTroubleshooting: Bool
+
+    init?(needsTroubleshooting: Bool, coder: NSCoder) {
+        self.needsTroubleshooting = needsTroubleshooting
+        super.init(coder: coder)
+    }
+
+    required init?(coder: NSCoder) {
+        self.needsTroubleshooting = false
+        super.init(coder: coder)
+    }
+
     // MARK: - Actions
     @IBAction func handleContinueButtonTapped(_ sender: NUXButton) {
         tracker.track(click: .submit)
@@ -513,6 +527,11 @@ private extension SiteAddressViewController {
         //
         if let verifiedSiteAddress = siteInfo?.url {
             loginFields.siteAddress = verifiedSiteAddress
+        }
+
+        guard needsTroubleshooting == false else {
+            WordPressAuthenticator.shared.delegate?.troubleshootSite(siteInfo, in: navigationController)
+            return
         }
 
         guard siteInfo?.isWPCom == false else {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/7468

### Description

This PR adds a new flow for troubleshooting a given site address. This flow reuses the current site address UI and returns the `WordPressSiteInfo` to a new delegate method for checking the problem of the site and show appropriate error message on the host app.

While testing the integration in https://github.com/woocommerce/woocommerce-ios/pull/7484, I found that for a non-existent site, the check is taking quite long to return an error - the library was checking for WordPress while we could check for its existence first. This PR adds that with a 10-second timeout and displays the error inline.

This PR also updates analytics by tracking a new flow `site_discovery`.

### Testing
Please check https://github.com/woocommerce/woocommerce-ios/pull/7484 for testing steps.