### PR TITLE
Complete `CaptureLogs` conformance to `WordPressLoggingDelegate`

### DIFF
--- a/WordPressAuthenticatorTests/Logging/LoggingTests.m
+++ b/WordPressAuthenticatorTests/Logging/LoggingTests.m
@@ -9,6 +9,10 @@
 
 @end
 
+// We are leaving some protocol methods intentionally unimplemented to then test that calling them
+// will not cause a crash.
+//
+// See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/720#issuecomment-1374952619
 #pragma GCC diagnostic ignored "-Wprotocol"
 @implementation CaptureLogs
 

--- a/WordPressAuthenticatorTests/Logging/LoggingTests.m
+++ b/WordPressAuthenticatorTests/Logging/LoggingTests.m
@@ -13,7 +13,7 @@
 // will not cause a crash.
 //
 // See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/720#issuecomment-1374952619
-#pragma GCC diagnostic ignored "-Wprotocol"
+#pragma clang diagnostic ignored "-Wprotocol"
 @implementation CaptureLogs
 
 - (instancetype)init
@@ -36,6 +36,7 @@
 }
 
 @end
+#pragma clang diagnostic pop
 
 @interface ObjCLoggingTest : XCTestCase
 

--- a/WordPressAuthenticatorTests/Logging/LoggingTests.m
+++ b/WordPressAuthenticatorTests/Logging/LoggingTests.m
@@ -9,6 +9,7 @@
 
 @end
 
+#pragma GCC diagnostic ignored "-Wprotocol"
 @implementation CaptureLogs
 
 - (instancetype)init


### PR DESCRIPTION
I had noticed this warning a while ago, but never made the time to address it.

The occasion came as part of The Code Quality Challenge day 3 "Get rid of a warning". See https://tuple.app/code-quality-challenge

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.