### PR TITLE
Use a new `Step` value for Enter WPCOM email screen

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.4.0-beta.1'
+  s.version       = '2.4.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -112,6 +112,10 @@ public class AuthenticatorAnalyticsTracker {
         /// This represents the user opening their mail. It’s not strictly speaking an in-app screen but for the user it is part of the flow.
         case emailOpened = "email_opened"
 
+        /// Represents the screen or step in which WPCOM account email is entered by the user
+        ///
+        case enterEmailAddress = "enter_email_address"
+
         /// The screen with a username and password visible
         ///
         case usernamePassword = "username_password"

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -452,9 +452,9 @@ private extension GetStartedViewController {
         }
 
         if isMovingToParent {
-            tracker.track(step: .start)
+            tracker.track(step: .enterEmailAddress)
         } else {
-            tracker.set(step: .start)
+            tracker.set(step: .enterEmailAddress)
         }
     }
 }


### PR DESCRIPTION
Related to - https://github.com/woocommerce/woocommerce-ios/issues/7572 and https://github.com/woocommerce/woocommerce-ios/pull/7573

### Changes
`GetStartedViewController` and `SiteAddressViewController` were using same `Step` values (.start) 

This makes it impossible to differentiate between those two screens in analytics events. 

Meanwhile, WC Android uses ["enter_email_address"](https://github.com/woocommerce/woocommerce-android/blob/trunk/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/login/UnifiedLoginTracker.kt#L154) as `Step` value for Enter email screen (`GetStartedViewController`)

This PR introduces a new `Step` value "enter_email_address" and uses that for `GetStartedViewController`. 


### Testing instructions

Follow the instructions from https://github.com/woocommerce/woocommerce-ios/pull/7573 to test this. 