### PR TITLE
SDK-less Google SignIn – Part 1 of n

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -755,24 +755,24 @@
 		B5ED78F6207E976500A8FD8C /* WordPressAuthenticator */ = {
 			isa = PBXGroup;
 			children = (
-				D881A307256B5A6900FE5605 /* Navigation */,
 				F12F9FB624D8A7E800771BCE /* Analytics */,
-				CE1B18CA20EEC31000BECC3F /* Credentials */,
 				B5609099208A4EAF00399AE4 /* Authenticator */,
+				CE1B18CA20EEC31000BECC3F /* Credentials */,
 				3F550D4F23DA4A6B007E5897 /* Email Client Picker */,
 				B560909B208A4EB000399AE4 /* Extensions */,
+				B5ED78F8207E976500A8FD8C /* Info.plist */,
 				B5ED7917207E993E00A8FD8C /* Logging */,
 				B5609098208A4EAF00399AE4 /* Model */,
+				D881A307256B5A6900FE5605 /* Navigation */,
 				B5609097208A4EAF00399AE4 /* NUX */,
 				1A4095132271AEFC009AA86D /* Private */,
+				B5A5273F20B477F70065BE81 /* Resources */,
 				B560909A208A4EAF00399AE4 /* Services */,
 				B5609095208A4EAF00399AE4 /* Signin */,
 				B5609096208A4EAF00399AE4 /* Signup */,
 				B5609094208A4EAF00399AE4 /* UI */,
 				98655A56247F2AEA005EF9CC /* Unified Auth */,
-				B5A5273F20B477F70065BE81 /* Resources */,
 				B5ED78F7207E976500A8FD8C /* WordPressAuthenticator.h */,
-				B5ED78F8207E976500A8FD8C /* Info.plist */,
 			);
 			path = WordPressAuthenticator;
 			sourceTree = "<group>";

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		3F9439BE27D6F9B60067183A /* LoginPrologueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */; };
 		3FE8071529364C410088420C /* Result+ConvenienceInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */; };
 		3FE80717293650190088420C /* Result+ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE80716293650190088420C /* Result+ConvenienceInit.swift */; };
+		3FE8071B2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071A2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift */; };
+		3FE8071D293652BB0088420C /* OAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071C293652BB0088420C /* OAuthError.swift */; };
 		3FFF2FC123D7ED7C00D38C77 /* EmailClients.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FFF2FC023D7ED7C00D38C77 /* EmailClients.plist */; };
 		3FFF2FC323D7F53200D38C77 /* AppSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFF2FC223D7F53200D38C77 /* AppSelector.swift */; };
 		4A1DEF4A29341B1F00322608 /* LoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A1DEF4829341B1F00322608 /* LoggingTests.m */; };
@@ -235,6 +237,8 @@
 		3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPrologueViewController.swift; sourceTree = "<group>"; };
 		3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInitTests.swift"; sourceTree = "<group>"; };
 		3FE80716293650190088420C /* Result+ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInit.swift"; sourceTree = "<group>"; };
+		3FE8071A2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASWebAuthenticationSession+Utils.swift .swift"; sourceTree = "<group>"; };
+		3FE8071C293652BB0088420C /* OAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthError.swift; sourceTree = "<group>"; };
 		3FFF2FC023D7ED7C00D38C77 /* EmailClients.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = EmailClients.plist; sourceTree = "<group>"; };
 		3FFF2FC223D7F53200D38C77 /* AppSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelector.swift; sourceTree = "<group>"; };
 		4A1DEF4829341B1F00322608 /* LoggingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoggingTests.m; sourceTree = "<group>"; };
@@ -470,6 +474,8 @@
 		3FE80718293650370088420C /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				3FE8071A2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift */,
+				3FE8071C293652BB0088420C /* OAuthError.swift */,
 				3FE80716293650190088420C /* Result+ConvenienceInit.swift */,
 			);
 			path = OAuth;
