### PR TITLE
Implement existing Google-SignIn flow in the demo app

### DIFF
--- a/Demo/AuthenticatorDemo/AppDelegate.swift
+++ b/Demo/AuthenticatorDemo/AppDelegate.swift
@@ -3,6 +3,13 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    // This is a property defined in `UIApplicationDelegate`. In modern UIKit apps,
+    // `UISceneConfiguration` is responsible for creating and holding the window.
+    //
+    // However, we need to set this anyway because SVProgressHUD accesses it internally and will
+    // crash the app if the value it finds is nil.
+    var window: UIWindow?
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         return true
     }

--- a/Demo/AuthenticatorDemo/Info.plist
+++ b/Demo/AuthenticatorDemo/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.108380595987-ujhrhknecrqli756i72gkcs4aaia6nhb</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Demo/AuthenticatorDemo/SceneDelegate.swift
+++ b/Demo/AuthenticatorDemo/SceneDelegate.swift
@@ -10,5 +10,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: scene)
         window?.rootViewController = UINavigationController(rootViewController: ViewController())
         window?.makeKeyAndVisible()
+
+        // We need to set this relationship to avoid a crash when using SVProgressHUD.
+        (UIApplication.shared.delegate as? AppDelegate)?.window = window
     }
 }

--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -25,7 +25,10 @@ extension ViewController {
                 enableSignInWithApple: false,
                 enableSignupWithGoogle: true,
                 enableUnifiedAuth: true,
-                enableUnifiedCarousel: true
+                enableUnifiedCarousel: true,
+                // Notice that this is required as well as `enableSignupWithGoogle` to show the
+                // option to login with Google.
+                enableSocialLogin: true
             ),
             style: WordPressAuthenticatorStyle(
                 // Primary (normal and highlight) is the color of buttons such as "Log in or signup

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -231,6 +231,10 @@ private extension GoogleAuthenticator {
         }
 
         // Initiate unified path by attempting to login first.
+        //
+        // `SVProgressHUD.show()` will crash in an app that doesn't have a window property in its
+        // `UIApplicationDelegate`, such as those created via the Xcode templates circa version 12
+        // onwards.
         SVProgressHUD.show()
         loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
     }


### PR DESCRIPTION
<table>
<tr>
	<td><img width="564" alt="Screenshot 2022-11-28 at 4 26 04 pm" src="https://user-images.githubusercontent.com/1218433/204324952-396cbc49-c043-4d50-bacf-a8ea061a389e.png"></td>
	<td>
<img width="564" alt="Screenshot 2022-11-28 at 4 26 16 pm" src="https://user-images.githubusercontent.com/1218433/204325226-6a92742f-3520-4956-a7f1-688cbc90fbb9.png"></td>
	<td><img width="564" alt="Screenshot 2022-11-28 at 4 27 29 pm" src="https://user-images.githubusercontent.com/1218433/204325001-ae4a01cc-aa7a-4c41-84fd-bd2114f910dc.png">
</td>
</tr>
</table>


When testing, you might see the following error in the console:

```
[Authorization] ASAuthorizationController credential request failed with error:
Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1001 "(null)"
```

Notice, though, that it's logged _before_ the start of any login flow. It will be good to chase it down, but it's out of scope for this time.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
