### PR TITLE
Bump version to 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ _None._
 
 _None._
 
+## 4.3.0
+
+### New Features
+
+- Make XMLRPC URL optional when verifying WP.com email [#711]
+- A new config is added to skip the XMLRPC check for the site discovery flow [#711]
+
 ## 4.2.0
 
 ### New Features

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (1.6.0)
-  - WordPressAuthenticator (4.3.0-beta.1):
+  - WordPressAuthenticator (4.3.0):
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
@@ -109,7 +109,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
-  WordPressAuthenticator: 6ef20b546ac4f90e7ff3452979e19f6167e9f605
+  WordPressAuthenticator: f9f04e01736adb75805a66b5fa4f033c1a9f973a
   WordPressKit: ee58e3d313ddce1f768e87d76364d261ad86fca9
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '4.3.0-beta.1'
+  s.version       = '4.3.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
#711 does not contain any release notes, so I wasn't sure how to handle the `CHANGELOG` file. I could either:
* Create a `4.3.0` without any release notes
* Don't have any `4.3.0` entry at all

I thought not having the entry made more sense, although neither feels right. I am happy to follow a different approach next time if reviewers have any suggestions. For this time, I have very limited time today to finish the WooCommerce-iOS code freeze and I didn't want this to be the blocker. We can even fix the issue after the fact, it just won't be part of `4.3.0` tag.

**Update**

I had to update the commit to include the `Podfile.lock` change.

I ran `bundle exec pod install` before opening this PR, but the `Podfile.lock` didn't get updated. I guess I missed something. Sorry about that!