@@ -1303,6 +1309,7 @@
 				98BC47E324F5B9AF000275AD /* GetStartedViewController.swift in Sources */,
 				B5609135208A563800399AE4 /* LoginWPComViewController.swift in Sources */,
 				CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */,
+				3FE8071D293652BB0088420C /* OAuthError.swift in Sources */,
 				B5609119208A555600399AE4 /* SiteInfoHeaderView.swift in Sources */,
 				B560913E208A563800399AE4 /* SigninEditingState.swift in Sources */,
 				CE2D03E024E5DD4500D18942 /* UnifiedSignupViewController.swift in Sources */,
@@ -1342,6 +1349,7 @@
 				B560913D208A563800399AE4 /* LoginProloguePageViewController.swift in Sources */,
 				B5609117208A555600399AE4 /* SearchTableViewCell.swift in Sources */,
 				BA70352424F70C9F00B3AA1C /* ModalViewControllerPresenting.swift in Sources */,
+				3FE8071B2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift in Sources */,
 				EEC7A621290FAEE5007793EE /* NUXStackedButtonsViewController.swift in Sources */,
 				B56090C9208A4F5400399AE4 /* NUXLinkMailViewController.swift in Sources */,
 				B56090F1208A527000399AE4 /* String+Underline.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -780,17 +780,17 @@
 		B5ED7901207E976500A8FD8C /* WordPressAuthenticatorTests */ = {
 			isa = PBXGroup;
 			children = (
-				D85C36E4256E0DAF00D56E34 /* Navigation */,
-				F18DF0E32525009200D83AFE /* SupportingFiles */,
-				BA53D64924DFE06C001F1ABF /* Mocks */,
-				BA53D64424DFDE0B001F1ABF /* Credentials */,
 				F12F9FB524D8A7DB00771BCE /* Analytics */,
-				3F550D5423DA5094007E5897 /* Email Client Picker */,
 				B501C03D208FC52500D1E58F /* Authenticator */,
-				B501C03B208FC52400D1E58F /* Model */,
-				B501C03F208FC52500D1E58F /* Services */,
-				4A1DEF4729341B1F00322608 /* Logging */,
+				BA53D64424DFDE0B001F1ABF /* Credentials */,
+				3F550D5423DA5094007E5897 /* Email Client Picker */,
 				B5ED7904207E976500A8FD8C /* Info.plist */,
+				4A1DEF4729341B1F00322608 /* Logging */,
+				BA53D64924DFE06C001F1ABF /* Mocks */,
+				B501C03B208FC52400D1E58F /* Model */,
+				D85C36E4256E0DAF00D56E34 /* Navigation */,
+				B501C03F208FC52500D1E58F /* Services */,
+				F18DF0E32525009200D83AFE /* SupportingFiles */,
 				3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */,
 			);
 			path = WordPressAuthenticatorTests;

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		3FE80717293650190088420C /* Result+ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE80716293650190088420C /* Result+ConvenienceInit.swift */; };
 		3FE8071B2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071A2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift */; };
 		3FE8071D293652BB0088420C /* OAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071C293652BB0088420C /* OAuthError.swift */; };
+		3FE8071F2936558F0088420C /* URL+GoogleSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071E2936558F0088420C /* URL+GoogleSignInTests.swift */; };
+		3FE8072129365F6D0088420C /* URL+GoogleSignIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8072029365F6D0088420C /* URL+GoogleSignIn.swift */; };
 		3FFF2FC123D7ED7C00D38C77 /* EmailClients.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FFF2FC023D7ED7C00D38C77 /* EmailClients.plist */; };
 		3FFF2FC323D7F53200D38C77 /* AppSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFF2FC223D7F53200D38C77 /* AppSelector.swift */; };
 		4A1DEF4A29341B1F00322608 /* LoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A1DEF4829341B1F00322608 /* LoggingTests.m */; };
