### PR TITLE
Bash cache & `UIPasteBoard` tests updates

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - automattic/bash-cache#2.8.0
+  - automattic/bash-cache#2.9.0
   env: &common_env
     IMAGE_ID: xcode-14
 

--- a/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
+++ b/WordPressAuthenticatorTests/Authenticator/PasteboardTests.swift
@@ -10,13 +10,17 @@ class PasteboardTests: XCTestCase {
     }
 
     func testNominalAuthCode() throws {
-        if #available(iOS 16.0, *) {
-            throw XCTSkip("UIPasteboard doesn't work in iOS 16.0.") // Check https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/696
-        }
-
         guard #available(iOS 14.0, *) else {
             throw XCTSkip("Unsupported iOS version")
         }
+
+        // FIXME: We'll need to find a way to make the test work the new pasteboard rules
+        //
+        // See:
+        // - https://developer.apple.com/forums/thread/713770
+        // - https://sarunw.com/posts/uipasteboard-privacy-change-ios16/
+        // - https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/696
+        XCTExpectFailure("Paste board access has changed in iOS 16 and this test is now failing")
 
         let expect = expectation(description: "Could read nominal auth code from pasteboard")
         let pasteboard = UIPasteboard.general
@@ -24,25 +28,30 @@ class PasteboardTests: XCTestCase {
 
         UIPasteboard.general.detectAuthenticatorCode { result in
             switch result {
-                case .success(let authenticationCode):
-                    XCTAssertEqual(authenticationCode, "123456")
-                case .failure:
-                    XCTAssert(false)
+            case .success(let authenticationCode):
+                XCTAssertEqual(authenticationCode, "123456")
+                expect.fulfill()
+            case .failure:
+                // Do nothing, by not fulfilling the expectation, the test will fail.
+                return
             }
-            expect.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testLeadingZeroInAuthCodePreserved() throws {
-        if #available(iOS 16.0, *) {
-            throw XCTSkip("UIPasteboard doesn't work in iOS 16.0.") // Check https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/696
-        }
-
         guard #available(iOS 14.0, *) else {
             throw XCTSkip("Unsupported iOS version")
         }
+
+        // FIXME: We'll need to find a way to make the test work the new pasteboard rules
+        //
+        // See:
+        // - https://developer.apple.com/forums/thread/713770
+        // - https://sarunw.com/posts/uipasteboard-privacy-change-ios16/
+        // - https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/696
+        XCTExpectFailure("Paste board access has changed in iOS 16 and this test is now failing")
 
         let expect = expectation(description: "Could read leading zero auth code from pasteboard")
         let pasteboard = UIPasteboard.general
@@ -50,12 +59,13 @@ class PasteboardTests: XCTestCase {
 
         UIPasteboard.general.detectAuthenticatorCode { result in
             switch result {
-                case .success(let authenticationCode):
-                    XCTAssertEqual(authenticationCode, "012345")
-                case .failure:
-                    XCTAssert(false)
+            case .success(let authenticationCode):
+                XCTAssertEqual(authenticationCode, "012345")
+                expect.fulfill()
+            case .failure:
+                // Do nothing, by not fulfilling the expectation, the test will fail.
+                return
             }
-            expect.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)


### PR DESCRIPTION
This PR started as one to upgrade the project to build using the `xcode-14` image in CI. However I didn't iterate on it fast enough and other PRs (https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/695, https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/699) did most of the work. So, this PR now only tracks minor improvements.