### PR TITLE
Run framework tests from AuthenticatorDemo scheme, for convenience

### DIFF
--- a/Demo/AuthenticatorDemo.xcodeproj/xcshareddata/xcschemes/AuthenticatorDemo.xcscheme
+++ b/Demo/AuthenticatorDemo.xcodeproj/xcshareddata/xcschemes/AuthenticatorDemo.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B5ED78FC207E976500A8FD8C"
+               BuildableName = "WordPressAuthenticatorTests.xctest"
+               BlueprintName = "WordPressAuthenticatorTests"
+               ReferencedContainer = "container:../WordPressAuthenticator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
What it says in the title...

When working on the demo app, one often modifies the actual library as well. In that case, it's useful to run the library tests from the demo app scheme, without having to bounce back and forth.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
