### PR TITLE
Login navigation bar disappears during a pop transition

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.2.1'
+  s.version       = '3.2.2-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -73,7 +73,7 @@ class LoginPrologueViewController: LoginViewController {
         super.viewWillAppear(animated)
 
         configureButtonVC()
-        navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -68,7 +68,7 @@ final class SiteAddressViewController: LoginViewController {
 
         siteURLField?.text = loginFields.siteAddress
         configureSubmitButton()
-        
+
         // Nav bar could be hidden from the host app, so reshow it.
         navigationController?.setNavigationBarHidden(false, animated: animated)
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -68,6 +68,9 @@ final class SiteAddressViewController: LoginViewController {
 
         siteURLField?.text = loginFields.siteAddress
         configureSubmitButton()
+        
+        // Nav bar could be hidden from the host app, so reshow it.
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -254,9 +257,6 @@ private extension SiteAddressViewController {
     func configureNavBar() {
         navigationItem.title = WordPressAuthenticator.shared.displayStrings.logInTitle
         styleNavigationBar(forUnified: true)
-
-        // Nav bar could be hidden from the host app, so reshow it.
-        navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
     func setupTable() {


### PR DESCRIPTION
## Related PR
This PR is blocking the following PR:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/19461

## Description
Please check the related the PR for more details on the issue and the test instructions.