### PR TITLE
Open up reset password flow for external trigger

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.1-beta.1'
+  s.version       = '2.2.1-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -446,7 +446,7 @@ import WordPressKit
     ///
     /// - Parameter loginFields: A LoginFields instance.
     ///
-    class func openForgotPasswordURL(_ loginFields: LoginFields) {
+    public class func openForgotPasswordURL(_ loginFields: LoginFields) {
         let baseURL = loginFields.meta.userIsDotCom ? "https://wordpress.com" : WordPressAuthenticator.baseSiteURL(string: loginFields.siteAddress)
         let forgotPasswordURL = URL(string: baseURL + "/wp-login.php?action=lostpassword&redirect_to=wordpress%3A%2F%2F")!
         UIApplication.shared.open(forgotPasswordURL)


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-ios/issues/7318, we'd like to add an action to reset password for users who encounter an error logging in with their WP.com password. Since this is already available in the WPAuthenticator, I thought we could open it up to reuse this flow.

### Testing instructions

Please refer to the WCiOS PR: https://github.com/woocommerce/woocommerce-ios/pull/7503