### PR TITLE
Config to check XMLRPC only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- New property in `WordPressAuthenticatorConfiguration` to check XMLRPC only when the user opts to sign in using .org site credentials. by @selanthiraiyan [#700]
 
 ### Bug Fixes
 

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '4.1.1'
+  s.version       = '4.2.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		D881A315256B5B5800FE5605 /* NavigateToEnterAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */; };
 		E8AF6B9EF50902F2117DFAF9 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A441EC80D2B8D2209C2E228 /* Pods_WordPressAuthenticatorTests.framework */; };
 		EE633D02287560E50002DE03 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE633D01287560E50002DE03 /* UITableView+Helpers.swift */; };
+		EE9F665E291A65C4009A5B02 /* NSError+XMLRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9F665D291A65C4009A5B02 /* NSError+XMLRPC.swift */; };
 		EEC7A621290FAEE5007793EE /* NUXStackedButtonsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC7A61F290FAEE5007793EE /* NUXStackedButtonsViewController.swift */; };
 		EEEAC912289272F20066D419 /* VerifyEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEAC911289272F20066D419 /* VerifyEmailViewController.swift */; };
 		EEEAC9142892731E0066D419 /* VerifyEmail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EEEAC9132892731E0066D419 /* VerifyEmail.storyboard */; };
@@ -391,6 +392,7 @@
 		D881A314256B5B5800FE5605 /* NavigateToEnterAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigateToEnterAccount.swift; sourceTree = "<group>"; };
 		E9414A95E29F3297555AC92B /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
 		EE633D01287560E50002DE03 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
+		EE9F665D291A65C4009A5B02 /* NSError+XMLRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+XMLRPC.swift"; sourceTree = "<group>"; };
 		EEC7A61F290FAEE5007793EE /* NUXStackedButtonsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NUXStackedButtonsViewController.swift; sourceTree = "<group>"; };
 		EEEAC911289272F20066D419 /* VerifyEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyEmailViewController.swift; sourceTree = "<group>"; };
 		EEEAC9132892731E0066D419 /* VerifyEmail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = VerifyEmail.storyboard; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 				F11448EB258B827B0048203D /* URL+JetpackConnect.swift */,
 				EE633D01287560E50002DE03 /* UITableView+Helpers.swift */,
 				02A526CC28A3A23900FD1812 /* UIButton+Styles.swift */,
+				EE9F665D291A65C4009A5B02 /* NSError+XMLRPC.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1283,6 +1286,7 @@
 				B56090E6208A4F9D00399AE4 /* WPNUXPrimaryButton.m in Sources */,
 				CE9091F72499549500AB50BD /* TextFieldTableViewCell.swift in Sources */,
 				98BC47E324F5B9AF000275AD /* GetStartedViewController.swift in Sources */,
+				EE9F665E291A65C4009A5B02 /* NSError+XMLRPC.swift in Sources */,
 				B5609135208A563800399AE4 /* LoginWPComViewController.swift in Sources */,
 				CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */,
 				B5609119208A555600399AE4 /* SiteInfoHeaderView.swift in Sources */,

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -132,6 +132,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let wpcomPasswordInstructions: String?
 
+    /// If enabled XMLRPC related checks will be performed only when the user opts to sign in using site credentials
+    ///
+    let checkXMLRPCOnlyIfSigningInUsingSiteCredentials: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -161,7 +165,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSiteCreation: Bool = false,
                  enableSocialLogin: Bool = false,
                  emphasizeEmailForWPComPassword: Bool = false,
-                 wpcomPasswordInstructions: String? = nil) {
+                 wpcomPasswordInstructions: String? = nil,
+                 checkXMLRPCOnlyIfSigningInUsingSiteCredentials: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -191,5 +196,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableSocialLogin = enableSocialLogin
         self.emphasizeEmailForWPComPassword = emphasizeEmailForWPComPassword
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
+        self.checkXMLRPCOnlyIfSigningInUsingSiteCredentials = checkXMLRPCOnlyIfSigningInUsingSiteCredentials
     }
 }

