### PR TITLE
New configuration for site address login only on the prologue screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- New configuration for site address login only on the prologue screen. [#725]
 
 ### Bug Fixes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.1.0-beta.1):
+  - WordPressAuthenticator (5.1.0-beta.2):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 95f698805ebbbe86c5721ce244e1302ea810326b
+  WordPressAuthenticator: aac1a2435f3bb1435e0b8726debf38fcd440fd6b
   WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.1.0-beta.1'
+  s.version       = '5.1.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -148,7 +148,7 @@ public struct WordPressAuthenticatorConfiguration {
 
     /// If enabled, the prologue screen should hide the WPCom login CTA and show only the entry point to site address login.
     ///
-    let enableSiteAddressLoginOnly: Bool
+    let enableSiteAddressLoginOnlyInPrologue: Bool
 
     /// Designated Initializer
     ///
@@ -182,7 +182,7 @@ public struct WordPressAuthenticatorConfiguration {
                  wpcomPasswordInstructions: String? = nil,
                  skipXMLRPCCheckForSiteDiscovery: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
-                 enableSiteAddressLoginOnly: Bool = false) {
+                 enableSiteAddressLoginOnlyInPrologue: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -214,6 +214,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
-        self.enableSiteAddressLoginOnly = enableSiteAddressLoginOnly
+        self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -146,6 +146,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let useEnterEmailAddressAsStepValueForGetStartedVC: Bool
 
+    /// If enabled, the prologue screen should hide the WPCom login CTA and show only the entry point to site address login.
+    ///
+    let enableSiteAddressLoginOnly: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -177,7 +181,8 @@ public struct WordPressAuthenticatorConfiguration {
                  emphasizeEmailForWPComPassword: Bool = false,
                  wpcomPasswordInstructions: String? = nil,
                  skipXMLRPCCheckForSiteDiscovery: Bool = false,
-                 useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false) {
+                 useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
+                 enableSiteAddressLoginOnly: Bool = false) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -209,5 +214,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
+        self.enableSiteAddressLoginOnly = enableSiteAddressLoginOnly
     }
 }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -271,7 +271,7 @@ class LoginPrologueViewController: LoginViewController {
                                                  style: primaryButtonStyle,
                                                  onTap: loginTapCallback())
         let enterYourSiteAddressButton = StackedButton(title: displayStrings.enterYourSiteAddressButtonTitle,
-                                                       isPrimary: configuration.enableSiteAddressLoginOnly,
+                                                       isPrimary: configuration.enableSiteAddressLoginOnlyInPrologue,
                                                        configureBodyFontForTitle: true,
                                                        accessibilityIdentifier: "Prologue Self Hosted Button",
                                                        style: secondaryButtonStyle,
@@ -305,7 +305,7 @@ class LoginPrologueViewController: LoginViewController {
 
         let showDivider = configuration.enableWPComLoginOnlyInPrologue == false &&
             configuration.enableSiteCreation == true &&
-            configuration.enableSiteAddressLoginOnly == false
+            configuration.enableSiteAddressLoginOnlyInPrologue == false
         stackedButtonsViewController.setUpButtons(using: buttons, showDivider: showDivider)
         setButtonViewControllerBackground()
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -288,9 +288,9 @@ class LoginPrologueViewController: LoginViewController {
                        createSiteButton]
         } else if configuration.enableWPComLoginOnlyInPrologue {
             buttons = [continueWithWPButton]
-        } else if configuration.enableSiteAddressLoginOnly && configuration.enableSiteCreation {
+        } else if configuration.enableWPComLoginOnlyInPrologue && configuration.enableSiteCreation {
             buttons = [enterYourSiteAddressButton, createSiteButton]
-        } else if configuration.enableSiteAddressLoginOnly {
+        } else if configuration.enableWPComLoginOnlyInPrologue {
             buttons = [enterYourSiteAddressButton]
         } else if configuration.enableSiteCreation {
             let createSiteButtonForBottomStackView = StackedButton(using: createSiteButton,

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -303,7 +303,9 @@ class LoginPrologueViewController: LoginViewController {
             buttons = []
         }
 
-        let showDivider = configuration.enableWPComLoginOnlyInPrologue == false && configuration.enableSiteCreation == true
+        let showDivider = configuration.enableWPComLoginOnlyInPrologue == false &&
+            configuration.enableSiteCreation == true &&
+            configuration.enableSiteAddressLoginOnly == false
         stackedButtonsViewController.setUpButtons(using: buttons, showDivider: showDivider)
         setButtonViewControllerBackground()
     }

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -271,7 +271,7 @@ class LoginPrologueViewController: LoginViewController {
                                                  style: primaryButtonStyle,
                                                  onTap: loginTapCallback())
         let enterYourSiteAddressButton = StackedButton(title: displayStrings.enterYourSiteAddressButtonTitle,
-                                                       isPrimary: false,
+                                                       isPrimary: configuration.enableSiteAddressLoginOnly,
                                                        configureBodyFontForTitle: true,
                                                        accessibilityIdentifier: "Prologue Self Hosted Button",
                                                        style: secondaryButtonStyle,
@@ -288,6 +288,10 @@ class LoginPrologueViewController: LoginViewController {
                        createSiteButton]
         } else if configuration.enableWPComLoginOnlyInPrologue {
             buttons = [continueWithWPButton]
+        } else if configuration.enableSiteAddressLoginOnly && configuration.enableSiteCreation {
+            buttons = [enterYourSiteAddressButton, createSiteButton]
+        } else if configuration.enableSiteAddressLoginOnly {
+            buttons = [enterYourSiteAddressButton]
         } else if configuration.enableSiteCreation {
             let createSiteButtonForBottomStackView = StackedButton(using: createSiteButton,
                                                                    stackView: .bottom)
@@ -295,7 +299,7 @@ class LoginPrologueViewController: LoginViewController {
                        enterYourSiteAddressButton,
                        createSiteButtonForBottomStackView]
         } else {
-            WPAuthenticatorLogError("Failed to create `StackedButton`s in login progue screen.")
+            WPAuthenticatorLogError("Failed to create `StackedButton`s in login prologue screen.")
             buttons = []
         }
 

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -288,9 +288,9 @@ class LoginPrologueViewController: LoginViewController {
                        createSiteButton]
         } else if configuration.enableWPComLoginOnlyInPrologue {
             buttons = [continueWithWPButton]
-        } else if configuration.enableWPComLoginOnlyInPrologue && configuration.enableSiteCreation {
+        } else if configuration.enableSiteAddressLoginOnlyInPrologue && configuration.enableSiteCreation {
             buttons = [enterYourSiteAddressButton, createSiteButton]
-        } else if configuration.enableWPComLoginOnlyInPrologue {
+        } else if configuration.enableSiteAddressLoginOnlyInPrologue {
             buttons = [enterYourSiteAddressButton]
         } else if configuration.enableSiteCreation {
             let createSiteButtonForBottomStackView = StackedButton(using: createSiteButton,


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8679

## Description
This PR adds a new config to show only the site address login button on the prologue screen.

## Testing steps
Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/8684.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
