### PR TITLE
Add properties for prologue background image and prologue buttons blur effect

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.4.0'
+  s.version       = '2.5.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.5.0-beta.1'
+  s.version       = '3.2.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorStyles.swift
@@ -84,9 +84,16 @@ public struct WordPressAuthenticatorStyle {
     ///
     public let prologueBackgroundColor: UIColor
 
+    /// Style: optional prologue background image
+    ///
+    public let prologueBackgroundImage: UIImage?
+
     /// Style: prologue background colors
     ///
     public let prologueTitleColor: UIColor
+
+    /// Style: optional prologue buttons blur effect
+    public let prologueButtonsBlurEffect: UIBlurEffect?
 
     /// Style: primary button on the prologue view (continue)
     /// When `nil` it will use the primary styles defined here
@@ -139,7 +146,9 @@ public struct WordPressAuthenticatorStyle {
                 navBarBackgroundColor: UIColor,
                 navButtonTextColor: UIColor = .white,
                 prologueBackgroundColor: UIColor = WPStyleGuide.wordPressBlue(),
+                prologueBackgroundImage: UIImage? = nil,
                 prologueTitleColor: UIColor = .white,
+                prologueButtonsBlurEffect: UIBlurEffect? = nil,
                 prologuePrimaryButtonStyle: NUXButtonStyle? = nil,
                 prologueSecondaryButtonStyle: NUXButtonStyle? = nil,
                 prologueTopContainerChildViewController: @autoclosure @escaping () -> UIViewController? = nil,
@@ -172,7 +181,9 @@ public struct WordPressAuthenticatorStyle {
         self.navBarBackgroundColor = navBarBackgroundColor
         self.navButtonTextColor = navButtonTextColor
         self.prologueBackgroundColor = prologueBackgroundColor
+        self.prologueBackgroundImage = prologueBackgroundImage
         self.prologueTitleColor = prologueTitleColor
+        self.prologueButtonsBlurEffect = prologueButtonsBlurEffect
         self.prologuePrimaryButtonStyle = prologuePrimaryButtonStyle
         self.prologueSecondaryButtonStyle = prologueSecondaryButtonStyle
         self.prologueTopContainerChildViewController = prologueTopContainerChildViewController
@@ -220,6 +231,12 @@ public struct WordPressAuthenticatorUnifiedStyle {
     /// Style: Auth Prologue view background color
     public let prologueViewBackgroundColor: UIColor
 
+    /// Style: optional auth Prologue view background image
+    public let prologueBackgroundImage: UIImage?
+
+    /// Style: optional blur effect for the buttons view
+    public let prologueButtonsBlurEffect: UIBlurEffect?
+
     /// Style: Status bar style. Defaults to `default`.
     ///
     public let statusBarStyle: UIStatusBarStyle
@@ -245,6 +262,8 @@ public struct WordPressAuthenticatorUnifiedStyle {
                 viewControllerBackgroundColor: UIColor,
                 prologueButtonsBackgroundColor: UIColor = .clear,
                 prologueViewBackgroundColor: UIColor? = nil,
+                prologueBackgroundImage: UIImage? = nil,
+                prologueButtonsBlurEffect: UIBlurEffect? = nil,
                 statusBarStyle: UIStatusBarStyle = .default,
                 navBarBackgroundColor: UIColor,
                 navButtonTextColor: UIColor,
@@ -259,6 +278,8 @@ public struct WordPressAuthenticatorUnifiedStyle {
         self.viewControllerBackgroundColor = viewControllerBackgroundColor
         self.prologueButtonsBackgroundColor = prologueButtonsBackgroundColor
         self.prologueViewBackgroundColor = prologueViewBackgroundColor ?? viewControllerBackgroundColor
+        self.prologueBackgroundImage = prologueBackgroundImage
+        self.prologueButtonsBlurEffect = prologueButtonsBlurEffect
         self.statusBarStyle = statusBarStyle
         self.navBarBackgroundColor = navBarBackgroundColor
         self.navButtonTextColor = navButtonTextColor

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -55,6 +55,9 @@ class LoginPrologueViewController: LoginViewController {
         }
 
         defaultButtonViewMargin = buttonViewLeadingConstraint?.constant ?? 0
+        if let backgroundImage = WordPressAuthenticator.shared.unifiedStyle?.prologueBackgroundImage {
+            view.layer.contents = backgroundImage.cgImage
+        }
     }
 
     override func styleBackground() {
@@ -276,9 +279,16 @@ class LoginPrologueViewController: LoginViewController {
             buttonBlurEffectView.effect = UIBlurEffect(style: blurEffect)
             return
         }
-
-        buttonBlurEffectView.isHidden = true
-        view.backgroundColor = prologueViewBackgroundColor
+        // do not set background color if we've set a background image earlier
+        if WordPressAuthenticator.shared.unifiedStyle?.prologueBackgroundImage == nil {
+            view.backgroundColor = prologueViewBackgroundColor
+        }
+        // if a blur effect for the buttons was passed, use it; otherwise hide the view.
+        guard let blurEffect = WordPressAuthenticator.shared.unifiedStyle?.prologueButtonsBlurEffect else {
+            buttonBlurEffectView.isHidden = true
+            return
+        }
+        buttonBlurEffectView.effect = blurEffect
     }
 
     // MARK: - Actions


### PR DESCRIPTION
This PR Adds two properties to the `WordPressStyles` that allow further customization of the prologue screen, specifically:

- add a custom background image
- add a custom blur effect to the buttons view


can be tested on the related WordPRess-iOS [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19277)