@@ -239,6 +241,8 @@
 		3FE80716293650190088420C /* Result+ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInit.swift"; sourceTree = "<group>"; };
 		3FE8071A2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASWebAuthenticationSession+Utils.swift .swift"; sourceTree = "<group>"; };
 		3FE8071C293652BB0088420C /* OAuthError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthError.swift; sourceTree = "<group>"; };
+		3FE8071E2936558F0088420C /* URL+GoogleSignInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+GoogleSignInTests.swift"; sourceTree = "<group>"; };
+		3FE8072029365F6D0088420C /* URL+GoogleSignIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+GoogleSignIn.swift"; sourceTree = "<group>"; };
 		3FFF2FC023D7ED7C00D38C77 /* EmailClients.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = EmailClients.plist; sourceTree = "<group>"; };
 		3FFF2FC223D7F53200D38C77 /* AppSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelector.swift; sourceTree = "<group>"; };
 		4A1DEF4829341B1F00322608 /* LoggingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoggingTests.m; sourceTree = "<group>"; };
@@ -487,6 +491,22 @@
 				3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */,
 			);
 			path = OAuth;
+			sourceTree = "<group>";
+		};
+		3FE8072229365F740088420C /* GoogleSignIn */ = {
+			isa = PBXGroup;
+			children = (
+				3FE8072029365F6D0088420C /* URL+GoogleSignIn.swift */,
+			);
+			path = GoogleSignIn;
+			sourceTree = "<group>";
+		};
+		3FE8072329365FC20088420C /* GoogleSignIn */ = {
+			isa = PBXGroup;
+			children = (
+				3FE8071E2936558F0088420C /* URL+GoogleSignInTests.swift */,
+			);
+			path = GoogleSignIn;
 			sourceTree = "<group>";
 		};
 		4A1DEF4729341B1F00322608 /* Logging */ = {
@@ -786,6 +806,7 @@
 				CE1B18CA20EEC31000BECC3F /* Credentials */,
 				3F550D4F23DA4A6B007E5897 /* Email Client Picker */,
 				B560909B208A4EB000399AE4 /* Extensions */,
+				3FE8072229365F740088420C /* GoogleSignIn */,
 				B5ED78F8207E976500A8FD8C /* Info.plist */,
 				B5ED7917207E993E00A8FD8C /* Logging */,
 				B5609098208A4EAF00399AE4 /* Model */,
@@ -811,6 +832,7 @@
 				B501C03D208FC52500D1E58F /* Authenticator */,
 				BA53D64424DFDE0B001F1ABF /* Credentials */,
 				3F550D5423DA5094007E5897 /* Email Client Picker */,
+				3FE8072329365FC20088420C /* GoogleSignIn */,
 				B5ED7904207E976500A8FD8C /* Info.plist */,
 				4A1DEF4729341B1F00322608 /* Logging */,
 				BA53D64924DFE06C001F1ABF /* Mocks */,
@@ -1306,6 +1328,7 @@
 				B56090E6208A4F9D00399AE4 /* WPNUXPrimaryButton.m in Sources */,
 				CE9091F72499549500AB50BD /* TextFieldTableViewCell.swift in Sources */,
 				3FE80717293650190088420C /* Result+ConvenienceInit.swift in Sources */,
+				3FE8072129365F6D0088420C /* URL+GoogleSignIn.swift in Sources */,
 				98BC47E324F5B9AF000275AD /* GetStartedViewController.swift in Sources */,
 				B5609135208A563800399AE4 /* LoginWPComViewController.swift in Sources */,
 				CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */,
@@ -1410,6 +1433,7 @@
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,
 				3108613125AFA4830022F75E /* PasteboardTests.swift in Sources */,
+				3FE8071F2936558F0088420C /* URL+GoogleSignInTests.swift in Sources */,
 				D85C36F0256E118D00D56E34 /* NavigationToEnterAccountTests.swift in Sources */,
 				D85C36E6256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift in Sources */,
 				D85C3882256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */; };
 		3F550D5323DA4AC6007E5897 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5223DA4AC6007E5897 /* URLHandler.swift */; };
 		3F9439BE27D6F9B60067183A /* LoginPrologueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */; };
