### PR TITLE
Site credential login entry point and site info fetching

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.1.0'
+  s.version       = '3.2.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -242,6 +242,9 @@ import WordPressKit
         let loginFields = LoginFields()
         loginFields.siteAddress = siteURL
         controller.loginFields = loginFields
+        controller.dismissBlock = { _ in
+            controller.navigationController?.dismiss(animated: true)
+        }
 
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -242,9 +242,6 @@ import WordPressKit
         let loginFields = LoginFields()
         loginFields.siteAddress = siteURL
         controller.loginFields = loginFields
-        controller.dismissBlock = { _ in
-            controller.navigationController?.dismiss(animated: true)
-        }
 
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -232,7 +232,7 @@ import WordPressKit
     ///
     public class func showSiteCredentialLogin(from presenter: UIViewController, siteURL: String, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
         let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) { coder in
-            SiteCredentialsViewController(coder: coder, onCompletion: onCompletion)
+            SiteCredentialsViewController(coder: coder, isDismissible: true, onCompletion: onCompletion)
         }
         guard let controller = controller else {
             DDLogError("Failed to navigate from GetStartedViewController to SiteCredentialsViewController")
@@ -242,6 +242,9 @@ import WordPressKit
         let loginFields = LoginFields()
         loginFields.siteAddress = siteURL
         controller.loginFields = loginFields
+        controller.dismissBlock = { _ in
+            controller.navigationController?.dismiss(animated: true)
+        }
 
         let navController = LoginNavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .fullScreen

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -228,9 +228,13 @@ import WordPressKit
     /// - Parameters:
     ///     - presenter: The view controller that presents the site credential login flow.
     ///     - siteURL: The URL of the site to log in to.
+    ///     - onCompletion: The closure to be trigged when the login succeeds with the input credentials.
     ///
-    @objc public class func showSiteCredentialLogin(from presenter: UIViewController, siteURL: String) {
-        guard let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
+    public class func showSiteCredentialLogin(from presenter: UIViewController, siteURL: String, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
+        let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) { coder in
+            SiteCredentialsViewController(coder: coder, onCompletion: onCompletion)
+        }
+        guard let controller = controller else {
             DDLogError("Failed to navigate from GetStartedViewController to SiteCredentialsViewController")
             return
         }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -251,6 +251,17 @@ import WordPressKit
         presenter.present(navController, animated: true, completion: nil)
     }
 
+    /// A helper method to fetch site info for a given URL.
+    ///
+    public class func fetchSiteInfo(for siteURL: String, onCompletion: @escaping (Result<WordPressComSiteInfo, Error>) -> Void) {
+        let service = WordPressComBlogService()
+        service.fetchUnauthenticatedSiteInfoForAddress(for: siteURL, success: { siteInfo in
+            onCompletion(.success(siteInfo))
+        }, failure: { error in
+            onCompletion(.failure(error))
+        })
+    }
+
     /// Shows the unified Login/Signup flow.
     ///
     private class func showGetStarted(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil, siteURL: String? = nil) {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -252,6 +252,9 @@ import WordPressKit
     }
 
     /// A helper method to fetch site info for a given URL.
+    /// - Parameters:
+    ///     - siteURL: The URL of the site to fetch information for.
+    ///     - onCompletion: The closure to be triggered when fetching site info is done.
     ///
     public class func fetchSiteInfo(for siteURL: String, onCompletion: @escaping (Result<WordPressComSiteInfo, Error>) -> Void) {
         let service = WordPressComBlogService()

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -223,6 +223,27 @@ import WordPressKit
         presenter.present(navController, animated: true, completion: nil)
     }
 
+    /// Used to present the site credential login flow directly from the delegate.
+    ///
+    /// - Parameters:
+    ///     - presenter: The view controller that presents the site credential login flow.
+    ///     - siteURL: The URL of the site to log in to.
+    ///
+    @objc public class func showSiteCredentialLogin(from presenter: UIViewController, siteURL: String) {
+        guard let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
+            DDLogError("Failed to navigate from GetStartedViewController to SiteCredentialsViewController")
+            return
+        }
+
+        let loginFields = LoginFields()
+        loginFields.siteAddress = siteURL
+        controller.loginFields = loginFields
+
+        let navController = LoginNavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .fullScreen
+        presenter.present(navController, animated: true, completion: nil)
+    }
+
     /// Shows the unified Login/Signup flow.
     ///
     private class func showGetStarted(from presenter: UIViewController, jetpackLogin: Bool, connectedEmail: String? = nil, siteURL: String? = nil) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -58,6 +58,9 @@ final class SiteCredentialsViewController: LoginViewController {
         loginFields.meta.userIsDotCom = false
 
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
+        if completionHandler != nil {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(dismissView))
+        }
         styleNavigationBar(forUnified: true)
 
         // Store default margin, and size table for the view.
