### PR TITLE
Make XMLRPC URL optional when verifying WP.com email and new config for skipping XMLRPC for site discovery

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (1.6.0)
-  - WordPressAuthenticator (4.2.0):
+  - WordPressAuthenticator (4.3.0-beta.1):
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
@@ -109,7 +109,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
-  WordPressAuthenticator: 3bbb0a33f2c1d7bda353bd123aba60b4a237b235
+  WordPressAuthenticator: 6ef20b546ac4f90e7ff3452979e19f6167e9f605
   WordPressKit: ee58e3d313ddce1f768e87d76364d261ad86fca9
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '4.2.0'
+  s.version       = '4.3.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -211,12 +211,8 @@ import WordPressKit
     ///     - siteURL: The URL of the site to log in to.
     ///
     @objc public class func showVerifyEmailForWPCom(from presenter: UIViewController, xmlrpc: String, connectedEmail: String, siteURL: String) {
-        guard let xmlrpcURL = URL(string: xmlrpc) else {
-            DDLogError("Failed to initiate XML-RPC URL from \(xmlrpc)")
-            return
-        }
         let loginFields = LoginFields()
-        loginFields.meta.xmlrpcURL = xmlrpcURL as NSURL
+        loginFields.meta.xmlrpcURL = NSURL(string: xmlrpc)
         loginFields.username = connectedEmail
         loginFields.siteAddress = siteURL
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -132,6 +132,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let wpcomPasswordInstructions: String?
 
+    /// If enabled, site discovery will not check for XMLRPC URL.
+    ///
+    let skipXMLRPCCheckForSiteDiscovery: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -161,7 +165,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSiteCreation: Bool = false,
                  enableSocialLogin: Bool = false,
                  emphasizeEmailForWPComPassword: Bool = false,
-                 wpcomPasswordInstructions: String? = nil) {
+                 wpcomPasswordInstructions: String? = nil,
+                 skipXMLRPCCheckForSiteDiscovery: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -191,5 +196,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableSocialLogin = enableSocialLogin
         self.emphasizeEmailForWPComPassword = emphasizeEmailForWPComPassword
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
+        self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -31,6 +31,7 @@ final class SiteAddressViewController: LoginViewController {
     /// Whether the protocol method `troubleshootSite` should be triggered after site info is fetched.
     ///
     private let isSiteDiscovery: Bool
+    private let configuration = WordPressAuthenticator.shared.configuration
 
     init?(isSiteDiscovery: Bool, coder: NSCoder) {
         self.isSiteDiscovery = isSiteDiscovery
@@ -442,6 +443,11 @@ private extension SiteAddressViewController {
         // Checks that the site exists
         checkSiteExistence(url: url) { [weak self] in
             guard let self = self else { return }
+            // skips XMLRPC check for site discovery if needed
+            if self.isSiteDiscovery && self.configuration.skipXMLRPCCheckForSiteDiscovery {
+                self.fetchSiteInfo()
+                return
+            }
             // Proceeds to check for the site's WordPress
             self.guessXMLRPCURL(for: self.loginFields.siteAddress)
         }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8258

## Description

Currently, when presenting the flow for verifying WP.com email, we are requiring that a valid XMLRPC URL should be provided. This is not necessary since this flow only handles authentication with WP.com. 

This PR fixes this by making XMLRPC optional for verifying WP.com email. It's better to remove it entirely, but I don't want to introduce a breaking change, so I'm still keeping XMLRPC as a parameter for the method. Please feel free to suggest another solution that's cleaner for this situation.

 A new config is also added to skip the XMLRPC check for the site discovery flow.

## Testing steps
Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/8259 for testing.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
