### PR TITLE
Add `PULL_REQUEST_TEMPLATE.md` with mention of `CHANGELOG.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+
+---
+
+- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,23 @@ _None._
 
 ### Internal Changes
 
+_None._
+
+## [4.0.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.0.0)
+
+### Breaking Changes
+
+- Allow the host app to pass a custom source identifier to the login flow. [#692]
+
+### New Features
+
+- New configuration options for the simplified login flow. [#691]
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
 - Add this changelog file. [#690]
+- Remove Alamofire as an explicit dependency. [#689]


### PR DESCRIPTION
Looking at the PRs in 4.0.0, I noticed they didn't update the `CHANGELOG.md` and realized I hadn't updated the PR template, which definitely didn't help with discoverability.

This PR addresses that, plus retroactively updates the changelog for 4.0.0, just to keep things consistent.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.