### PR TITLE
Use configuration flag to log custom `step` event for `GetStartedViewController`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _None._
 ### Bug Fixes
 
 - Fix unresponsive issue in Onboading Questions screen. [#719]
+- Use configuration flag to log custom `step` event for `GetStartedViewController`. [#724]
 
 ### Internal Changes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.0.0):
+  - WordPressAuthenticator (5.1.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: e4fbd4ef3b266d4efad59a28db1dd1c626fc3286
+  WordPressAuthenticator: 95f698805ebbbe86c5721ce244e1302ea810326b
   WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.0.0'
+  s.version       = '5.1.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -136,6 +136,16 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let skipXMLRPCCheckForSiteDiscovery: Bool
 
+    /// Used to determine the `step` value for `unified_login_step` analytics event in `GetStartedViewController`
+    ///
+    ///  - If disabled `start` will be used as `step` value
+    ///     - Disabled by default
+    ///  - If enabled, `enter_email_address` will be used as `step` value
+    ///     - Custom step value is used because `start` is used in other VCs as well, which doesn't allow us to differentiate between screens.
+    ///     - i.e. Some screens have the same `step` and `flow` value. `GetStartedViewController` and `SiteAddressViewController` for example.
+    ///
+    let useEnterEmailAddressAsStepValueForGetStartedVC: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -166,7 +176,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSocialLogin: Bool = false,
                  emphasizeEmailForWPComPassword: Bool = false,
                  wpcomPasswordInstructions: String? = nil,
-                 skipXMLRPCCheckForSiteDiscovery: Bool = false) {
+                 skipXMLRPCCheckForSiteDiscovery: Bool = false,
+                 useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -197,5 +208,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.emphasizeEmailForWPComPassword = emphasizeEmailForWPComPassword
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
+        self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -464,10 +464,11 @@ private extension GetStartedViewController {
             tracker.set(flow: .wpCom)
         }
 
+        let stepValue: AuthenticatorAnalyticsTracker.Step = configuration.useEnterEmailAddressAsStepValueForGetStartedVC ? .enterEmailAddress : .start
         if isMovingToParent {
-            tracker.track(step: .enterEmailAddress)
+            tracker.track(step: stepValue)
         } else {
-            tracker.set(step: .enterEmailAddress)
+            tracker.set(step: stepValue)
         }
     }
 }


### PR DESCRIPTION
Closes #723 
### Description

Previously in #674 we introduced a new step value `enter_email_address` for `GetStartedViewController `. 
This was added to differentiate between `GetStartedViewController` and `SiteAddressViewController` in Woo mobile app. Those two screens had the same `flow` and `step` value.

This new step value change has led to an issue with the WPiOS Looker dashboard (ref: pe5sF9-FU-p2#comment-1542).
To fix the issue, we are introducing a configuration flag in `WordPressAuthenticatorConfiguration` to use custom step event only when the `useEnterEmailAddressAsStepValueForGetStartedVC` flag is enabled. 

### Testing steps

Follow the testing instructions from
1. https://github.com/woocommerce/woocommerce-ios/pull/8669
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/19940

---


- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
