### PR TITLE
Bump version from 3.3.0-beta.2 to 4.0.0

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '3.3.0-beta.2'
+  s.version       = '4.0.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
A breaking change was introduced with this PR (see its description), so I bumped it to 4.0.0: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/692

