### PR TITLE
Site discovery: bypass app transport security when checking site existence

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.1-beta.4'
+  s.version       = '2.2.1-beta.5'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -440,6 +440,14 @@ private extension SiteAddressViewController {
         }
 
         // Checks that the site exists
+        checkSiteExistence(url: url) { [weak self] in
+            guard let self = self else { return }
+            // Proceeds to check for the site's WordPress
+            self.guessXMLRPCURL(for: self.loginFields.siteAddress)
+        }
+    }
+
+    func checkSiteExistence(url: URL, onCompletion: @escaping () -> Void) {
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
         request.timeoutInterval = 10.0 // waits for 10 seconds
@@ -460,8 +468,7 @@ private extension SiteAddressViewController {
                     return self.displayError(message: Localization.nonExistentSiteError, moveVoiceOverFocus: true)
                 }
 
-                // Proceeds to check for the site's WordPress
-                self.guessXMLRPCURL(for: self.loginFields.siteAddress)
+                onCompletion()
             }
         }
         task.resume()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -447,7 +447,7 @@ private extension SiteAddressViewController {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
 
-                if let error = error {
+                if let error = error, (error as NSError).code != NSURLErrorAppTransportSecurityRequiresSecureConnection {
                     self.configureViewLoading(false)
 
                     if self.authenticationDelegate.shouldHandleError(error) {


### PR DESCRIPTION
### Description
In #666 I introduced checking site existence for site address login / site discovery. This involves creating a URLRequest to the site address.

There's an issue when the entered site address uses the HTTP scheme, in this case the request fails with `NSURLErrorAppTransportSecurityRequiresSecureConnection` if the host app doesn't allow HTTP in its Info.plist file, causes the existence check to fail.

This PR adds a fix to bypass if the existence check encounters the app transport security error.

### Testing
- Update the `WordPressAuthenticator` library in the host app to point to the latest commit in this branch.
- Navigate to the log in with site address flow in the host app.
- Enter a valid site address to a WP site that has HTTP scheme.
- Notice that the app navigates to the next screen of the flow without error.