### PR TITLE
Pass `Flow` and `Step` via `WordPressAuthenticatorDelegate`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.3.0'
+  s.version       = '2.4.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -60,7 +60,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?)
 
-    /// Presents the Support Interface from a given ViewController, with a specified SourceTag.
+    /// Presents the Support Interface from a given ViewController.
     ///
     /// - Parameters:
     ///     - from: ViewController from which to present the support interface from

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -68,7 +68,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///     - lastStep: Last `Step` tracked in `AuthenticatorAnalyticsTracker`
     ///     - lastFlow: Last `Flow` tracked in `AuthenticatorAnalyticsTracker`
     ///
-    func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, lastStep: String, lastFlow: String)
+    func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, lastStep: AuthenticatorAnalyticsTracker.Step, lastFlow: AuthenticatorAnalyticsTracker.Flow)
 
     /// Indicates if the Login Epilogue should be displayed.
     ///

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -62,7 +62,13 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
 
     /// Presents the Support Interface from a given ViewController, with a specified SourceTag.
     ///
-    func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag)
+    /// - Parameters:
+    ///     - from: ViewController from which to present the support interface from
+    ///     - sourceTag: Support source tag of the view controller.
+    ///     - lastStep: Last `Step` tracked in `AuthenticatorAnalyticsTracker`
+    ///     - lastFlow: Last `Flow` tracked in `AuthenticatorAnalyticsTracker`
+    ///
+    func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, lastStep: String, lastFlow: String)
 
     /// Indicates if the Login Epilogue should be displayed.
     ///

--- a/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -122,7 +122,7 @@ extension FancyAlertViewController {
                 }
 
                 let state = AuthenticatorAnalyticsTracker.shared.state
-                authDelegate.presentSupport(from: sourceViewController, sourceTag: sourceTag, lastStep: state.lastStep.rawValue, lastFlow: state.lastFlow.rawValue)
+                authDelegate.presentSupport(from: sourceViewController, sourceTag: sourceTag, lastStep: state.lastStep, lastFlow: state.lastFlow)
             }
         }
 

--- a/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -121,7 +121,8 @@ extension FancyAlertViewController {
                     return
                 }
 
-                authDelegate.presentSupport(from: sourceViewController, sourceTag: sourceTag)
+                let state = AuthenticatorAnalyticsTracker.shared.state
+                authDelegate.presentSupport(from: sourceViewController, sourceTag: sourceTag, lastStep: state.lastStep.rawValue, lastFlow: state.lastFlow.rawValue)
             }
         }
 

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -320,6 +320,6 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         }
 
         let state = AuthenticatorAnalyticsTracker.shared.state
-        WordPressAuthenticator.shared.delegate?.presentSupport(from: navigationController, sourceTag: source, lastStep: state.lastStep.rawValue, lastFlow: state.lastFlow.rawValue)
+        WordPressAuthenticator.shared.delegate?.presentSupport(from: navigationController, sourceTag: source, lastStep: state.lastStep, lastFlow: state.lastFlow)
     }
 }

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -319,6 +319,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             fatalError()
         }
 
-        WordPressAuthenticator.shared.delegate?.presentSupport(from: navigationController, sourceTag: source)
+        let state = AuthenticatorAnalyticsTracker.shared.state
+        WordPressAuthenticator.shared.delegate?.presentSupport(from: navigationController, sourceTag: source, lastStep: state.lastStep.rawValue, lastFlow: state.lastFlow.rawValue)
     }
 }


### PR DESCRIPTION
For https://github.com/woocommerce/woocommerce-ios/pull/7553

### Changes
In order to open custom web pages for login-related screens, we need to be able to identify the login screens in WC iOS code base. This PR passes `Step` and `Flow` via `presentSupport` delegate method. 

We will use the `Step` and `Flow` in WCiOS for identifying screens and tracking. 


### Testing steps

Follow the testing instructions from https://github.com/woocommerce/woocommerce-ios/pull/7553