+		3FE8071529364C410088420C /* Result+ConvenienceInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */; };
+		3FE80717293650190088420C /* Result+ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE80716293650190088420C /* Result+ConvenienceInit.swift */; };
 		3FFF2FC123D7ED7C00D38C77 /* EmailClients.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FFF2FC023D7ED7C00D38C77 /* EmailClients.plist */; };
 		3FFF2FC323D7F53200D38C77 /* AppSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFF2FC223D7F53200D38C77 /* AppSelector.swift */; };
 		4A1DEF4A29341B1F00322608 /* LoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A1DEF4829341B1F00322608 /* LoggingTests.m */; };
@@ -231,6 +233,8 @@
 		3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkMailPresenter.swift; sourceTree = "<group>"; };
 		3F550D5223DA4AC6007E5897 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
 		3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPrologueViewController.swift; sourceTree = "<group>"; };
+		3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInitTests.swift"; sourceTree = "<group>"; };
+		3FE80716293650190088420C /* Result+ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInit.swift"; sourceTree = "<group>"; };
 		3FFF2FC023D7ED7C00D38C77 /* EmailClients.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = EmailClients.plist; sourceTree = "<group>"; };
 		3FFF2FC223D7F53200D38C77 /* AppSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelector.swift; sourceTree = "<group>"; };
 		4A1DEF4829341B1F00322608 /* LoggingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoggingTests.m; sourceTree = "<group>"; };
@@ -461,6 +465,22 @@
 				3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */,
 			);
 			path = "Email Client Picker";
+			sourceTree = "<group>";
+		};
+		3FE80718293650370088420C /* OAuth */ = {
+			isa = PBXGroup;
+			children = (
+				3FE80716293650190088420C /* Result+ConvenienceInit.swift */,
+			);
+			path = OAuth;
+			sourceTree = "<group>";
+		};
+		3FE807192936504F0088420C /* OAuth */ = {
+			isa = PBXGroup;
+			children = (
+				3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */,
+			);
+			path = OAuth;
 			sourceTree = "<group>";
 		};
 		4A1DEF4729341B1F00322608 /* Logging */ = {
@@ -765,6 +785,7 @@
 				B5609098208A4EAF00399AE4 /* Model */,
 				D881A307256B5A6900FE5605 /* Navigation */,
 				B5609097208A4EAF00399AE4 /* NUX */,
+				3FE80718293650370088420C /* OAuth */,
 				1A4095132271AEFC009AA86D /* Private */,
 				B5A5273F20B477F70065BE81 /* Resources */,
 				B560909A208A4EAF00399AE4 /* Services */,
@@ -789,6 +810,7 @@
 				BA53D64924DFE06C001F1ABF /* Mocks */,
 				B501C03B208FC52400D1E58F /* Model */,
 				D85C36E4256E0DAF00D56E34 /* Navigation */,
+				3FE807192936504F0088420C /* OAuth */,
 				B501C03F208FC52500D1E58F /* Services */,
 				F18DF0E32525009200D83AFE /* SupportingFiles */,
 				3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */,
@@ -1277,6 +1299,7 @@
 				B56090E2208A4F9D00399AE4 /* WPNUXSecondaryButton.m in Sources */,
 				B56090E6208A4F9D00399AE4 /* WPNUXPrimaryButton.m in Sources */,
 				CE9091F72499549500AB50BD /* TextFieldTableViewCell.swift in Sources */,
+				3FE80717293650190088420C /* Result+ConvenienceInit.swift in Sources */,
 				98BC47E324F5B9AF000275AD /* GetStartedViewController.swift in Sources */,
 				B5609135208A563800399AE4 /* LoginWPComViewController.swift in Sources */,
 				CEDE0D972420126900CB3345 /* UIViewController+Helpers.swift in Sources */,
@@ -1365,6 +1388,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F18DF0E5252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h in Sources */,
+				3FE8071529364C410088420C /* Result+ConvenienceInitTests.swift in Sources */,
 				B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */,
 				BA53D64824DFDF97001F1ABF /* WordPressSourceTagTests.swift in Sources */,
 				4A1DEF4B29341B1F00322608 /* LoggingTests.swift in Sources */,

--- a/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension URL {
+
+    // TODO: This is incomplete
+    static func googleSignInAuthURL() throws -> URL {
+        let baseURL = "https://accounts.google.com/o/oauth2/v2/auth"
+
+        let queryItems = [
+            ("response_type", "code")
+        ].map { URLQueryItem(name: $0.0, value: $0.1) }
+
+        if #available(iOS 16.0, *) {
+            return URL(string: baseURL)!.appending(queryItems: queryItems)
+        } else {
+            var components = URLComponents(string: baseURL)!
+            components.queryItems = queryItems
+            return try components.asURL()
+        }
+    }
+}

