### PR TITLE
Show verify email screen from the authenticator

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '2.4.0'
+  s.version       = '2.5.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.0.0'
+  s.version       = '3.1.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -194,6 +194,29 @@ import WordPressKit
         showGetStarted(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail, siteURL: siteURL)
     }
 
+    /// Used to present the Verify Email flow from the app delegate
+    ///
+    @objc public class func showVerifyEmailForWPCom(from presenter: UIViewController, xmlrpc: String, connectedEmail: String, siteURL: String) {
+        guard let xmlrpcURL = URL(string: xmlrpc) else {
+            DDLogError("Failed to initiate XML-RPC URL from \(xmlrpc)")
+            return
+        }
+        let loginFields = LoginFields()
+        loginFields.meta.xmlrpcURL = xmlrpcURL as NSURL
+        loginFields.username = connectedEmail
+        loginFields.siteAddress = siteURL
+
+        guard let vc = VerifyEmailViewController.instantiate(from: .verifyEmail) else {
+            DDLogError("Failed to navigate to VerifyEmailViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+        let navController = LoginNavigationController(rootViewController: vc)
+        navController.modalPresentationStyle = .fullScreen
+        presenter.present(navController, animated: true, completion: nil)
+    }
+
     /// Shows the unified Login/Signup flow.
     ///
     private class func showGetStarted(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil, siteURL: String? = nil) {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -194,7 +194,13 @@ import WordPressKit
         showGetStarted(from: presenter, jetpackLogin: jetpackLogin, connectedEmail: connectedEmail, siteURL: siteURL)
     }
 
-    /// Used to present the Verify Email flow from the app delegate
+    /// Used to present the Verify Email flow from the app delegate.
+    ///
+    /// - Parameters:
+    ///     - presenter: The view controller that presents the Verify Email view.
+    ///     - xmlrpc: The URL to reach the XMLRPC file of the site to log in to.
+    ///     - connectedEmail: The email address used to authorized Jetpack connection with the site.
+    ///     - siteURL: The URL of the site to log in to.
     ///
     @objc public class func showVerifyEmailForWPCom(from presenter: UIViewController, xmlrpc: String, connectedEmail: String, siteURL: String) {
         guard let xmlrpcURL = URL(string: xmlrpc) else {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/7597.

## Description
This PR adds a new method to `WordPressAuthenticator` to make it possible to present the verify email flow from the authenticator.

This is needed for when the user has set up Jetpack connection and needs to log in again to the app. The necessary input for this flow is the xmlrpc URL, authorized email address, and site address that the user is trying to log in to.

## Testing steps
Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/7608 to test this PR.