### PR TITLE
Refactor part of `GoogleAuthenticator` in preparation for the SDK-less flow

### DIFF
--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -135,13 +135,12 @@ class GoogleAuthenticator: NSObject {
     func createGoogleAccount(loginFields: LoginFields) {
         self.loginFields = loginFields
 
-        guard let user = loginFields.meta.googleUser,
-            let token = loginFields.meta.socialServiceIDToken else {
-                WPAuthenticatorLogError("GoogleAuthenticator - createGoogleAccount: Failed to get Google account information.")
-                return
+        guard let token = loginFields.meta.socialServiceIDToken else {
+            WPAuthenticatorLogError("GoogleAuthenticator - createGoogleAccount: Failed to get Google account information.")
+            return
         }
 
-        createWordPressComUser(user: user, token: token, email: loginFields.emailAddress)
+        createWordPressComUser(token: token, email: loginFields.emailAddress)
     }
 
 }
@@ -224,7 +223,7 @@ private extension GoogleAuthenticator {
                 SVProgressHUD.show()
                 loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
             case .signup:
-                createWordPressComUser(user: user, token: token, email: email)
+                createWordPressComUser(token: token, email: email)
             }
 
             return
@@ -337,9 +336,9 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
 
 private extension GoogleAuthenticator {
 
-    /// Creates a WordPress.com account with the associated Google User + Google Token + Google Email.
+    /// Creates a WordPress.com account with the associated Google token and email.
     ///
-    func createWordPressComUser(user: GIDGoogleUser, token: String, email: String) {
+    func createWordPressComUser(token: String, email: String) {
         SVProgressHUD.show()
         let service = SignupService()
 

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -192,32 +192,10 @@ private extension GoogleAuthenticator {
             return
         }
 
-        // Save account information to pass back to delegate later.
-        loginFields.emailAddress = email
-        loginFields.username = email
-        loginFields.meta.socialServiceIDToken = token
+        // Set `googleUser` here, `didSignIn(token:, email:)` will do the rest.
         loginFields.meta.googleUser = user
 
-        guard authConfig.enableUnifiedAuth else {
-            // Initiate separate WP login / signup paths.
-            switch authType {
-            case .login:
-                SVProgressHUD.show()
-                loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
-            case .signup:
-                createWordPressComUser(token: token, email: email)
-            }
-
-            return
-        }
-
-        // Initiate unified path by attempting to login first.
-        //
-        // `SVProgressHUD.show()` will crash in an app that doesn't have a window property in its
-        // `UIApplicationDelegate`, such as those created via the Xcode templates circa version 12
-        // onwards.
-        SVProgressHUD.show()
-        loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
+        didSignIn(token: token, email: email)
     }
 
     private func failedToSignIn(error: Error?) {
@@ -242,6 +220,34 @@ private extension GoogleAuthenticator {
         // FIXME: Shouldn't we be calling a method to report error, if there was one?
         signupDelegate?.googleSignupCancelled()
         delegate?.googleAuthCancelled()
+    }
+
+    private func didSignIn(token: String, email: String) {
+        // Save account information to pass back to delegate later.
+        loginFields.emailAddress = email
+        loginFields.username = email
+        loginFields.meta.socialServiceIDToken = token
+
+        guard authConfig.enableUnifiedAuth else {
+            // Initiate separate WP login / signup paths.
+            switch authType {
+            case .login:
+                SVProgressHUD.show()
+                loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
+            case .signup:
+                createWordPressComUser(token: token, email: email)
+            }
+
+            return
+        }
+
+        // Initiate unified path by attempting to login first.
+        //
+        // `SVProgressHUD.show()` will crash in an app that doesn't have a window property in its
+        // `UIApplicationDelegate`, such as those created via the Xcode templates circa version 12
+        // onwards.
+        SVProgressHUD.show()
+        loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.google.rawValue)
     }
 
     enum LocalizedText {

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -153,15 +153,7 @@ private extension GoogleAuthenticator {
     ///   - viewController: The UIViewController that Google is being presented from.
     ///                     Required by Google SDK.
     func requestAuthorization(from viewController: UIViewController) {
-        switch authType {
-        case .login:
-            tracker.set(flow: .loginWithGoogle)
-            tracker.track(step: .start) {
-                track(.loginSocialButtonClick)
-            }
-        case .signup:
-            track(.createAccountInitiated)
-        }
+        trackRequestAuthorizitation(type: authType)
 
         let googleInstance = GIDSignIn.sharedInstance
         let configuration = GIDConfiguration(clientID: authConfig.googleLoginClientId, serverClientID: authConfig.googleLoginServerClientId)
@@ -172,6 +164,18 @@ private extension GoogleAuthenticator {
         // Assigning the view controller has no effect since we don't use Google UI, but it's is required, so here we are.
         googleInstance.signIn(with: configuration, presenting: viewController) { user, error in
             self.didSignIn(for: user, error: error)
+        }
+    }
+
+    private func trackRequestAuthorizitation(type: GoogleAuthType) {
+        switch type {
+        case .login:
+            tracker.set(flow: .loginWithGoogle)
+            tracker.track(step: .start) {
+                track(.loginSocialButtonClick)
+            }
+        case .signup:
+            track(.createAccountInitiated)
         }
     }
 


### PR DESCRIPTION
- Remove an unused `GIDGoogleUser` parameter
- Separate logic independent of the SDK so that we can use it later from the new flow

_Reviewing with "Hide whitespace changes" makes for a cleaner diff._

### Next steps

- Wait for #728 to land on `trunk`
- Build to top of it and this to integrate the SDK-less flow in the current one (see WIP in `mokagio/oauth-part-3-plug-in-delegate` branch)

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
