### PR TITLE
Bump version from 2.4.0 to 3.0.0 – 2.4.0 introduced a breaking change!

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.4.0'
+  s.version       = '3.0.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
The change from e61570ca0b0afcaac496a7d6497b5471f0bb6f43 changed the `WordPressAuthenticatorDelegate` public
interface in a breaking way.

The breaking result can be seen in the [this WordPress iOS build](https://buildkite.com/automattic/wordpress-ios/builds/9808#01830b2b-76f3-4fe1-b385-52e09f417c3c/1745-8411), where we upgraded WordPressAuthenticator following Semantic Versioning and experienced a build failure:

```
WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift:228:1: type 'WordPressAuthenticationManager' does not conform to protocol 'WordPressAuthenticatorDelegate'
```

Given the circumstances, the library version ought to have gone from 2.3.0 to 3.0.0, rather than 2.4.0.

---

I'm leaving this as a draft because we have discussed SemVer in the past and I don't think we got to an agreement. I want to discuss this with @wordpress-mobile/apps-infrastructure internally to check my own assumptions before opening the conversation to the rest of the mobile dev groups.