### PR TITLE
Run `bundle exec pod install` to track new version in demo app

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (1.6.0)
-  - WordPressAuthenticator (4.1.1):
+  - WordPressAuthenticator (4.2.0):
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
@@ -109,7 +109,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
-  WordPressAuthenticator: 1bcc5090c1f0f774162ffc58db32906d9b9e775c
+  WordPressAuthenticator: 3bbb0a33f2c1d7bda353bd123aba60b4a237b235
   WordPressKit: ee58e3d313ddce1f768e87d76364d261ad86fca9
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0


### PR DESCRIPTION
This addresses a build failure on `trunk` which we missed because we don't have a requirement to keep PR up-to-date with `trunk` before merging (unless there are conflicts, of course). 

See https://buildkite.com/automattic/wordpress-authenticator-ios/builds/436, #698, and #703.

The rare fix like this is in my opinion worth the smoother developer experience the rest of the time.

This PR changes no code and addresses an issue for which CI is the only kind of verification we need. I'll admin-merge this as soon as CI is green (there's an incident currently on).

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
