### PR TITLE
Allow the host app to pass a custom source identifier to the login flow

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.3.0-beta.1'
+  s.version       = '3.3.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -19,6 +19,10 @@ import WordPressKit
     ///
     private var appleIDCredentialObserver: NSObjectProtocol?
 
+    /// Optional sign in source that could be from the login prologue or the host app to track the entry point
+    /// for customizations in the epilogue handling.
+    var signInSource: SignInSource?
+
     /// Shared Instance.
     ///
     @objc public static var shared: WordPressAuthenticator {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -54,7 +54,12 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void)
+    /// - Parameters:
+    ///   - navigationController: navigation stack for any epilogue views to be shown on.
+    ///   - credentials: WPCOM or WPORG credentials.
+    ///   - source: an optional identifier of the login flow, can be from the login prologue or provided by the host app.
+    ///   - onDismiss: called when the auth flow is dismissed.
+    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, source: SignInSource?, onDismiss: @escaping () -> Void)
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -3,7 +3,12 @@ import Foundation
 /// Navigates to the unified "Continue with WordPress.com" flow.
 ///
 public struct NavigateToEnterAccount: NavigationCommand {
-    public init() {}
+    private let signInSource: SignInSource
+
+    public init(signInSource: SignInSource) {
+        self.signInSource = signInSource
+    }
+
     public func execute(from: UIViewController?) {
         continueWithDotCom(navigationController: from?.navigationController)
     }
@@ -15,7 +20,7 @@ private extension NavigateToEnterAccount {
             DDLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
             return
         }
-        vc.source = .wpCom
+        vc.source = signInSource
 
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -172,7 +172,9 @@ private extension AppleAuthenticator {
             fatalError()
         }
 
-        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) {}
+        authenticationDelegate.presentLoginEpilogue(in: navigationController,
+                                                    for: credentials,
+                                                    source: WordPressAuthenticator.shared.signInSource) {}
     }
 
     func signupFailed(with error: Error) {

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -144,7 +144,9 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             fatalError()
         }
 
-        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
+        authenticationDelegate.presentLoginEpilogue(in: navigationController,
+                                                    for: credentials,
+                                                    source: WordPressAuthenticator.shared.signInSource) { [weak self] in
             self?.dismissBlock?(false)
         }
     }

--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -179,7 +179,10 @@ extension StoredCredentialsAuthenticator {
             return
         }
 
-        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: {})
+        authenticationDelegate.presentLoginEpilogue(in: navigationController,
+                                                    for: credentials,
+                                                    source: WordPressAuthenticator.shared.signInSource,
+                                                    onDismiss: {})
     }
 
     /// Presents the login email screen, displaying the specified error.  This is useful

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -3,11 +3,13 @@ import SafariServices
 import WordPressKit
 
 /// The source for the sign in flow for external tracking.
-public enum SignInSource {
+public enum SignInSource: Equatable {
     /// Initiated from the WP.com login CTA.
     case wpCom
     /// Initiated from the WP.com login flow that starts with site address.
     case wpComSiteAddress
+    /// Other source identifier from the host app.
+    case custom(source: String)
 }
 
 /// The error during the sign in flow.
@@ -66,7 +68,11 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
     // This is public so it can be set from StoredCredentialsAuthenticator.
     var errorMessage: String?
 
-    var source: SignInSource?
+    var source: SignInSource? {
+        didSet {
+            WordPressAuthenticator.shared.signInSource = source
+        }
+    }
 
     private var rows = [Row]()
     private var buttonViewController: NUXButtonViewController?

--- a/WordPressAuthenticatorTests/Navigation/NavigationToEnterAccountTests.swift
+++ b/WordPressAuthenticatorTests/Navigation/NavigationToEnterAccountTests.swift
@@ -6,7 +6,7 @@ final class NavigationToAccountTests: XCTestCase {
         let origin = UIViewController()
         let navigationController = MockNavigationController(rootViewController: origin)
 
-        let command = NavigateToEnterAccount()
+        let command = NavigateToEnterAccount(signInSource: .wpCom)
         command.execute(from: origin)
 
         let pushedViewController = navigationController.pushedViewController


### PR DESCRIPTION
⚠️ Please note that this PR includes a breaking change to the `WordPressAuthenticatorDelegate` protocol and `NavigateToEnterAccount` initializer, any host app that uses these needs to update its implementation.

## Why

For store creation in WCiOS, the user could enter the store creation flow but choose to log in instead of signing up for an account in the app. Since the login flow is completely handled in the WPAuthententicator library, starting either from the login prologue or via `NavigateToEnterAccount`, we want to pass a source identifier in order for the app to continue the store creation flow instead of the usual login completion path (store picker).

## Changes

An optional `SignInSource` was added to `WordPressAuthenticatorDelegate.presentLoginEpilogue`. In order for the source to be accessed in various places that can call `WordPressAuthenticatorDelegate.presentLoginEpilogue`, I decided to add a variable to the global singleton `WordPressAuthenticator` (it's not the cleanest, but if we don't do this we have to DI this source in so many classes with potential misses). When `GetStartedViewController.source` is set, it also sets `WordPressAuthenticator.signInSource`. This value in the singleton is then used in call sites of `WordPressAuthenticatorDelegate.presentLoginEpilogue` to pass the source to the host app.

## Testing steps

Please check out the WCiOS PR.