### PR TITLE
Release version `3.2.1`

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.3.0-beta.1'
+  s.version       = '3.2.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
Notice that I went from a proposed `3.3.0` to `3.2.1`.

That's because the only change that landed in `trunk` since the previous version `3.2.0`, was a bug fix. See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/684.

---

This version bump PR is part of the code freeze workflow for WordPress iOS 20.9 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.