### PR TITLE
Respect showCancel state and show cancel button when appropriate

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.2.0'
+  s.version       = '3.2.3-beta1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.2.1-beta1'
+  s.version       = '3.3.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.2.3-beta1'
+  s.version       = '3.2.1-beta1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -177,6 +177,10 @@ import WordPressKit
             return nil
         }
 
+        if let loginNavController = controller as? LoginNavigationController, let loginPrologueViewController = loginNavController.viewControllers.first as? LoginPrologueViewController {
+            loginPrologueViewController.showCancel = showCancel
+        }
+
         controller.modalPresentationStyle = .fullScreen
         return controller
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -163,6 +163,7 @@ class LoginPrologueViewController: LoginViewController {
         buttonViewController.shadowLayoutGuide = view.safeAreaLayoutGuide
         buttonViewController.topButtonStyle = WordPressAuthenticator.shared.style.prologuePrimaryButtonStyle
         buttonViewController.bottomButtonStyle = WordPressAuthenticator.shared.style.prologueSecondaryButtonStyle
+        buttonViewController.tertiaryButtonStyle = WordPressAuthenticator.shared.style.prologueSecondaryButtonStyle
     }
 
     /// Displays the old UI prologue buttons.


### PR DESCRIPTION
This PR fixes the issue where a user was unable to abandon the WP.com login flow while logged into a self hosted site by showing a Cancel button when showCancel = true is passed from caller.  Related to https://github.com/wordpress-mobile/WordPress-iOS/issues/19245

To test
Please test using the steps in the associated WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/19349