### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.2.1-beta.5'
+  s.version       = '2.3.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
In `x.y.z` version scheme, unless we are doing a hotfix, we want to increase the `y` value while creating a new beta/release. It looks like the current beta versions were incorrectly created for `2.2.1-beta.{version}` instead of `2.3.0-beta.{version}` which is minor mistake most of us have made.

While deciding on the final release version between `2.2.1` & `2.3.0`, I thought it was more important to use the correct final release version than to stay consistent with the beta versions and decided to go with `2.3.0`.

cc @jaclync @itsmeichigo (so you can keep this in mind for next beta versions)