### PR TITLE
Merge 4.2.0 final to trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,13 @@ _None._
 
 -->
 
-## 4.2.0 [Unreleased]
+## Unreleased
 
 ### Breaking Changes
 
 _None._
 
-- New tracking event for XMLRPC related failure. by @selanthiraiyan [#701]  
+### New Features
 
 _None._
 
@@ -47,6 +47,12 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 4.2.0
+
+### New Features
+
+- New tracking event for XMLRPC related failure. by @selanthiraiyan [#701]  
 
 ## [4.1.1](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.1.1)
 

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '4.2.0-beta.1'
+  s.version       = '4.2.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
In #701, the `New Features` header was removed from `4.2.0` in the `CHANGELOG.md`, so I've re-added it for the release. I also created the new section with the `Unreleased` header as suggested by @mokagio [here](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/699#discussion_r1014975366).