--- a/WordPressAuthenticator/Extensions/NSError+XMLRPC.swift
+++ b/WordPressAuthenticator/Extensions/NSError+XMLRPC.swift
@@ -4,7 +4,7 @@ import WordPressKit
 /// Helper methods for XMLRPC validation related errors
 ///
 extension NSError {
-    func originalErrorOrError() -> NSError {
+    func extractXMLRPCError() -> NSError {
         guard let err = userInfo[XMLRPCOriginalErrorKey] as? NSError else {
             return self
         }

--- a/WordPressAuthenticator/Extensions/NSError+XMLRPC.swift
+++ b/WordPressAuthenticator/Extensions/NSError+XMLRPC.swift
@@ -1,5 +1,8 @@
 import Foundation
+import WordPressKit
 
+/// Helper methods for XMLRPC validation related errors
+///
 extension NSError {
     func originalErrorOrError() -> NSError {
         guard let err = userInfo[XMLRPCOriginalErrorKey] as? NSError else {
@@ -7,5 +10,19 @@ extension NSError {
         }
 
         return err
+    }
+
+    func errorMessage() -> String? {
+        if let xmlrpcValidatorError = self as? WordPressOrgXMLRPCValidatorError {
+            return xmlrpcValidatorError.localizedDescription
+        } else if (domain == NSURLErrorDomain && code == NSURLErrorCannotFindHost) ||
+                    (domain == NSURLErrorDomain && code == NSURLErrorNetworkConnectionLost) {
+            // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
+           return NSLocalizedString(
+                "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
+                comment: "Error message shown a URL does not point to an existing site.")
+        }
+
+        return nil
     }
 }

--- a/WordPressAuthenticator/Extensions/NSError+XMLRPC.swift
+++ b/WordPressAuthenticator/Extensions/NSError+XMLRPC.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension NSError {
+    func originalErrorOrError() -> NSError {
+        guard let err = userInfo[XMLRPCOriginalErrorKey] as? NSError else {
+            return self
+        }
+
+        return err
+    }
+}

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -86,6 +86,22 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         presentingController.present(controller, animated: true, completion: nil)
     }
 
+    /// Push a custom view controller, provided by a host app, to the navigation stack
+    ///
+    /// Takes care of adding support button if enabled.
+    ///
+    public func pushCustomUIViewController(_ customUI: UIViewController) {
+        /// Assign the help button of the newly injected UI to the same help button we are currently displaying
+        /// We are making a somewhat big assumption here: the chrome of the new UI we insert would look like the UI
+        /// WPAuthenticator is already displaying. Which is risky, but also kind of makes sense, considering
+        /// we are also pushing that injected UI to the current navigation controller.
+        if WordPressAuthenticator.shared.delegate?.supportActionEnabled == true {
+            customUI.navigationItem.rightBarButtonItems = navigationItem.rightBarButtonItems
+        }
+
+        navigationController?.pushViewController(customUI, animated: true)
+    }
+
     /// It is assumed that NUX view controllers are always presented modally.
     ///
     func dismiss() {

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -171,7 +171,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             WordPressAuthenticator.track(.loginFailed, error: error)
             self.configureViewLoading(false)
 
-            let err = self.originalErrorOrError(error: error as NSError)
+            let err = (error as NSError).originalErrorOrError()
 
             if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
                 self.displayError(message: xmlrpcValidatorError.localizedDescription, moveVoiceOverFocus: true)
@@ -233,13 +233,6 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                 break
             }
         })
-    }
-
-    @objc func originalErrorOrError(error: NSError) -> NSError {
-        guard let err = error.userInfo[XMLRPCOriginalErrorKey] as? NSError else {
-            return error
-        }
-        return err
     }
 
     /// Here we will continue with the self-hosted flow.

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -171,21 +171,12 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             WordPressAuthenticator.track(.loginFailed, error: error)
             self.configureViewLoading(false)
 
-            let err = (error as NSError).originalErrorOrError()
+            let extractedXMLRPCError = (error as NSError).extractXMLRPCError()
 
-            if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                self.displayError(message: xmlrpcValidatorError.localizedDescription, moveVoiceOverFocus: true)
-
-            } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
-                (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
-                // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
-                let msg = NSLocalizedString(
-                    "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
-                    comment: "Error message shown a URL does not point to an existing site.")
-                self.displayError(message: msg, moveVoiceOverFocus: true)
-
+            if let errorMessage = extractedXMLRPCError.errorMessage() {
+                self.displayErrorAlert(errorMessage, sourceTag: self.sourceTag)
             } else {
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                self.displayError(extractedXMLRPCError, sourceTag: self.sourceTag)
             }
         })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -915,7 +915,7 @@ private extension GetStartedViewController {
                 /// If it does, insert the custom UI provided by the host app and exit early
                 if self.authenticationDelegate.shouldHandleError(xmlrpcError) {
                     self.authenticationDelegate.handleError(xmlrpcError) { customUI in
-                        self.pushCustomUI(customUI)
+                        self.pushCustomUIViewController(customUI)
                     }
 
                     return
@@ -928,19 +928,6 @@ private extension GetStartedViewController {
                     self.displayError(extractedXMLRPCError, sourceTag: self.sourceTag)
                 }
         })
