### PR TITLE
New configs and updates for simplified login flow i1

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.2.2'
+  s.version       = '3.3.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -124,6 +124,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSocialLogin: Bool
 
+    /// If enabled, there will be a border around the email label on the WPCom password screen.
+    ///
+    let emphasizeEmailForWPComPassword: Bool
+
     /// The optional instructions for WPCom password.
     ///
     let wpcomPasswordInstructions: String?
@@ -156,6 +160,7 @@ public struct WordPressAuthenticatorConfiguration {
                  enableWPComLoginOnlyInPrologue: Bool = false,
                  enableSiteCreation: Bool = false,
                  enableSocialLogin: Bool = false,
+                 emphasizeEmailForWPComPassword: Bool = false,
                  wpcomPasswordInstructions: String? = nil) {
 
         self.wpcomClientId = wpcomClientId
@@ -184,6 +189,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableWPComLoginOnlyInPrologue = enableWPComLoginOnlyInPrologue
         self.enableSiteCreation = enableSiteCreation
         self.enableSocialLogin = enableSocialLogin
+        self.emphasizeEmailForWPComPassword = emphasizeEmailForWPComPassword
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -112,15 +112,21 @@ public struct WordPressAuthenticatorConfiguration {
     /// If disabled, the alternative magic link action on the password screen is shown below the reset password action.
     let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool
 
-    /// If enabled, the Prologue screen will display a simplified version of the bottom buttons.
-    /// The Get Started screen will be replaced with a simple login screen with only an email address field.
-    /// No mention of WordPress.com or social logins will be included.
+    /// If enabled, the Prologue screen will display only the entry point for WPCom login and no site address login.
     ///
-    let enableSimplifiedLoginI1: Bool
+    let enableWPComLoginOnlyInPrologue: Bool
 
     /// If enabled, an entry point to the site creation flow will be added to the bottom button of the prologue screen of simplified login.
     ///
-    let enableSiteCreationForSimplifiedLoginI1: Bool
+    let enableSiteCreation: Bool
+
+    /// If enabled, social login will be display at the bottom of the WPCom login screen.
+    ///
+    let enableSocialLogin: Bool
+
+    /// The optional instructions for WPCom password.
+    ///
+    let wpcomPasswordInstructions: String?
 
     /// Designated Initializer
     ///
@@ -147,8 +153,10 @@ public struct WordPressAuthenticatorConfiguration {
                  isWPComLoginRequiredForSiteCredentialsLogin: Bool = false,
                  isWPComMagicLinkPreferredToPassword: Bool = false,
                  isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool = false,
-                 enableSimplifiedLoginI1: Bool = false,
-                 enableSiteCreationForSimplifiedLoginI1: Bool = false) {
+                 enableWPComLoginOnlyInPrologue: Bool = false,
+                 enableSiteCreation: Bool = false,
+                 enableSocialLogin: Bool = false,
+                 wpcomPasswordInstructions: String? = nil) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -173,7 +181,9 @@ public struct WordPressAuthenticatorConfiguration {
         self.isWPComLoginRequiredForSiteCredentialsLogin = isWPComLoginRequiredForSiteCredentialsLogin
         self.isWPComMagicLinkPreferredToPassword = isWPComMagicLinkPreferredToPassword
         self.isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen
-        self.enableSimplifiedLoginI1 = enableSimplifiedLoginI1
-        self.enableSiteCreationForSimplifiedLoginI1 = enableSiteCreationForSimplifiedLoginI1
+        self.enableWPComLoginOnlyInPrologue = enableWPComLoginOnlyInPrologue
+        self.enableSiteCreation = enableSiteCreation
+        self.enableSocialLogin = enableSocialLogin
+        self.wpcomPasswordInstructions = wpcomPasswordInstructions
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -112,6 +112,11 @@ public struct WordPressAuthenticatorConfiguration {
     /// If disabled, the alternative magic link action on the password screen is shown below the reset password action.
     let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool
 
+    /// If enabled, the Get Started screen will be replaced with a simple login screen with only an email address field.
+    /// No mention of WordPress.com or social logins will be included.
+    ///
+    let enableSimplifiedLoginI1: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -136,7 +141,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSiteCredentialsLoginForSelfHostedSites: Bool = false,
                  isWPComLoginRequiredForSiteCredentialsLogin: Bool = false,
                  isWPComMagicLinkPreferredToPassword: Bool = false,
-                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool = false) {
+                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool = false,
+                 enableSimplifiedLoginI1: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -161,5 +167,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.isWPComLoginRequiredForSiteCredentialsLogin = isWPComLoginRequiredForSiteCredentialsLogin
         self.isWPComMagicLinkPreferredToPassword = isWPComMagicLinkPreferredToPassword
         self.isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen
+        self.enableSimplifiedLoginI1 = enableSimplifiedLoginI1
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -112,10 +112,15 @@ public struct WordPressAuthenticatorConfiguration {
     /// If disabled, the alternative magic link action on the password screen is shown below the reset password action.
     let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool
 
-    /// If enabled, the Get Started screen will be replaced with a simple login screen with only an email address field.
+    /// If enabled, the Prologue screen will display a simplified version of the bottom buttons.
+    /// The Get Started screen will be replaced with a simple login screen with only an email address field.
     /// No mention of WordPress.com or social logins will be included.
     ///
     let enableSimplifiedLoginI1: Bool
+
+    /// If enabled, an entry point to the site creation flow will be added to the bottom button of the prologue screen.
+    ///
+    let enableSiteCreation: Bool
 
     /// Designated Initializer
     ///
@@ -142,7 +147,8 @@ public struct WordPressAuthenticatorConfiguration {
                  isWPComLoginRequiredForSiteCredentialsLogin: Bool = false,
                  isWPComMagicLinkPreferredToPassword: Bool = false,
                  isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool = false,
-                 enableSimplifiedLoginI1: Bool = false) {
+                 enableSimplifiedLoginI1: Bool = false,
+                 enableSiteCreation: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -168,5 +174,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.isWPComMagicLinkPreferredToPassword = isWPComMagicLinkPreferredToPassword
         self.isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen
         self.enableSimplifiedLoginI1 = enableSimplifiedLoginI1
+        self.enableSiteCreation = enableSiteCreation
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -118,9 +118,9 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSimplifiedLoginI1: Bool
 
-    /// If enabled, an entry point to the site creation flow will be added to the bottom button of the prologue screen.
+    /// If enabled, an entry point to the site creation flow will be added to the bottom button of the prologue screen of simplified login.
     ///
-    let enableSiteCreation: Bool
+    let enableSiteCreationForSimplifiedLoginI1: Bool
 
     /// Designated Initializer
     ///
@@ -148,7 +148,7 @@ public struct WordPressAuthenticatorConfiguration {
                  isWPComMagicLinkPreferredToPassword: Bool = false,
                  isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen: Bool = false,
                  enableSimplifiedLoginI1: Bool = false,
-                 enableSiteCreation: Bool = false) {
+                 enableSiteCreationForSimplifiedLoginI1: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -174,6 +174,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.isWPComMagicLinkPreferredToPassword = isWPComMagicLinkPreferredToPassword
         self.isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen
         self.enableSimplifiedLoginI1 = enableSimplifiedLoginI1
-        self.enableSiteCreation = enableSiteCreation
+        self.enableSiteCreationForSimplifiedLoginI1 = enableSiteCreationForSimplifiedLoginI1
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -105,6 +105,15 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?)
 
+    /// Signals to the Host App to navigate to the account creation flow.
+    /// This method is currently used only in the simplified login flow
+    /// when the configuration `enableSimplifiedLoginI1` is enabled
+    ///
+    /// - Parameters:
+    ///     - navigationController: the current navigation stack of the login flow.
+    ///
+    func showAccountCreation(in navigationController: UINavigationController?)
+
     /// Signals the Host App that a given Analytics Event has occurred.
     ///
     func track(event: WPAnalyticsStat)
@@ -122,6 +131,10 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
 ///
 public extension WordPressAuthenticatorDelegate {
     func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?) {
+        // No-op
+    }
+
+    func showAccountCreation(in navigationController: UINavigationController?) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -105,14 +105,14 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?)
 
-    /// Signals to the Host App to navigate to the account creation flow.
+    /// Signals to the Host App to navigate to the site creation flow.
     /// This method is currently used only in the simplified login flow
-    /// when the configuration `enableSimplifiedLoginI1` is enabled
+    /// when the configs `enableSimplifiedLoginI1` and `enableSiteCreationForSimplifiedLoginI1` is enabled
     ///
     /// - Parameters:
     ///     - navigationController: the current navigation stack of the login flow.
     ///
-    func showAccountCreation(in navigationController: UINavigationController?)
+    func showSiteCreation(in navigationController: UINavigationController?)
 
     /// Signals the Host App that a given Analytics Event has occurred.
     ///
@@ -134,7 +134,7 @@ public extension WordPressAuthenticatorDelegate {
         // No-op
     }
 
-    func showAccountCreation(in navigationController: UINavigationController?) {
+    func showSiteCreation(in navigationController: UINavigationController?) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -112,7 +112,7 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// - Parameters:
     ///     - navigationController: the current navigation stack of the login flow.
     ///
-    func showSiteCreation(in navigationController: UINavigationController?)
+    func showSiteCreation(in navigationController: UINavigationController)
 
     /// Signals the Host App that a given Analytics Event has occurred.
     ///
@@ -134,7 +134,7 @@ public extension WordPressAuthenticatorDelegate {
         // No-op
     }
 
-    func showSiteCreation(in navigationController: UINavigationController?) {
+    func showSiteCreation(in navigationController: UINavigationController) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -22,6 +22,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let googleSignupInstructions: String
     public let googlePasswordInstructions: String
     public let applePasswordInstructions: String
+    public let wpcomPasswordInstructions: String
 
     /// Strings: primary call-to-action button titles.
     ///
@@ -80,7 +81,8 @@ public struct WordPressAuthenticatorDisplayStrings {
                 googleSignupInstructions: String = defaultStrings.googleSignupInstructions,
                 googlePasswordInstructions: String = defaultStrings.googlePasswordInstructions,
                 applePasswordInstructions: String = defaultStrings.applePasswordInstructions,
-                continueButtonTitle: String = defaultStrings.continueButtonTitle,
+                wpcomPasswordInstructions: String = defaultStrings.wpcomPasswordInstructions,
+                continueButtonTitle: String =  defaultStrings.continueButtonTitle,
                 magicLinkButtonTitle: String = defaultStrings.magicLinkButtonTitle,
                 openMailButtonTitle: String = defaultStrings.openMailButtonTitle,
                 createAccountButtonTitle: String = defaultStrings.createAccountButtonTitle,
@@ -123,6 +125,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.googleSignupInstructions = googleSignupInstructions
         self.googlePasswordInstructions = googlePasswordInstructions
         self.applePasswordInstructions = applePasswordInstructions
+        self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.continueButtonTitle = continueButtonTitle
         self.magicLinkButtonTitle = magicLinkButtonTitle
         self.openMailButtonTitle = openMailButtonTitle
@@ -186,6 +189,8 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                           comment: "Instructional text shown when requesting the user's password for Google login."),
             applePasswordInstructions: NSLocalizedString("To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.",
                                                          comment: "Instructional text shown when requesting the user's password for Apple login."),
+            wpcomPasswordInstructions: NSLocalizedString("Enter the password for your account",
+                                                         comment: "Instructional text shown when requesting the user's password for WPCom login."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                    comment: "The button title text when there is a next step for logging in or signing up."),
             magicLinkButtonTitle: NSLocalizedString("Send Link by Email",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -51,6 +51,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let loginTermsOfService: String
     public let signupTermsOfService: String
     public let whatIsWPComLinkTitle: String
+    public let siteCreationButtonTitle: String
 
 	/// Placeholder text for textfields.
 	///
@@ -95,6 +96,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 loginTermsOfService: String = defaultStrings.loginTermsOfService,
                 signupTermsOfService: String = defaultStrings.signupTermsOfService,
                 whatIsWPComLinkTitle: String = defaultStrings.whatIsWPComLinkTitle,
+                siteCreationButtonTitle: String = defaultStrings.siteCreationButtonTitle,
                 getStartedTitle: String = defaultStrings.getStartedTitle,
                 logInTitle: String = defaultStrings.logInTitle,
                 signUpTitle: String = defaultStrings.signUpTitle,
@@ -137,6 +139,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.loginTermsOfService = loginTermsOfService
         self.signupTermsOfService = signupTermsOfService
         self.whatIsWPComLinkTitle = whatIsWPComLinkTitle
+        self.siteCreationButtonTitle = siteCreationButtonTitle
         self.getStartedTitle = getStartedTitle
         self.logInTitle = logInTitle
         self.signUpTitle = signUpTitle
@@ -213,6 +216,8 @@ public extension WordPressAuthenticatorDisplayStrings {
             signupTermsOfService: NSLocalizedString("If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_.", comment: "Legal disclaimer for signing up. The underscores _..._ denote underline."),
             whatIsWPComLinkTitle: NSLocalizedString("What is WordPress.com?",
                                                      comment: "Navigates to page with details about What is WordPress.com."),
+            siteCreationButtonTitle: NSLocalizedString("Create a Site",
+                                                       comment: "Navigates to a new flow for site creation."),
             getStartedTitle: NSLocalizedString("Get Started",
                                                comment: "View title for initial auth views."),
             logInTitle: NSLocalizedString("Log In",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -80,7 +80,7 @@ public struct WordPressAuthenticatorDisplayStrings {
                 googleSignupInstructions: String = defaultStrings.googleSignupInstructions,
                 googlePasswordInstructions: String = defaultStrings.googlePasswordInstructions,
                 applePasswordInstructions: String = defaultStrings.applePasswordInstructions,
-                continueButtonTitle: String =  defaultStrings.continueButtonTitle,
+                continueButtonTitle: String = defaultStrings.continueButtonTitle,
                 magicLinkButtonTitle: String = defaultStrings.magicLinkButtonTitle,
                 openMailButtonTitle: String = defaultStrings.openMailButtonTitle,
                 createAccountButtonTitle: String = defaultStrings.createAccountButtonTitle,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -189,7 +189,7 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                           comment: "Instructional text shown when requesting the user's password for Google login."),
             applePasswordInstructions: NSLocalizedString("To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.",
                                                          comment: "Instructional text shown when requesting the user's password for Apple login."),
-            wpcomPasswordInstructions: NSLocalizedString("Enter the password for your account",
+            wpcomPasswordInstructions: NSLocalizedString("Enter the password for your account.",
                                                          comment: "Instructional text shown when requesting the user's password for WPCom login."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                    comment: "The button title text when there is a next step for logging in or signing up."),

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -22,7 +22,6 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let googleSignupInstructions: String
     public let googlePasswordInstructions: String
     public let applePasswordInstructions: String
-    public let wpcomPasswordInstructions: String
 
     /// Strings: primary call-to-action button titles.
     ///
@@ -81,7 +80,6 @@ public struct WordPressAuthenticatorDisplayStrings {
                 googleSignupInstructions: String = defaultStrings.googleSignupInstructions,
                 googlePasswordInstructions: String = defaultStrings.googlePasswordInstructions,
                 applePasswordInstructions: String = defaultStrings.applePasswordInstructions,
-                wpcomPasswordInstructions: String = defaultStrings.wpcomPasswordInstructions,
                 continueButtonTitle: String =  defaultStrings.continueButtonTitle,
                 magicLinkButtonTitle: String = defaultStrings.magicLinkButtonTitle,
                 openMailButtonTitle: String = defaultStrings.openMailButtonTitle,
@@ -125,7 +123,6 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.googleSignupInstructions = googleSignupInstructions
         self.googlePasswordInstructions = googlePasswordInstructions
         self.applePasswordInstructions = applePasswordInstructions
-        self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.continueButtonTitle = continueButtonTitle
         self.magicLinkButtonTitle = magicLinkButtonTitle
         self.openMailButtonTitle = openMailButtonTitle
@@ -189,8 +186,6 @@ public extension WordPressAuthenticatorDisplayStrings {
                                                           comment: "Instructional text shown when requesting the user's password for Google login."),
             applePasswordInstructions: NSLocalizedString("To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.",
                                                          comment: "Instructional text shown when requesting the user's password for Apple login."),
-            wpcomPasswordInstructions: NSLocalizedString("Enter the password for your account.",
-                                                         comment: "Instructional text shown when requesting the user's password for WPCom login."),
             continueButtonTitle: NSLocalizedString("Continue",
                                                    comment: "The button title text when there is a next step for logging in or signing up."),
             magicLinkButtonTitle: NSLocalizedString("Send Link by Email",

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -249,11 +249,11 @@ class LoginPrologueViewController: LoginViewController {
 
         let displayStrings = WordPressAuthenticator.shared.displayStrings
         let loginTitle = displayStrings.continueWithWPButtonTitle
-        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button", onTap: loginTapCallback())
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button", onTap: loginTapCallback())
 
-        if configuration.enableSignUp {
-            let createAccountTitle = displayStrings.createAccountButtonTitle
-            buttonViewController.setupBottomButton(title: createAccountTitle, isPrimary: false, accessibilityIdentifier: "Prologue Create Account Button", onTap: simplifiedLoginAccountCreationCallback())
+        if configuration.enableSiteCreation {
+            let createSiteTitle = displayStrings.siteCreationButtonTitle
+            buttonViewController.setupBottomButton(title: createSiteTitle, isPrimary: false, accessibilityIdentifier: "Prologue Create Site Button", onTap: simplifiedLoginSiteCreationCallback())
         }
 
         setButtonViewControllerBackground(buttonViewController)
@@ -276,7 +276,7 @@ class LoginPrologueViewController: LoginViewController {
         }
     }
 
-    private func simplifiedLoginAccountCreationCallback() -> NUXButtonViewController.CallBackType {
+    private func simplifiedLoginSiteCreationCallback() -> NUXButtonViewController.CallBackType {
         { [weak self] in
             guard let self else { return }
             // triggers the delegate to ask the host app to handle account creation

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -251,7 +251,7 @@ class LoginPrologueViewController: LoginViewController {
         let loginTitle = displayStrings.continueWithWPButtonTitle
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button", onTap: loginTapCallback())
 
-        if configuration.enableSiteCreation {
+        if configuration.enableSiteCreationForSimplifiedLoginI1 {
             let createSiteTitle = displayStrings.siteCreationButtonTitle
             buttonViewController.setupBottomButton(title: createSiteTitle, isPrimary: false, accessibilityIdentifier: "Prologue Create Site Button", onTap: simplifiedLoginSiteCreationCallback())
         }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -278,9 +278,9 @@ class LoginPrologueViewController: LoginViewController {
 
     private func simplifiedLoginSiteCreationCallback() -> NUXButtonViewController.CallBackType {
         { [weak self] in
-            guard let self = self else { return }
+            guard let self = self, let navigationController = self.navigationController else { return }
             // triggers the delegate to ask the host app to handle site creation
-            WordPressAuthenticator.shared.delegate?.showSiteCreation(in: self.navigationController)
+            WordPressAuthenticator.shared.delegate?.showSiteCreation(in: navigationController)
         }
     }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -278,7 +278,7 @@ class LoginPrologueViewController: LoginViewController {
 
     private func simplifiedLoginSiteCreationCallback() -> NUXButtonViewController.CallBackType {
         { [weak self] in
-            guard let self else { return }
+            guard let self = self else { return }
             // triggers the delegate to ask the host app to handle account creation
             WordPressAuthenticator.shared.delegate?.showAccountCreation(in: self.navigationController)
         }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -158,8 +158,8 @@ class LoginPrologueViewController: LoginViewController {
             return
         }
 
-        if configuration.enableSimplifiedLoginI1 {
-            buildSimplifiedPrologueButtonsI1(buttonViewController: buttonViewController)
+        if configuration.enableWPComLoginOnlyInPrologue {
+            buildPrologueButtonsWithWPComAndOptionalSiteCreation(buttonViewController: buttonViewController)
         } else {
             buildUnifiedPrologueButtons(buttonViewController)
         }
@@ -244,14 +244,14 @@ class LoginPrologueViewController: LoginViewController {
         setButtonViewControllerBackground(buttonViewController)
     }
 
-    private func buildSimplifiedPrologueButtonsI1(buttonViewController: NUXButtonViewController) {
+    private func buildPrologueButtonsWithWPComAndOptionalSiteCreation(buttonViewController: NUXButtonViewController) {
         setButtonViewMargins(forWidth: view.frame.width)
 
         let displayStrings = WordPressAuthenticator.shared.displayStrings
         let loginTitle = displayStrings.continueWithWPButtonTitle
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Log In Button", onTap: loginTapCallback())
 
-        if configuration.enableSiteCreationForSimplifiedLoginI1 {
+        if configuration.enableSiteCreation {
             let createSiteTitle = displayStrings.siteCreationButtonTitle
             buttonViewController.setupBottomButton(title: createSiteTitle, isPrimary: false, accessibilityIdentifier: "Prologue Create Site Button", onTap: simplifiedLoginSiteCreationCallback())
         }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -158,7 +158,11 @@ class LoginPrologueViewController: LoginViewController {
             return
         }
 
-        buildUnifiedPrologueButtons(buttonViewController)
+        if configuration.enableSimplifiedLoginI1 {
+            buildSimplifiedPrologueButtonsI1(buttonViewController: buttonViewController)
+        } else {
+            buildUnifiedPrologueButtons(buttonViewController)
+        }
 
         buttonViewController.shadowLayoutGuide = view.safeAreaLayoutGuide
         buttonViewController.topButtonStyle = WordPressAuthenticator.shared.style.prologuePrimaryButtonStyle
@@ -240,6 +244,21 @@ class LoginPrologueViewController: LoginViewController {
         setButtonViewControllerBackground(buttonViewController)
     }
 
+    private func buildSimplifiedPrologueButtonsI1(buttonViewController: NUXButtonViewController) {
+        setButtonViewMargins(forWidth: view.frame.width)
+
+        let displayStrings = WordPressAuthenticator.shared.displayStrings
+        let loginTitle = displayStrings.continueWithWPButtonTitle
+        buttonViewController.setupTopButton(title: loginTitle, isPrimary: true, accessibilityIdentifier: "Prologue Continue Button", onTap: loginTapCallback())
+
+        if configuration.enableSignUp {
+            let createAccountTitle = displayStrings.createAccountButtonTitle
+            buttonViewController.setupBottomButton(title: createAccountTitle, isPrimary: false, accessibilityIdentifier: "Prologue Create Account Button", onTap: simplifiedLoginAccountCreationCallback())
+        }
+
+        setButtonViewControllerBackground(buttonViewController)
+    }
+
     private func siteAddressTapCallback() -> NUXButtonViewController.CallBackType {
         return { [weak self] in
             self?.siteAddressTapped()
@@ -254,6 +273,14 @@ class LoginPrologueViewController: LoginViewController {
 
             self.tracker.track(click: .continueWithWordPressCom)
             self.continueWithDotCom()
+        }
+    }
+
+    private func simplifiedLoginAccountCreationCallback() -> NUXButtonViewController.CallBackType {
+        { [weak self] in
+            guard let self else { return }
+            // triggers the delegate to ask the host app to handle account creation
+            WordPressAuthenticator.shared.delegate?.showAccountCreation(in: self.navigationController)
         }
     }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -279,8 +279,8 @@ class LoginPrologueViewController: LoginViewController {
     private func simplifiedLoginSiteCreationCallback() -> NUXButtonViewController.CallBackType {
         { [weak self] in
             guard let self = self else { return }
-            // triggers the delegate to ask the host app to handle account creation
-            WordPressAuthenticator.shared.delegate?.showAccountCreation(in: self.navigationController)
+            // triggers the delegate to ask the host app to handle site creation
+            WordPressAuthenticator.shared.delegate?.showSiteCreation(in: self.navigationController)
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -111,6 +111,11 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         return button
     }()
 
+    private var showsContinueButtonAtTheBottom: Bool {
+        screenMode == .signInUsingSiteCredentials ||
+            configuration.enableSocialLogin == false
+    }
+
     override open var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginEmail
@@ -131,8 +136,8 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
 
         if screenMode == .signInUsingSiteCredentials {
             configureButtonViewControllerForSiteCredentialsMode()
-        } else if configuration.enableSimplifiedLoginI1 {
-            configureButtonViewControllerForSimplifiedLoginI1()
+        } else if configuration.enableSocialLogin == false {
+            configureButtonViewControllerWithoutSocialLogin()
         } else {
             configureSocialButtons()
         }
@@ -160,8 +165,7 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         hiddenPasswordField?.text = nil
         hiddenPasswordField?.isAccessibilityElement = false
 
-        if screenMode == .signInUsingSiteCredentials ||
-            configuration.enableSimplifiedLoginI1 {
+        if showsContinueButtonAtTheBottom {
             registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                       keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
         }
@@ -258,8 +262,7 @@ private extension GetStartedViewController {
         stackView.layoutMargins = Constants.FooterStackView.layoutMargins
         stackView.isLayoutMarginsRelativeArrangement = true
 
-        if screenMode == .signInUsingWordPressComOrSocialAccounts,
-           configuration.enableSimplifiedLoginI1 == false {
+        if showsContinueButtonAtTheBottom == false {
             // Continue button will be added to `buttonViewController` along with sign in with site credentials button when `screenMode` is `signInUsingSiteCredentials`
             // and simplified login flow is disabled.
             stackView.addArrangedSubview(continueButton)
@@ -282,8 +285,7 @@ private extension GetStartedViewController {
     /// Style the "OR" divider.
     ///
     func configureDivider() {
-        guard screenMode == .signInUsingWordPressComOrSocialAccounts,
-              configuration.enableSimplifiedLoginI1 == false else {
+        guard showsContinueButtonAtTheBottom == false else {
             return dividerStackView.isHidden = true
         }
         let color = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
@@ -472,7 +474,7 @@ private extension GetStartedViewController {
     ///
     func configureContinueButton(animating: Bool) {
         if screenMode == .signInUsingSiteCredentials ||
-            configuration.enableSimplifiedLoginI1 {
+            configuration.enableSocialLogin == false {
             buttonViewController?.setTopButtonState(isLoading: animating,
                                                     isEnabled: enableSubmit(animating: animating))
         } else {
@@ -809,14 +811,14 @@ private extension GetStartedViewController {
                                                onTap: handleSiteCredentialsButtonTapped)
     }
 
-    func configureButtonViewControllerForSimplifiedLoginI1() {
+    func configureButtonViewControllerWithoutSocialLogin() {
         guard let buttonViewController = buttonViewController else {
             return
         }
 
         buttonViewController.hideShadowView()
 
-        // Add a "Continue" button here as the `continueButton` at the top
+        // Add a "Continue" button here as the `continueButton` at the top will be hidden
         //
         buttonViewController.setupTopButton(title: ButtonConfiguration.Continue.title,
                                             isPrimary: true,

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -159,7 +159,8 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         hiddenPasswordField?.text = nil
         hiddenPasswordField?.isAccessibilityElement = false
 
-        if screenMode == .signInUsingSiteCredentials {
+        if screenMode == .signInUsingSiteCredentials ||
+            configuration.enableSimplifiedLoginI1 {
             registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                       keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -127,12 +127,13 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         registerTableViewCells()
         loadRows()
         setupTableFooterView()
-        configureDivider()
+
         if screenMode == .signInUsingSiteCredentials {
             configureButtonViewControllerForSiteCredentialsMode()
         } else if configuration.enableSimplifiedLoginI1 {
             configureButtonViewControllerForSimplifiedLoginI1()
         } else {
+            configureDivider()
             configureSocialButtons()
         }
     }
@@ -281,10 +282,6 @@ private extension GetStartedViewController {
     /// Style the "OR" divider.
     ///
     func configureDivider() {
-        guard screenMode == .signInUsingWordPressComOrSocialAccounts else {
-            return dividerStackView.isHidden = true
-        }
-
         let color = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         leadingDividerLine.backgroundColor = color
         leadingDividerLineWidth.constant = WPStyleGuide.hairlineBorderWidth
@@ -470,18 +467,13 @@ private extension GetStartedViewController {
     /// Configures appearance of the submit button.
     ///
     func configureContinueButton(animating: Bool) {
-        switch screenMode {
-        case .signInUsingSiteCredentials:
+        if screenMode == .signInUsingSiteCredentials ||
+            configuration.enableSimplifiedLoginI1 {
             buttonViewController?.setTopButtonState(isLoading: animating,
                                                     isEnabled: enableSubmit(animating: animating))
-        case .signInUsingWordPressComOrSocialAccounts:
-            if configuration.enableSimplifiedLoginI1 {
-                buttonViewController?.setTopButtonState(isLoading: animating,
-                                                        isEnabled: enableSubmit(animating: animating))
-            } else {
-                continueButton.showActivityIndicator(animating)
-                continueButton.isEnabled = enableSubmit(animating: animating)
-            }
+        } else {
+            continueButton.showActivityIndicator(animating)
+            continueButton.isEnabled = enableSubmit(animating: animating)
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -473,8 +473,7 @@ private extension GetStartedViewController {
     /// Configures appearance of the submit button.
     ///
     func configureContinueButton(animating: Bool) {
-        if screenMode == .signInUsingSiteCredentials ||
-            configuration.enableSocialLogin == false {
+        if showsContinueButtonAtTheBottom {
             buttonViewController?.setTopButtonState(isLoading: animating,
                                                     isEnabled: enableSubmit(animating: animating))
         } else {

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -127,13 +127,13 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         registerTableViewCells()
         loadRows()
         setupTableFooterView()
+        configureDivider()
 
         if screenMode == .signInUsingSiteCredentials {
             configureButtonViewControllerForSiteCredentialsMode()
         } else if configuration.enableSimplifiedLoginI1 {
             configureButtonViewControllerForSimplifiedLoginI1()
         } else {
-            configureDivider()
             configureSocialButtons()
         }
     }
@@ -282,6 +282,10 @@ private extension GetStartedViewController {
     /// Style the "OR" divider.
     ///
     func configureDivider() {
+        guard screenMode == .signInUsingWordPressComOrSocialAccounts,
+              configuration.enableSimplifiedLoginI1 == false else {
+            return dividerStackView.isHidden = true
+        }
         let color = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         leadingDividerLine.backgroundColor = color
         leadingDividerLineWidth.constant = WPStyleGuide.hairlineBorderWidth

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -21,10 +21,6 @@ class PasswordViewController: LoginViewController {
 
     private let configuration = WordPressAuthenticator.shared.configuration
 
-    private var isSiteCredentialPassword: Bool {
-        loginFields.siteAddress.isEmpty == false && configuration.enableSiteCredentialsLoginForSelfHostedSites
-    }
-
     /// Depending on where we're coming from, this screen needs to track a password challenge
     /// (if logging on with a Social account) or not (if logging in through WP.com).
     ///
@@ -346,7 +342,7 @@ private extension PasswordViewController {
 
         // Instructions only for social accounts and simplified WPCom login flow
         if loginFields.meta.socialService != nil ||
-            (configuration.enableSimplifiedLoginI1 && isSiteCredentialPassword == false) {
+            configuration.wpcomPasswordInstructions != nil {
             rows.append(.instructions)
         }
 
@@ -408,13 +404,17 @@ private extension PasswordViewController {
     ///
     func configureInstructionLabel(_ cell: TextLabelTableViewCell) {
         let displayStrings = WordPressAuthenticator.shared.displayStrings
-        let instructions: String = {
+        let instructions: String? = {
             if let service = loginFields.meta.socialService {
                 return (service == .google) ? displayStrings.googlePasswordInstructions :
                 displayStrings.applePasswordInstructions
             }
-            return displayStrings.wpcomPasswordInstructions
+            return configuration.wpcomPasswordInstructions
         }()
+
+        guard let instructions = instructions else {
+            return
+        }
 
         cell.configureLabel(text: instructions)
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -19,10 +19,10 @@ class PasswordViewController: LoginViewController {
 
     private let isMagicLinkShownAsSecondaryAction: Bool = WordPressAuthenticator.shared.configuration.isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen
 
-    private let configurations = WordPressAuthenticator.shared.configuration
+    private let configuration = WordPressAuthenticator.shared.configuration
 
     private var isSiteCredentialPassword: Bool {
-        loginFields.siteAddress.isEmpty == false && configurations.enableSiteCredentialsLoginForSelfHostedSites
+        loginFields.siteAddress.isEmpty == false && configuration.enableSiteCredentialsLoginForSelfHostedSites
     }
 
     /// Depending on where we're coming from, this screen needs to track a password challenge
@@ -346,7 +346,7 @@ private extension PasswordViewController {
 
         // Instructions only for social accounts and simplified WPCom login flow
         if loginFields.meta.socialService != nil ||
-            (configurations.enableSimplifiedLoginI1 && isSiteCredentialPassword == false) {
+            (configuration.enableSimplifiedLoginI1 && isSiteCredentialPassword == false) {
             rows.append(.instructions)
         }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -383,7 +383,7 @@ private extension PasswordViewController {
     /// Configure the gravatar + email cell.
     ///
     func configureGravatarEmail(_ cell: GravatarEmailTableViewCell) {
-        cell.configure(withEmail: loginFields.username)
+        cell.configure(withEmail: loginFields.username, hasBorders: configuration.emphasizeEmailForWPComPassword)
 
         cell.onChangeSelectionHandler = { [weak self] textfield in
             // The email can only be changed via a password manager.

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -24,7 +24,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         containerView.layer.cornerRadius = 8
-        containerView.layer.borderColor = UIColor.gray.cgColor
+        containerView.layer.borderColor = UIColor.systemGray3.cgColor
     }
 
     /// Public Methods
@@ -35,7 +35,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         emailLabel?.text = email
 
-        let gridicon: UIImage = hasBorders ? .gridicon(.userCircle, size: girdiconSmallSize) : .gridicon(.userCircle, size: gridiconSize)
+        let gridicon: UIImage = .gridicon(.userCircle, size: hasBorders ? girdiconSmallSize : gridiconSize)
 
         guard let email = email,
             email.isValidEmail() else {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -21,12 +21,6 @@ class GravatarEmailTableViewCell: UITableViewCell {
     public static let reuseIdentifier = "GravatarEmailTableViewCell"
     public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        containerView.layer.cornerRadius = 8
-        containerView.layer.borderColor = UIColor.systemGray3.cgColor
-    }
-
     /// Public Methods
     ///
     public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil, hasBorders: Bool = false) {
@@ -45,8 +39,8 @@ class GravatarEmailTableViewCell: UITableViewCell {
 
         gravatarImageView?.downloadGravatarWithEmail(email, placeholderImage: placeholderImage ?? gridicon)
 
-        gravatarImageViewSizeConstraints.forEach { constraints in
-            constraints.constant = gridicon.size.width
+        gravatarImageViewSizeConstraints.forEach { constraint in
+            constraint.constant = gridicon.size.width
         }
 
         let margin: CGFloat = hasBorders ? 16 : 0
@@ -55,6 +49,8 @@ class GravatarEmailTableViewCell: UITableViewCell {
         }
 
         containerView.layer.borderWidth = hasBorders ? 1 : 0
+        containerView.layer.cornerRadius = hasBorders ? 8 : 0
+        containerView.layer.borderColor = hasBorders ? UIColor.systemGray3.cgColor : UIColor.clear.cgColor
     }
 
     func updateEmailAddress(_ email: String?) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -8,7 +8,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
     ///
     @IBOutlet private weak var gravatarImageView: UIImageView?
     @IBOutlet private weak var emailLabel: UITextField?
-    @IBOutlet private weak var containerView: UIView?
+    @IBOutlet private var containerView: UIView!
 
     @IBOutlet private var containerViewMargins: [NSLayoutConstraint]!
     @IBOutlet private var gravatarImageViewSizeConstraints: [NSLayoutConstraint]!
@@ -23,9 +23,8 @@ class GravatarEmailTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        containerView?.layer.cornerRadius = 8
-        containerView?.layer.borderWidth = 0
-        containerView?.layer.borderColor = UIColor.gray.cgColor
+        containerView.layer.cornerRadius = 8
+        containerView.layer.borderColor = UIColor.gray.cgColor
     }
 
     /// Public Methods
@@ -46,12 +45,16 @@ class GravatarEmailTableViewCell: UITableViewCell {
 
         gravatarImageView?.downloadGravatarWithEmail(email, placeholderImage: placeholderImage ?? gridicon)
 
+        gravatarImageViewSizeConstraints.forEach { constraints in
+            constraints.constant = gridicon.size.width
+        }
+
         let margin: CGFloat = hasBorders ? 16 : 0
         containerViewMargins.forEach { constraint in
             constraint.constant = margin
         }
 
-        containerView?.layer.borderWidth = hasBorders ? 1 : 0
+        containerView.layer.borderWidth = hasBorders ? 1 : 0
     }
 
     func updateEmailAddress(_ email: String?) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -8,23 +8,35 @@ class GravatarEmailTableViewCell: UITableViewCell {
     ///
     @IBOutlet private weak var gravatarImageView: UIImageView?
     @IBOutlet private weak var emailLabel: UITextField?
+    @IBOutlet private weak var containerView: UIView?
+
+    @IBOutlet private var containerViewMargins: [NSLayoutConstraint]!
+    @IBOutlet private var gravatarImageViewSizeConstraints: [NSLayoutConstraint]!
 
     private let gridiconSize = CGSize(width: 48, height: 48)
+    private let girdiconSmallSize = CGSize(width: 32, height: 32)
 
     /// Public properties
     ///
     public static let reuseIdentifier = "GravatarEmailTableViewCell"
     public var onChangeSelectionHandler: ((_ sender: UITextField) -> Void)?
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        containerView?.layer.cornerRadius = 8
+        containerView?.layer.borderWidth = 0
+        containerView?.layer.borderColor = UIColor.gray.cgColor
+    }
+
     /// Public Methods
     ///
-    public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil) {
+    public func configure(withEmail email: String?, andPlaceholder placeholderImage: UIImage? = nil, hasBorders: Bool = false) {
         gravatarImageView?.tintColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         emailLabel?.textColor = WordPressAuthenticator.shared.unifiedStyle?.gravatarEmailTextColor ?? WordPressAuthenticator.shared.unifiedStyle?.textSubtleColor ?? WordPressAuthenticator.shared.style.subheadlineColor
         emailLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         emailLabel?.text = email
 
-        let gridicon = UIImage.gridicon(.userCircle, size: gridiconSize)
+        let gridicon: UIImage = hasBorders ? .gridicon(.userCircle, size: girdiconSmallSize) : .gridicon(.userCircle, size: gridiconSize)
 
         guard let email = email,
             email.isValidEmail() else {
@@ -33,6 +45,13 @@ class GravatarEmailTableViewCell: UITableViewCell {
         }
 
         gravatarImageView?.downloadGravatarWithEmail(email, placeholderImage: placeholderImage ?? gridicon)
+
+        let margin: CGFloat = hasBorders ? 16 : 0
+        containerViewMargins.forEach { constraint in
+            constraint.constant = margin
+        }
+
+        containerView?.layer.borderWidth = hasBorders ? 1 : 0
     }
 
     func updateEmailAddress(_ email: String?) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -1,60 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticator">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GravatarEmailTableViewCell" rowHeight="76" id="KGk-i7-Jjw" customClass="GravatarEmailTableViewCell" customModule="WordPressAuthenticator">
+            <rect key="frame" x="0.0" y="0.0" width="318" height="76"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
+                <rect key="frame" x="0.0" y="0.0" width="318" height="76"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPressAuthenticator">
-                        <rect key="frame" x="16" y="11" width="48" height="48"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ciD-RW-w3b">
+                        <rect key="frame" x="16" y="12" width="286" height="50"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="5X7-in-Ybt">
+                                <rect key="frame" x="0.0" y="0.0" width="286" height="50"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPressAuthenticator">
+                                        <rect key="frame" x="0.0" y="0.0" width="48" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="48" id="BHy-vU-hNn"/>
+                                            <constraint firstAttribute="height" constant="48" id="u4Z-Cy-2ey"/>
+                                        </constraints>
+                                    </imageView>
+                                    <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
+                                        <rect key="frame" x="59" y="0.0" width="227" height="50"/>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <accessibilityTraits key="traits" staticText="YES"/>
+                                        </accessibility>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="axC-0i-jGu"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <textInputTraits key="textInputTraits" textContentType="username"/>
+                                        <connections>
+                                            <action selector="textFieldDidChangeSelection" destination="KGk-i7-Jjw" eventType="editingChanged" id="CBE-yc-dqf"/>
+                                        </connections>
+                                    </textField>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="48" id="RU3-mW-PAl"/>
-                            <constraint firstAttribute="width" secondItem="odI-Gb-fXa" secondAttribute="height" multiplier="1:1" id="TSH-sA-5Pw"/>
-                            <constraint firstAttribute="width" constant="48" id="oKU-lB-dYx"/>
+                            <constraint firstAttribute="trailing" secondItem="5X7-in-Ybt" secondAttribute="trailing" id="6Hm-zP-IsX"/>
+                            <constraint firstItem="5X7-in-Ybt" firstAttribute="top" secondItem="ciD-RW-w3b" secondAttribute="top" id="6zZ-zk-nOw"/>
+                            <constraint firstAttribute="bottom" secondItem="5X7-in-Ybt" secondAttribute="bottom" id="QKK-EA-WiY"/>
+                            <constraint firstItem="5X7-in-Ybt" firstAttribute="leading" secondItem="ciD-RW-w3b" secondAttribute="leading" id="ccQ-62-Rq6"/>
                         </constraints>
-                    </imageView>
-                    <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
-                        <rect key="frame" x="75" y="13" width="229" height="44"/>
-                        <accessibility key="accessibilityConfiguration">
-                            <accessibilityTraits key="traits" staticText="YES"/>
-                        </accessibility>
-                        <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="axC-0i-jGu"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <textInputTraits key="textInputTraits" textContentType="username"/>
-                        <connections>
-                            <action selector="textFieldDidChangeSelection" destination="KGk-i7-Jjw" eventType="editingChanged" id="CBE-yc-dqf"/>
-                        </connections>
-                    </textField>
+                    </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="3kD-7a-MeN" firstAttribute="leading" secondItem="odI-Gb-fXa" secondAttribute="trailing" constant="11" id="M5P-4D-Dig"/>
-                    <constraint firstAttribute="trailing" secondItem="3kD-7a-MeN" secondAttribute="trailing" constant="16" id="Uu4-bo-sjK"/>
-                    <constraint firstItem="odI-Gb-fXa" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" constant="-2" id="YZD-yX-ic3"/>
-                    <constraint firstItem="3kD-7a-MeN" firstAttribute="centerY" secondItem="odI-Gb-fXa" secondAttribute="centerY" id="guc-Ls-SYV"/>
-                    <constraint firstItem="odI-Gb-fXa" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="hPB-Uy-lLS"/>
-                    <constraint firstItem="odI-Gb-fXa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="kVa-7e-I73"/>
+                    <constraint firstAttribute="trailing" secondItem="ciD-RW-w3b" secondAttribute="trailing" constant="16" id="B9M-NT-mor"/>
+                    <constraint firstItem="ciD-RW-w3b" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Bcs-Z7-G3C"/>
+                    <constraint firstItem="ciD-RW-w3b" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="ONh-bO-btb"/>
+                    <constraint firstAttribute="bottom" secondItem="ciD-RW-w3b" secondAttribute="bottom" constant="12" id="Uur-hS-olA"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="emailLabel" destination="3kD-7a-MeN" id="8Ck-Rg-3Cw"/>
                 <outlet property="gravatarImageView" destination="odI-Gb-fXa" id="eHP-78-0Fg"/>
+                <outletCollection property="containerViewMargins" destination="6Hm-zP-IsX" collectionClass="NSMutableArray" id="NPv-eW-Qzo"/>
+                <outletCollection property="containerViewMargins" destination="6zZ-zk-nOw" collectionClass="NSMutableArray" id="0Sj-gh-fsO"/>
+                <outletCollection property="containerViewMargins" destination="QKK-EA-WiY" collectionClass="NSMutableArray" id="Vg7-nB-xlI"/>
+                <outletCollection property="containerViewMargins" destination="ccQ-62-Rq6" collectionClass="NSMutableArray" id="4eH-Mi-Iif"/>
             </connections>
-            <point key="canvasLocation" x="131.8840579710145" y="126.5625"/>
+            <point key="canvasLocation" x="130.43478260869566" y="127.90178571428571"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -19,20 +19,21 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ciD-RW-w3b">
-                        <rect key="frame" x="16" y="12" width="286" height="50"/>
+                        <rect key="frame" x="16" y="12" width="286" height="48"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="5X7-in-Ybt">
-                                <rect key="frame" x="0.0" y="0.0" width="286" height="50"/>
+                                <rect key="frame" x="0.0" y="0.0" width="286" height="48"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="odI-Gb-fXa" customClass="CircularImageView" customModule="WordPressAuthenticator">
-                                        <rect key="frame" x="0.0" y="0.0" width="48" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="48" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="48" id="BHy-vU-hNn"/>
+                                            <constraint firstAttribute="width" secondItem="odI-Gb-fXa" secondAttribute="height" multiplier="1:1" id="McZ-Z1-Yaf"/>
                                             <constraint firstAttribute="height" constant="48" id="u4Z-Cy-2ey"/>
                                         </constraints>
                                     </imageView>
                                     <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Email Label" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3kD-7a-MeN">
-                                        <rect key="frame" x="59" y="0.0" width="227" height="50"/>
+                                        <rect key="frame" x="59" y="0.0" width="227" height="48"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" staticText="YES"/>
                                         </accessibility>

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.xib
@@ -67,12 +67,15 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="containerView" destination="ciD-RW-w3b" id="Cjj-in-9Su"/>
                 <outlet property="emailLabel" destination="3kD-7a-MeN" id="8Ck-Rg-3Cw"/>
                 <outlet property="gravatarImageView" destination="odI-Gb-fXa" id="eHP-78-0Fg"/>
                 <outletCollection property="containerViewMargins" destination="6Hm-zP-IsX" collectionClass="NSMutableArray" id="NPv-eW-Qzo"/>
                 <outletCollection property="containerViewMargins" destination="6zZ-zk-nOw" collectionClass="NSMutableArray" id="0Sj-gh-fsO"/>
                 <outletCollection property="containerViewMargins" destination="QKK-EA-WiY" collectionClass="NSMutableArray" id="Vg7-nB-xlI"/>
                 <outletCollection property="containerViewMargins" destination="ccQ-62-Rq6" collectionClass="NSMutableArray" id="4eH-Mi-Iif"/>
+                <outletCollection property="gravatarImageViewSizeConstraints" destination="BHy-vU-hNn" collectionClass="NSMutableArray" id="B4z-MU-OXS"/>
+                <outletCollection property="gravatarImageViewSizeConstraints" destination="u4Z-Cy-2ey" collectionClass="NSMutableArray" id="3se-X1-5CQ"/>
             </connections>
             <point key="canvasLocation" x="130.43478260869566" y="127.90178571428571"/>
         </tableViewCell>


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/7899, https://github.com/woocommerce/woocommerce-ios/issues/7900, and https://github.com/woocommerce/woocommerce-ios/issues/7901.
## Description
This PR adds a few updates to support the simplified login flow in the Woo app. We planned to duplicate the screens, but it seems to take so much more time, so I went for conditional checks instead.
- New config `enableSimplifiedLoginI1` to update the prologue, get started, and password screens to not mention the WP.com account during login.
- New config `enableSiteCreationForSimplifiedLoginI1` to show the secondary button in the prologue screen for simplified login.
- New delegate method `showSiteCreation` to ask the host app to navigate to site creation when the site creation button on the prologue screen is tapped.
- Prologue screen: new buttons for simplified login.
- Get Started screen: Pin the Continue button to the bottom for simplified login
- Password screen: show instruction text for WP.com password in simplified login (I'm keeping the screen for WP.org password as-is).

## Testing
Please follow the PR https://github.com/woocommerce/woocommerce-ios/pull/7929 for instructions to test the changes here.
