### PR TITLE
New tracking event for XMLRPC error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ _None._
 
 _None._
 
-### New Features
+- New tracking event for XMLRPC related failure. by @selanthiraiyan [#701]  
 
 _None._
 

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '4.1.1'
+  s.version       = '4.2.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -360,6 +360,12 @@ public class AuthenticatorAnalyticsTracker {
         track(event(click: click))
     }
 
+    /// Track a predefined failure enum.
+    ///
+    public func track(failure: Failure) {
+        track(failure: failure.rawValue)
+    }
+
     /// Track a failure.
     ///
     public func track(failure: String) {

--- a/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -264,6 +264,12 @@ public class AuthenticatorAnalyticsTracker {
         case loginWithAccountPassword = "login_with_password"
     }
 
+    public enum Failure: String {
+        /// Failure to guess XMLRPC URL
+        ///
+        case loginFailedToGuessXMLRPC = "login_failed_to_guess_xmlrpc_url"
+    }
+
     /// Shared Instance.
     ///
     public static var shared: AuthenticatorAnalyticsTracker = {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -493,9 +493,9 @@ private extension SiteAddressViewController {
                 // It's not guaranteed to be included in the error object depending on the error.
                 DDLogInfo("Error attempting to connect to site address: \(self.loginFields.siteAddress)")
                 DDLogError(error.localizedDescription)
-                // TODO: - Tracks.
-                // WordPressAuthenticator.track(.loginFailedToGuessXMLRPC, error: error)
-                // WordPressAuthenticator.track(.loginFailed, error: error)
+
+                self.tracker.track(failure: .loginFailedToGuessXMLRPC)
+
                 self.configureViewLoading(false)
 
                 guard self.isSiteDiscovery == false else {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -505,27 +505,41 @@ private extension SiteAddressViewController {
 
                 let err = self.originalErrorOrError(error: error as NSError)
 
+                let errorMessage: String? = {
+                    if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
+                        return xmlrpcValidatorError.localizedDescription
+                    } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
+                                (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
+                        // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
+                        let msg = NSLocalizedString(
+                            "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
+                            comment: "Error message shown a URL does not point to an existing site.")
+                        return msg
+                    } else {
+                        return nil
+                    }
+                }()
+
                 /// Check if the host app wants to provide custom UI to handle the error.
                 /// If it does, insert the custom UI provided by the host app and exit early
                 if self.authenticationDelegate.shouldHandleError(err) {
+
+                    // Send the error to the host app
                     self.authenticationDelegate.handleError(err) { customUI in
                         self.pushCustomUI(customUI)
                     }
 
+                    // Track error message as failure
+                    if let message = errorMessage {
+                        self.tracker.track(failure: message)
+                    }
+
+                    // Return as the error has been handled by the host app.
                     return
                 }
 
-                if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                    self.displayError(message: xmlrpcValidatorError.localizedDescription, moveVoiceOverFocus: true)
-
-                } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
-                    (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {
-                    // NSURLErrorNetworkConnectionLost can be returned when an invalid URL is entered.
-                    let msg = NSLocalizedString(
-                        "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.",
-                        comment: "Error message shown a URL does not point to an existing site.")
-                    self.displayError(message: msg, moveVoiceOverFocus: true)
-
+                if let message = errorMessage {
+                    self.displayError(message: message, moveVoiceOverFocus: true)
                 } else {
                     self.displayError(error as NSError, sourceTag: self.sourceTag)
                 }


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-ios/issues/8063

This PR adds a new event for tracking XMLRPC URL guessing failures.

### Changes
- New `Failure` enum to track failures.
- Track `loginFailedToGuessXMLRPC` event when guessing XMLRPC fails.

### Testing instructions
Please follow the testing instructions from - https://github.com/woocommerce/woocommerce-ios/pull/8064

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
