### PR TITLE
Login: fix a crash after visiting site credentials screen and then auto-filling WP.com credentials

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.1-beta.3'
+  s.version       = '2.2.1-beta.4'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.1-beta.2'
+  s.version       = '2.2.1-beta.3'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -57,16 +57,18 @@ public class LoginFields: NSObject {
         return loginFields
     }
 
-    init(username: String = "",
-         password: String = "",
-         siteAddress: String = "",
-         multifactorCode: String = "",
-         nonceInfo: SocialLogin2FANonceInfo? = nil,
-         nonceUserID: Int = 0,
-         restrictToWPCom: Bool = false,
-         emailAddress: String = "",
-         meta: LoginFieldsMeta = LoginFieldsMeta(),
-         storedCredentials: SafariStoredCredentials? = nil) {
+    /// Using a convenience initializer for its Objective-C usage in unit tests.
+    convenience init(username: String,
+                     password: String,
+                     siteAddress: String,
+                     multifactorCode: String,
+                     nonceInfo: SocialLogin2FANonceInfo?,
+                     nonceUserID: Int,
+                     restrictToWPCom: Bool,
+                     emailAddress: String,
+                     meta: LoginFieldsMeta,
+                     storedCredentials: SafariStoredCredentials?) {
+        self.init()
         self.username = username
         self.password = password
         self.siteAddress = siteAddress

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -99,7 +99,7 @@ extension LoginFields {
 
 /// A helper class for storing safari saved password information.
 ///
-struct SafariStoredCredentials {
+class SafariStoredCredentials {
     var storedUserameHash = 0
     var storedPasswordHash = 0
 }

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -56,11 +56,48 @@ public class LoginFields: NSObject {
 
         return loginFields
     }
+
+    init(username: String = "",
+         password: String = "",
+         siteAddress: String = "",
+         multifactorCode: String = "",
+         nonceInfo: SocialLogin2FANonceInfo? = nil,
+         nonceUserID: Int = 0,
+         restrictToWPCom: Bool = false,
+         emailAddress: String = "",
+         meta: LoginFieldsMeta = LoginFieldsMeta(),
+         storedCredentials: SafariStoredCredentials? = nil) {
+        self.username = username
+        self.password = password
+        self.siteAddress = siteAddress
+        self.multifactorCode = multifactorCode
+        self.nonceInfo = nonceInfo
+        self.nonceUserID = nonceUserID
+        self.restrictToWPCom = restrictToWPCom
+        self.emailAddress = emailAddress
+        self.meta = meta
+        self.storedCredentials = storedCredentials
+    }
+}
+
+extension LoginFields {
+    func copy() -> LoginFields {
+        .init(username: username,
+              password: password,
+              siteAddress: siteAddress,
+              multifactorCode: multifactorCode,
+              nonceInfo: nonceInfo,
+              nonceUserID: nonceUserID,
+              restrictToWPCom: restrictToWPCom,
+              emailAddress: emailAddress,
+              meta: meta.copy(),
+              storedCredentials: storedCredentials)
+    }
 }
 
 /// A helper class for storing safari saved password information.
 ///
-class SafariStoredCredentials {
+struct SafariStoredCredentials {
     var storedUserameHash = 0
     var storedPasswordHash = 0
 }
@@ -116,4 +153,44 @@ public class LoginFieldsMeta: NSObject {
     var googleUser: GIDGoogleUser?
 
     var appleUser: AppleUser?
+
+    init(emailMagicLinkSource: EmailMagicLinkSource? = nil,
+         jetpackLogin: Bool = false,
+         userIsDotCom: Bool = true,
+         passwordless: Bool = false,
+         xmlrpcURL: NSURL? = nil,
+         siteInfo: WordPressComSiteInfo? = nil,
+         requiredMultifactor: Bool = false,
+         socialService: SocialServiceName? = nil,
+         socialServiceIDToken: String? = nil,
+         googleUser: GIDGoogleUser? = nil,
+         appleUser: AppleUser? = nil) {
+        self.emailMagicLinkSource = emailMagicLinkSource
+        self.jetpackLogin = jetpackLogin
+        self.userIsDotCom = userIsDotCom
+        self.passwordless = passwordless
+        self.xmlrpcURL = xmlrpcURL
+        self.siteInfo = siteInfo
+        self.requiredMultifactor = requiredMultifactor
+        self.socialService = socialService
+        self.socialServiceIDToken = socialServiceIDToken
+        self.googleUser = googleUser
+        self.appleUser = appleUser
+    }
+}
+
+extension LoginFieldsMeta {
+    func copy() -> LoginFieldsMeta {
+        .init(emailMagicLinkSource: emailMagicLinkSource,
+              jetpackLogin: jetpackLogin,
+              userIsDotCom: userIsDotCom,
+              passwordless: passwordless,
+              xmlrpcURL: xmlrpcURL,
+              siteInfo: siteInfo,
+              requiredMultifactor: requiredMultifactor,
+              socialService: socialService,
+              socialServiceIDToken: socialServiceIDToken,
+              googleUser: googleUser,
+              appleUser: appleUser)
+    }
 }

--- a/WordPressAuthenticator/Services/LoginFacade.m
+++ b/WordPressAuthenticator/Services/LoginFacade.m
@@ -132,7 +132,9 @@
         [self.delegate displayRemoteError:error];
     };
 
-    [self.delegate displayLoginMessage:NSLocalizedString(@"Authenticating", nil)];
+    if ([self.delegate respondsToSelector:@selector(displayLoginMessage:)]) {
+        [self.delegate displayLoginMessage:NSLocalizedString(@"Authenticating", nil)];
+    }
 
     NSString *siteUrl = [NSURL IDNEncodedURL: loginFields.siteAddress];
     [self.wordpressXMLRPCAPIFacade guessXMLRPCURLForSite:siteUrl success:guessXMLRPCURLSuccess failure:guessXMLRPCURLFailure];

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -752,7 +752,7 @@ private extension GetStartedViewController {
             return
         }
 
-        vc.loginFields = loginFields
+        vc.loginFields = loginFields.copy()
         vc.dismissBlock = dismissBlock
         vc.errorToPresent = errorToPresent
 


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/issues/7512

### Why

After visiting the site credentials screen and then auto-filling WP.com credentials on the email screen, the app crashes. It's because [`SiteCredentialsViewController` sets its `loginFields.meta.userIsDotCom = false` in `viewDidLoad`](https://href.li/?https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/blob/8121ebd0cecc340f329538c4dad1f10eb92b5c3e/WordPressAuthenticator/Unified%20Auth/View%20Related/Site%20Address/SiteCredentialsViewController.swift#L46) and `loginFields` is a class (reference type), this `meta.userIsDotCom` is altered for all view controllers including `GetStartedViewController` and thus it goes to the self-hosted path when validating the fields in Objective-C that calls an optional delegate function without checking if it is implemented 😅

### The fix

- Instead of sharing the same `LoginFields` between `GetStartedViewController` and `SiteCredentialsViewController`, the former view controller now sets a copy of its `LoginFields`
- In the crashing Objective-C `LoginFacade.signInToSelfHosted`, it now checks if the delegate implements the optional method `displayLoginMessage` before calling (which triggers a crash without the check)

### Testing steps

Please test the steps in https://github.com/woocommerce/woocommerce-ios/pull/7514