### PR TITLE
Add `WordPressSupportSourceTag` for "Enter site address" screen

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.3.1-beta.1'
+  s.version       = '2.4.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.3.0'
+  s.version       = '2.3.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
@@ -12,8 +12,12 @@ public struct WordPressSupportSourceTag {
     }
 }
 
-func ==(lhs: WordPressSupportSourceTag, rhs: WordPressSupportSourceTag) -> Bool {
-    return lhs.name == rhs.name
+// MARK: - Equatable Conformance
+//
+extension WordPressSupportSourceTag: Equatable {
+    public static func == (lhs: WordPressSupportSourceTag, rhs: WordPressSupportSourceTag) -> Bool {
+        lhs.name == rhs.name
+    }
 }
 
 extension WordPressSupportSourceTag {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -11,6 +11,12 @@ final class SiteAddressViewController: LoginViewController {
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
 
+    override var sourceTag: WordPressSupportSourceTag {
+        get {
+            .loginSiteAddress
+        }
+    }
+
     // Required for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -12,9 +12,7 @@ final class SiteAddressViewController: LoginViewController {
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
 
     override var sourceTag: WordPressSupportSourceTag {
-        get {
-            .loginSiteAddress
-        }
+        .loginSiteAddress
     }
 
     // Required for `NUXKeyboardResponder` but unused here.


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/pull/7553

### Changes
In order to open custom web pages for login-related screens, we need to be able to identify the login screens from WC iOS. I decided to use the `WordPressSupportSourceTag` to identify each login screen.
- Adds a `WordPressSupportSourceTag` to `SiteAddressViewController` to identify the screen in WC iOS.
- Adds `Equatable` conformance to `WordPressSupportSourceTag` in order to equate the values in WC iOS.

### Testing steps

Follow the testing instructions from https://github.com/woocommerce/woocommerce-ios/pull/7553