### PR TITLE
Bump version to 4.1.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   plugins: &common_plugins
   - automattic/bash-cache#2.8.0
   env: &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14
 
 # This is the default pipeline – it will build and test the pod
 steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## 4.1.0-beta.1 [Unreleased]
+## 4.2.0 [Unreleased]
 
 ### Breaking Changes
 
@@ -38,12 +38,22 @@ _None._
 
 ### New Features
 
-- New `NUXStackedButtonsViewController` with two stack views and a configurable OR divider. by @selanthiraiyan [#695]
-- Add OR divider colors to `WordPressAuthenticatorStyle` with default values. @selanthiraiyan [#695]
+_None._
 
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## [4.1.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.1.0)
+
+### New Features
+
+- New `NUXStackedButtonsViewController` with two stack views and a configurable OR divider. by @selanthiraiyan [#695]
+- Add OR divider colors to `WordPressAuthenticatorStyle` with default values. @selanthiraiyan [#695]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ _None._
 
 _None._
 
-## [4.1.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.1.0)
+## [4.1.1](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.1.1)
 
 ### New Features
 

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '4.1.0'
+  s.version       = '4.1.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '4.1.0-beta.1'
+  s.version       = '4.1.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This is my first release after the `CHANGELOG.md` introduction, so hopefully it's done correctly 🤞 

Note that the initial commit failed with `VM xcode-13.4.1 is invalid` so I updated the xcode image to 14 which is the image that is in use in WCiOS.

**Question:** Does the `.xcversion` file need to be updated to `14.0` as well? I am guessing yes, but I am not familiar with the xcode version updates, so I'd appreciate some help.

**Update**
---
I had a few CI failures during publishing of the `4.1.0` version and ended up having to bump the version to `4.1.1`.