@@ -233,6 +236,9 @@ extension SiteCredentialsViewController: UITextFieldDelegate {
 // MARK: - Private Methods
 private extension SiteCredentialsViewController {
 
+    @objc func dismissView() {
+        navigationController?.dismiss(animated: true)
+    }
     /// Registers all of the available TableViewCells.
     ///
     func registerTableViewCells() {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -16,14 +16,17 @@ final class SiteCredentialsViewController: LoginViewController {
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
 
+    private let isDismissible: Bool
     private let completionHandler: ((WordPressOrgCredentials) -> Void)?
 
-    init?(coder: NSCoder, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
+    init?(coder: NSCoder, isDismissible: Bool, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
+        self.isDismissible = isDismissible
         self.completionHandler = onCompletion
         super.init(coder: coder)
     }
 
     required init?(coder: NSCoder) {
+        self.isDismissible = false
         self.completionHandler = nil
         super.init(coder: coder)
     }
@@ -58,8 +61,8 @@ final class SiteCredentialsViewController: LoginViewController {
         loginFields.meta.userIsDotCom = false
 
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
-        if completionHandler != nil {
-            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(dismissView))
+        if isDismissible {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissView))
         }
         styleNavigationBar(forUnified: true)
 
@@ -237,7 +240,7 @@ extension SiteCredentialsViewController: UITextFieldDelegate {
 private extension SiteCredentialsViewController {
 
     @objc func dismissView() {
-        navigationController?.dismiss(animated: true)
+        dismissBlock?(true)
     }
     /// Registers all of the available TableViewCells.
     ///

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -474,9 +474,6 @@ extension SiteCredentialsViewController {
         }
 
         let wporg = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
-        if let completionHandler = completionHandler {
-            return completionHandler(wporg)
-        }
         let credentials = AuthenticatorCredentials(wporg: wporg)
 
         guard WordPressAuthenticator.shared.configuration.isWPComLoginRequiredForSiteCredentialsLogin else {
@@ -493,6 +490,9 @@ extension SiteCredentialsViewController {
         // Try to get the jetpack email from XML-RPC response dictionary.
         //
         guard let loginFields = makeLoginFieldsUsing(xmlrpc: xmlrpc, options: options) else {
+            if let completionHandler = completionHandler {
+                return completionHandler(wporg)
+            }
             DDLogError("Unexpected response from .org site credentials sign in using XMLRPC.")
             showLoginEpilogue(for: credentials)
             return

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -16,6 +16,18 @@ final class SiteCredentialsViewController: LoginViewController {
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
 
+    private let completionHandler: ((WordPressOrgCredentials) -> Void)?
+
+    init?(coder: NSCoder, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
+        self.completionHandler = onCompletion
+        super.init(coder: coder)
+    }
+
+    required init?(coder: NSCoder) {
+        self.completionHandler = nil
+        super.init(coder: coder)
+    }
+
     // Required for `NUXKeyboardResponder` but unused here.
     var verticalCenterConstraint: NSLayoutConstraint?
 
@@ -462,6 +474,9 @@ extension SiteCredentialsViewController {
         }
 
         let wporg = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
+        if let completionHandler = completionHandler {
+            return completionHandler(wporg)
+        }
         let credentials = AuthenticatorCredentials(wporg: wporg)
 
         guard WordPressAuthenticator.shared.configuration.isWPComLoginRequiredForSiteCredentialsLogin else {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/7745.

## Description
This PR adds a new helper method to the authenticator so that the site credential login flow can be presented directly at the call site. 

Another helper method is for fetching site info, which triggers an existing API call in the library to get the essential information for a site given its URL.

## Testing
Please follow https://github.com/woocommerce/woocommerce-ios/pull/7748 for instructions to test the changes.
