### PR TITLE
Fix unresponsive issue in Onboading Questions screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix unresponsive issue in Onboading Questions screen. [#719]
 
 ### Internal Changes
 
@@ -65,7 +65,7 @@ _None._
 
 ### New Features
 
-- New tracking event for XMLRPC related failure. by @selanthiraiyan [#701]  
+- New tracking event for XMLRPC related failure. by @selanthiraiyan [#701]
 
 ## [4.1.1](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.1.1)
 

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -474,6 +474,7 @@ extension LoginViewController {
             return
         }
 
+        vc.dismissBlock = dismissBlock
         vc.loginFields = loginFields
         navigationController?.pushViewController(vc, animated: true)
     }


### PR DESCRIPTION
## Related PR
This PR is blocking the following PR:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/19791

## Description
Please check the related the PR for more details on the issue and the test instructions.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