-    }
-
-    /// Push a custom view controller, provided by a host app, to the navigation stack
-    func pushCustomUI(_ customUI: UIViewController) {
-        /// Assign the help button of the newly injected UI to the same help button we are currently displaying
-        /// We are making a somewhat big assumption here: the chrome of the new UI we insert would look like the UI
-        /// WPAuthenticator is already displaying. Which is risky, but also kind of makes sense, considering
-        /// we are also pushing that injected UI to the current navigation controller.
-        if WordPressAuthenticator.shared.delegate?.supportActionEnabled == true {
-            customUI.navigationItem.rightBarButtonItems = navigationItem.rightBarButtonItems
-        }
-
-        navigationController?.pushViewController(customUI, animated: true)
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -876,7 +876,9 @@ private extension GetStartedViewController {
 // MARK: - XMLRPC checks
 
 private extension GetStartedViewController {
-    func configureSiteCredsButton(loading: Bool) {
+    /// Configures the buttons and navigation item
+    ///
+    func configureScreenForRunningXMLRPCChecks(loading: Bool) {
         buttonViewController?.setTopButtonState(isLoading: false,
                                                 isEnabled: !loading)
         buttonViewController?.setBottomButtonState(isLoading: loading,
@@ -887,11 +889,11 @@ private extension GetStartedViewController {
     /// Navigates to site credentials screen where .org site credentials can be entered
     ///
     func guessXMLRPCURL(for siteAddress: String) {
-        configureSiteCredsButton(loading: true)
+        configureScreenForRunningXMLRPCChecks(loading: true)
 
         let facade = WordPressXMLRPCAPIFacade()
         facade.guessXMLRPCURL(forSite: siteAddress, success: { [weak self] (url) in
-            self?.configureSiteCredsButton(loading: false)
+            self?.configureScreenForRunningXMLRPCChecks(loading: false)
 
             if let url = url {
                 self?.loginFields.meta.xmlrpcURL = url as NSURL
@@ -906,7 +908,7 @@ private extension GetStartedViewController {
 
                 self.tracker.track(failure: error.localizedDescription)
 
-                self.configureSiteCredsButton(loading: false)
+                self.configureScreenForRunningXMLRPCChecks(loading: false)
 
                 let xmlrpcError = XMLRPCError.xmlrpcError(siteAddress: siteAddress)
                 /// Check if the host app wants to provide custom UI to handle the error.

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -951,10 +951,10 @@ private extension GetStartedViewController {
         /// WPAuthenticator is already displaying. Which is risky, but also kind of makes sense, considering
         /// we are also pushing that injected UI to the current navigation controller.
         if WordPressAuthenticator.shared.delegate?.supportActionEnabled == true {
-            customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
+            customUI.navigationItem.rightBarButtonItems = navigationItem.rightBarButtonItems
         }
 
-        self.navigationController?.pushViewController(customUI, animated: true)
+        navigationController?.pushViewController(customUI, animated: true)
     }
 }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -921,7 +921,7 @@ private extension GetStartedViewController {
                     return
                 }
 
-                let err = self.originalErrorOrError(error: error as NSError)
+                let err = (error as NSError).originalErrorOrError()
 
                 if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
                     self.displayErrorAlert(xmlrpcValidatorError.localizedDescription, sourceTag: self.sourceTag)
@@ -937,15 +937,6 @@ private extension GetStartedViewController {
                     self.displayError(error as NSError, sourceTag: self.sourceTag)
                 }
         })
-    }
-
-    /// Extracts XMLRPC error
-    ///
-    func originalErrorOrError(error: NSError) -> NSError {
-        guard let err = error.userInfo[XMLRPCOriginalErrorKey] as? NSError else {
-            return error
-        }
-        return err
     }
 
     /// Push a custom view controller, provided by a host app, to the navigation stack

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -319,7 +319,13 @@ private extension GetStartedViewController {
     // MARK: - Sign in with site credentials Button Action
     @objc func handleSiteCredentialsButtonTapped() {
         tracker.track(click: .signInWithSiteCredentials)
-        goToSiteCredentialsScreen()
+        guard WordPressAuthenticator.shared.configuration.checkXMLRPCOnlyIfSigningInUsingSiteCredentials else {
+            // XMLRPC already checked in "Enter site address" screen.
+            return goToSiteCredentialsScreen()
+        }
+
+        // Check XMLRPC before asking for site credentials.
+        guessXMLRPCURL(for: loginFields.siteAddress)
     }
 
     // MARK: - What is WordPress.com Button Action

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -939,6 +939,8 @@ private extension GetStartedViewController {
         })
     }
 
+    /// Extracts XMLRPC error
+    ///
     func originalErrorOrError(error: NSError) -> NSError {
         guard let err = error.userInfo[XMLRPCOriginalErrorKey] as? NSError else {
             return error

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -921,20 +921,11 @@ private extension GetStartedViewController {
                     return
                 }
 
-                let err = (error as NSError).originalErrorOrError()
-
-                if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                    self.displayErrorAlert(xmlrpcValidatorError.localizedDescription, sourceTag: self.sourceTag)
-                } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
-                            (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
-                    // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
-                    let msg = NSLocalizedString(
-                        "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
-                        comment: "Error message shown a URL does not point to an existing site.")
-                    self.displayErrorAlert(msg, sourceTag: self.sourceTag)
-
+                let extractedXMLRPCError = (error as NSError).extractXMLRPCError()
+                if let errorMessage = extractedXMLRPCError.errorMessage() {
+                    self.displayErrorAlert(errorMessage, sourceTag: self.sourceTag)
                 } else {
-                    self.displayError(error as NSError, sourceTag: self.sourceTag)
+                    self.displayError(extractedXMLRPCError, sourceTag: self.sourceTag)
                 }
         })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -319,7 +319,7 @@ private extension GetStartedViewController {
     // MARK: - Sign in with site credentials Button Action
     @objc func handleSiteCredentialsButtonTapped() {
         tracker.track(click: .signInWithSiteCredentials)
-        guard WordPressAuthenticator.shared.configuration.checkXMLRPCOnlyIfSigningInUsingSiteCredentials else {
+        guard configuration.checkXMLRPCOnlyIfSigningInUsingSiteCredentials else {
             // XMLRPC already checked in "Enter site address" screen.
             return goToSiteCredentialsScreen()
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -34,6 +34,12 @@ public enum SignInError: Error {
     }
 }
 
+/// Error due to site's `xmlrpc.php` file not being public
+///
+public enum XMLRPCError: Error {
+    case xmlrpcError(siteAddress: String)
+}
+
 class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
 
     private enum ScreenMode {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -377,19 +377,6 @@ private extension SiteAddressViewController {
         }
     }
 
-    /// Push a custom view controller, provided by a host app, to the navigation stack
-    func pushCustomUI(_ customUI: UIViewController) {
-        /// Assign the help button of the newly injected UI to the same help button we are currently displaying
-        /// We are making a somewhat big assumption here: the chrome of the new UI we insert would look like the UI
-        /// WPAuthenticator is already displaying. Which is risky, but also kind of makes sense, considering
-        /// we are also pushing that injected UI to the current navigation controller.
-        if WordPressAuthenticator.shared.delegate?.supportActionEnabled == true {
-            customUI.navigationItem.rightBarButtonItems = self.navigationItem.rightBarButtonItems
-        }
-
-        self.navigationController?.pushViewController(customUI, animated: true)
-    }
-
     // MARK: - Private Constants
 
     /// Rows listed in the order they were created.
@@ -465,7 +452,7 @@ private extension SiteAddressViewController {
 
                     if self.authenticationDelegate.shouldHandleError(error) {
                         self.authenticationDelegate.handleError(error) { customUI in
-                            self.pushCustomUI(customUI)
+                            self.pushCustomUIViewController(customUI)
                         }
                         return
                     }
@@ -514,7 +501,7 @@ private extension SiteAddressViewController {
                 /// If it does, insert the custom UI provided by the host app and exit early
                 if self.authenticationDelegate.shouldHandleError(extractedXMLRPCError) {
                     self.authenticationDelegate.handleError(extractedXMLRPCError) { customUI in
-                        self.pushCustomUI(customUI)
+                        self.pushCustomUIViewController(customUI)
                     }
 
                     return
@@ -599,7 +586,7 @@ private extension SiteAddressViewController {
             case .presentEmailController:
                 self.showGetStarted()
             case let .injectViewController(customUI):
-                self.pushCustomUI(customUI)
+                self.pushCustomUIViewController(customUI)
             }
         })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -508,31 +508,22 @@ private extension SiteAddressViewController {
                     return
                 }
 
-                let err = (error as NSError).originalErrorOrError()
+                let extractedXMLRPCError = (error as NSError).extractXMLRPCError()
 
                 /// Check if the host app wants to provide custom UI to handle the error.
                 /// If it does, insert the custom UI provided by the host app and exit early
-                if self.authenticationDelegate.shouldHandleError(err) {
-                    self.authenticationDelegate.handleError(err) { customUI in
+                if self.authenticationDelegate.shouldHandleError(extractedXMLRPCError) {
+                    self.authenticationDelegate.handleError(extractedXMLRPCError) { customUI in
                         self.pushCustomUI(customUI)
                     }
 
                     return
                 }
 
-                if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                    self.displayError(message: xmlrpcValidatorError.localizedDescription, moveVoiceOverFocus: true)
-
-                } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
-                    (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
-                    // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
-                    let msg = NSLocalizedString(
-                        "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
-                        comment: "Error message shown a URL does not point to an existing site.")
-                    self.displayError(message: msg, moveVoiceOverFocus: true)
-
+                if let errorMessage = extractedXMLRPCError.errorMessage() {
+                    self.displayErrorAlert(errorMessage, sourceTag: self.sourceTag)
                 } else {
-                    self.displayError(error as NSError, sourceTag: self.sourceTag)
+                    self.displayError(extractedXMLRPCError, sourceTag: self.sourceTag)
                 }
         })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -442,8 +442,13 @@ private extension SiteAddressViewController {
         // Checks that the site exists
         checkSiteExistence(url: url) { [weak self] in
             guard let self = self else { return }
-            // Proceeds to check for the site's WordPress
-            self.guessXMLRPCURL(for: self.loginFields.siteAddress)
+
+            guard WordPressAuthenticator.shared.configuration.checkXMLRPCOnlyIfSigningInUsingSiteCredentials else {
+                return self.guessXMLRPCURL(for: self.loginFields.siteAddress)
+            }
+
+            // Skip checking XMLRPC
+            self.fetchSiteInfo()
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -508,7 +508,7 @@ private extension SiteAddressViewController {
                     return
                 }
 
-                let err = self.originalErrorOrError(error: error as NSError)
+                let err = (error as NSError).originalErrorOrError()
 
                 /// Check if the host app wants to provide custom UI to handle the error.
                 /// If it does, insert the custom UI provided by the host app and exit early
@@ -611,14 +611,6 @@ private extension SiteAddressViewController {
                 self.pushCustomUI(customUI)
             }
         })
-    }
-
-    func originalErrorOrError(error: NSError) -> NSError {
-        guard let err = error.userInfo[XMLRPCOriginalErrorKey] as? NSError else {
-            return error
-        }
-
-        return err
     }
 
     /// Here we will continue with the self-hosted flow.


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-ios/pull/8054 and https://github.com/woocommerce/woocommerce-ios/issues/8049

### Changes

To be able to defer the XMLRPC checks this PR adds a new configuration property to `WordPressAuthenticatorConfiguration`.
- New error to handle XMLRPC check related failures
- If the property `checkXMLRPCOnlyIfSigningInUsingSiteCredentials` is enabled 
  - XMLRPC checks will be skipped in `SiteAddressViewController`
  - XMLRPC checks will be run in `GetStartedViewController`
  - A loading indicator will be displayed over sign in using site credentials button while running XMLRPC checks.
  - In case of a failure `XMLRPCError` is sent via delegate. (Handled in Woo)
- If the property `checkXMLRPCOnlyIfSigningInUsingSiteCredentials` is disable (default value)
  -  There should be no change to the existing behaviour. 

### Testing
Please follow the testing instructions from https://github.com/woocommerce/woocommerce-ios/pull/8054

### Screenshot

| | Dark | Light |
|-|-|-|
| Loading indicator in "Sign in with store credentials" button | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-11-08 at 08 58 42](https://user-images.githubusercontent.com/524475/200469261-d1c153ab-6f9b-419f-bdb0-e3bda9b40900.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-11-08 at 08 59 01](https://user-images.githubusercontent.com/524475/200469269-390d9216-4a61-4611-a9b7-bd0b892476e4.png) |