--- a/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
@@ -3,10 +3,11 @@ import Foundation
 extension URL {
 
     // TODO: This is incomplete
-    static func googleSignInAuthURL() throws -> URL {
+    static func googleSignInAuthURL(clientId: String) throws -> URL {
         let baseURL = "https://accounts.google.com/o/oauth2/v2/auth"
 
         let queryItems = [
+            ("client_id", clientId),
             ("response_type", "code")
         ].map { URLQueryItem(name: $0.0, value: $0.1) }
 

--- a/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
@@ -8,6 +8,7 @@ extension URL {
 
         let queryItems = [
             ("client_id", clientId),
+            ("redirect_uri", redirectURI(from: clientId)),
             ("response_type", "code")
         ].map { URLQueryItem(name: $0.0, value: $0.1) }
 
@@ -18,5 +19,14 @@ extension URL {
             components.queryItems = queryItems
             return try components.asURL()
         }
+    }
+
+    private static func redirectURI(from clientId: String) -> String {
+        // Google's client id is in the form: 123-abc245def.apps.googleusercontent.com
+        // The redirect URI uses the reverse-DNS notation.
+        let reverseDNSClientId = clientId.split(separator: ".").reversed().joined(separator: ".")
+        // After that, we add "oautha2callback", as per GIDSignIn.m line 421 at
+        // commit 1b0c4ec33a6fe282f4fa35d8ac64263230ddaf36
+        return "\(reverseDNSClientId):/oauth2callback"
     }
 }

--- a/WordPressAuthenticator/OAuth/ASWebAuthenticationSession+Utils.swift .swift
+++ b/WordPressAuthenticator/OAuth/ASWebAuthenticationSession+Utils.swift .swift
@@ -12,7 +12,7 @@ extension ASWebAuthenticationSession {
                     error: error,
                     // Unfortunately we cannot exted `ASWebAuthenticationSessionError.Code` to add
                     // a custom error for this scenario, so we're left to use a "generic" one.
-                    inconsistentStateError: OAuthErrors.inconsistentASWebAuthenticationSessionCompletion
+                    inconsistentStateError: OAuthError.inconsistentWebAuthenticationSessionCompletion
                 )
             )
         }

--- a/WordPressAuthenticator/OAuth/ASWebAuthenticationSession+Utils.swift .swift
+++ b/WordPressAuthenticator/OAuth/ASWebAuthenticationSession+Utils.swift .swift
@@ -1,0 +1,20 @@
+import AuthenticationServices
+
+extension ASWebAuthenticationSession {
+
+    /// Wrapper around the default `init(url:, callbackULRScheme:, completionHandler:)` where the
+    /// `completionHandler` argument is a `Result<URL, Error>` instead of a `URL` and `Error` pair.
+    convenience init(url: URL, callbackURLScheme: String, completionHandler: @escaping (Result<URL, Error>) -> Void) {
+        self.init(url: url, callbackURLScheme: callbackURLScheme) { callbackURL, error in
+            completionHandler(
+                Result(
+                    value: callbackURL,
+                    error: error,
+                    // Unfortunately we cannot exted `ASWebAuthenticationSessionError.Code` to add
+                    // a custom error for this scenario, so we're left to use a "generic" one.
+                    inconsistentStateError: OAuthErrors.inconsistentASWebAuthenticationSessionCompletion
+                )
+            )
+        }
+    }
+}

--- a/WordPressAuthenticator/OAuth/OAuthError.swift
+++ b/WordPressAuthenticator/OAuth/OAuthError.swift
@@ -1,0 +1,10 @@
+enum OAuthErrors {
+
+    static let inconsistentASWebAuthenticationSessionCompletion = NSError(
+        domain: "org.wordpress.authenticator.oauth",
+        code: 1,
+        userInfo: [
+            NSLocalizedDescriptionKey: "ASWebAuthenticationSession authentication finished with neither a callback URL nor error"
+        ]
+    )
+}

--- a/WordPressAuthenticator/OAuth/OAuthError.swift
+++ b/WordPressAuthenticator/OAuth/OAuthError.swift
@@ -1,10 +1,11 @@
-enum OAuthErrors {
+enum OAuthError: LocalizedError {
 
-    static let inconsistentASWebAuthenticationSessionCompletion = NSError(
-        domain: "org.wordpress.authenticator.oauth",
-        code: 1,
-        userInfo: [
-            NSLocalizedDescriptionKey: "ASWebAuthenticationSession authentication finished with neither a callback URL nor error"
-        ]
-    )
+    case inconsistentWebAuthenticationSessionCompletion
+
+    var errorDescription: String {
+        switch self {
+        case .inconsistentWebAuthenticationSessionCompletion:
+            return "ASWebAuthenticationSession authentication finished with neither a callback URL nor error"
+        }
+    }
 }

--- a/WordPressAuthenticator/OAuth/Result+ConvenienceInit.swift
+++ b/WordPressAuthenticator/OAuth/Result+ConvenienceInit.swift
@@ -1,0 +1,15 @@
+extension Swift.Result {
+
+    /// Convenience init to lift the values in an Objective-C style callback, where both success and failure parameters can be nil, to
+    /// a domain where at least one is not nil.
+    ///
+    /// If both values are nil, it will create a `failure` instance wrapping the given `inconsistentStateError`.
+    init(value: Success?, error: Failure?, inconsistentStateError: Failure) {
+        switch (value, error) {
+        case (.some(let value), .none): self = .success(value)
+        case (.some, .some(let error)): self = .failure(error)
+        case (.none, .some(let error)): self = .failure(error)
+        case (.none, .none): self = .failure(inconsistentStateError)
+        }
+    }
+}

--- a/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -1,0 +1,68 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+class URLGoogleSignInTests: XCTestCase {
+
+    func testGoogleSignInAuthURL() throws {
+        let url = try URL.googleSignInAuthURL()
+
+        assert(url, matchesBaseURL: "https://accounts.google.com/o/oauth2/v2/auth")
+        assertQueryItems(for: url, includeItemNamed: "response_type", withValue: "code")
+        // TODO: need to check more parameters
+    }
+}
+
+func assert(
+    _ actual: URL,
+    matchesBaseURL baseURLString: String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    guard var components = URLComponents(url: actual, resolvingAgainstBaseURL: false) else {
+        return XCTFail(
+            "Could not created `URLComponents` from given `URL` \(actual).",
+            file: file,
+            line: line
+        )
+    }
+
+    components.query = .none
+
+    guard let baseURL = components.url else {
+        return XCTFail(
+            "Could not extract `URL` from `URLComponents` created from \(actual).",
+            file: file,
+            line: line
+        )
+    }
+
+    XCTAssertEqual(baseURL.absoluteString, baseURLString, file: file, line: line)
+}
+
+func assertQueryItems(
+    for url: URL,
+    includeItemNamed name: String,
+    withValue value: String?,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        return XCTFail(
+            "Could not created `URLComponents` from given `URL` \(url).",
+            file: file,
+            line: line
+        )
+    }
+
+    guard let queryItems = components.queryItems else {
+        XCTFail("URL \(url) has no query items", file: file, line: line)
+        return
+    }
+
+    XCTAssertTrue(
+        queryItems.contains(where: { $0.name == name && $0.value == value }),
+        "Could not find query item with name '\(name)' and value '\(value ?? "nil")'. Query items found: \(queryItems.map { "'name: \($0.name), value: \($0.value ?? "nil")'" }.joined(separator: ", "))",
+        file: file,
+        line: line
+    )
+}

--- a/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -12,6 +12,11 @@ class URLGoogleSignInTests: XCTestCase {
             includeItemNamed: "client_id",
             withValue: "123-abc245def.apps.googleusercontent.com"
         )
+        assertQueryItems(
+            for: url,
+            includeItemNamed: "redirect_uri",
+            withValue: "com.googleusercontent.apps.123-abc245def:/oauth2callback"
+        )
         assertQueryItems(for: url, includeItemNamed: "response_type", withValue: "code")
         // TODO: need to check more parameters
     }

--- a/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -4,9 +4,14 @@ import XCTest
 class URLGoogleSignInTests: XCTestCase {
 
     func testGoogleSignInAuthURL() throws {
-        let url = try URL.googleSignInAuthURL()
+        let url = try URL.googleSignInAuthURL(clientId: "123-abc245def.apps.googleusercontent.com")
 
         assert(url, matchesBaseURL: "https://accounts.google.com/o/oauth2/v2/auth")
+        assertQueryItems(
+            for: url,
+            includeItemNamed: "client_id",
+            withValue: "123-abc245def.apps.googleusercontent.com"
+        )
         assertQueryItems(for: url, includeItemNamed: "response_type", withValue: "code")
         // TODO: need to check more parameters
     }

--- a/WordPressAuthenticatorTests/OAuth/Result+ConvenienceInitTests.swift
+++ b/WordPressAuthenticatorTests/OAuth/Result+ConvenienceInitTests.swift
@@ -1,0 +1,40 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+class ResultConvenienceInitTests: XCTestCase {
+
+    func testResultWithOptionalInputs() throws {
+        // Syntax sugar to keep line length shorter. SUT = System Under Test
+        typealias SUT = Result<Int, NSError>
+
+        let testError = NSError(domain: "test", code: 1, userInfo: .none)
+
+        // When value is some and error is nil, returns the value
+        XCTAssertEqual(
+            try XCTUnwrap(SUT(value: 1, error: .none, inconsistentStateError: testError).get()),
+            1
+        )
+
+        // When value is some and error is some, returns the error
+        let someError = NSError(domain: "test", code: 2)
+        XCTAssertThrowsError(
+            try SUT(value: 1, error: someError, inconsistentStateError: testError).get()
+        ) { error in
+            XCTAssertEqual(error as NSError, someError)
+        }
+
+        // When value is none and error is some, returns the error
+        XCTAssertThrowsError(
+            try SUT(value: .none, error: someError, inconsistentStateError: testError).get()
+        ) { error in
+            XCTAssertEqual(error as NSError, someError)
+        }
+
+        // When both value and error are none, returns the given error for this inconsistent state
+        XCTAssertThrowsError(
+            try SUT(value: .none, error: .none, inconsistentStateError: testError).get()
+        ) { error in
+            XCTAssertEqual(error as NSError, testError)
+        }
+    }
+}


### PR DESCRIPTION
Took the work from https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/704 and replayed the first parts adding tests.

Nothing to test in the demo app yet. Just adding some components to build things with later. I opened this as a ready to review PR because I don't want the diff to become overwhelming.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. 

I'll add the changelog entry in the last PR of the series.
