### PR TITLE
SDK-less Google SignIn part 4

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -55,6 +55,8 @@ public struct WordPressAuthenticatorConfiguration {
         return clientId
     }
 
+    let googleLoginWithoutSDK: Bool
+
     /// UserAgent
     ///
     let userAgent: String
@@ -200,7 +202,9 @@ public struct WordPressAuthenticatorConfiguration {
                  skipXMLRPCCheckForSiteAddressLogin: Bool = false,
                  enableManualSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
-                 enableSiteAddressLoginOnlyInPrologue: Bool = false) {
+                 enableSiteAddressLoginOnlyInPrologue: Bool = false,
+                 googleLoginWithoutSDK: Bool = false
+    ) {
 
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
@@ -212,6 +216,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginClientId =  googleLoginClientId
         self.googleLoginServerClientId = googleLoginServerClientId
         self.googleLoginScheme = googleLoginScheme
+        self.googleLoginWithoutSDK = googleLoginWithoutSDK
         self.userAgent = userAgent
         self.showLoginOptions = showLoginOptions
         self.enableSignUp = enableSignUp

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -47,6 +47,14 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let googleLoginScheme: String
 
+    internal var googleClientId: GoogleClientId {
+        guard let clientId = GoogleClientId(string: googleLoginClientId) else {
+            fatalError("Could not init GoogleClientId from developer provided value.")
+        }
+
+        return clientId
+    }
+
     /// UserAgent
     ///
     let userAgent: String

--- a/WordPressAuthenticator/GoogleSignIn/GoogleOAuthTokenGetter.swift
+++ b/WordPressAuthenticator/GoogleSignIn/GoogleOAuthTokenGetter.swift
@@ -8,11 +8,17 @@ class GoogleOAuthTokenGetter: GoogleOAuthTokenGetting {
 
     func getToken(
         clientId: GoogleClientId,
+        audience: String,
         authCode: String,
         pkce: ProofKeyForCodeExchange
     ) async throws -> OAuthTokenResponseBody {
         let request = try URLRequest.googleSignInTokenRequest(
-            body: .googleSignInRequestBody(clientId: clientId, authCode: authCode, pkce: pkce)
+            body: .googleSignInRequestBody(
+                clientId: clientId,
+                audience: audience,
+                authCode: authCode,
+                pkce: pkce
+            )
         )
 
         let data = try await dataGetter.data(for: request)

--- a/WordPressAuthenticator/GoogleSignIn/GoogleOAuthTokenGetting.swift
+++ b/WordPressAuthenticator/GoogleSignIn/GoogleOAuthTokenGetting.swift
@@ -2,6 +2,7 @@ protocol GoogleOAuthTokenGetting {
 
     func getToken(
         clientId: GoogleClientId,
+        audience: String,
         authCode: String,
         pkce: ProofKeyForCodeExchange
     ) async throws -> OAuthTokenResponseBody

--- a/WordPressAuthenticator/GoogleSignIn/OAuthRequestBody+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/OAuthRequestBody+GoogleSignIn.swift
@@ -2,6 +2,7 @@ extension OAuthTokenRequestBody {
 
     static func googleSignInRequestBody(
         clientId: GoogleClientId,
+        audience: String,
         authCode: String,
         pkce: ProofKeyForCodeExchange
     ) -> Self {
@@ -13,6 +14,7 @@ extension OAuthTokenRequestBody {
             // There doesn't seem to be any secret for iOS app credentials.
             // The process works with an empty string...
             clientSecret: "",
+            audience: audience,
             code: authCode,
             codeVerifier: pkce.codeVerifier,
             // As defined in the OAuth 2.0 specification, this field's value must be set to authorization_code.

--- a/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
@@ -19,17 +19,8 @@ extension URL {
             ("redirect_uri", clientId.defaultRedirectURI),
             ("response_type", "code"),
             // TODO: We might want to add some of these or them configurable
-            //
-            // The request we make with the SDK asks for:
-            //
-            // - email
-            // - profile
-            // - https://www.googleapis.com/auth/userinfo.email
-            // - https://www.googleapis.com/auth/userinfo.profile
-            // - openid
-            //
             // See https://developers.google.com/identity/protocols/oauth2/scopes
-            ("scope", "https://www.googleapis.com/auth/userinfo.email")
+            ("scope", "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile")
         ].map { URLQueryItem(name: $0.0, value: $0.1) }
 
         if #available(iOS 16.0, *) {

--- a/WordPressAuthenticator/OAuth/OAuthTokenRequestBody.swift
+++ b/WordPressAuthenticator/OAuth/OAuthTokenRequestBody.swift
@@ -4,6 +4,7 @@
 struct OAuthTokenRequestBody: Encodable {
     let clientId: String
     let clientSecret: String
+    let audience: String
     let code: String
     let codeVerifier: String
     let grantType: String
@@ -12,6 +13,7 @@ struct OAuthTokenRequestBody: Encodable {
     enum CodingKeys: String, CodingKey {
         case clientId = "client_id"
         case clientSecret = "client_secret"
+        case audience
         case code
         case codeVerifier = "code_verifier"
         case grantType = "grant_type"
@@ -26,6 +28,10 @@ struct OAuthTokenRequestBody: Encodable {
             (CodingKeys.codeVerifier.rawValue, codeVerifier),
             (CodingKeys.grantType.rawValue, grantType),
             (CodingKeys.redirectURI.rawValue, redirectURI),
+            // This is not in the spec at
+            // https://developers.google.com/identity/protocols/oauth2/native-app#step-2:-send-a-request-to-googles-oauth-2.0-server
+            // but we'll get an idToken that our backend considers invalid if omitted.
+            (CodingKeys.audience.rawValue, audience),
         ]
 
         let items = params.map { URLQueryItem(name: $0.0, value: $0.1) }

--- a/WordPressAuthenticatorTests/GoogleSignIn/GoogleOAuthTokenGetterTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/GoogleOAuthTokenGetterTests.swift
@@ -11,6 +11,7 @@ class GoogleOAuthTokenGetterTests: XCTestCase {
         do {
             _ = try await getter.getToken(
                 clientId: GoogleClientId(string: "a.b.c")!,
+                audience: "audience",
                 authCode: "abc",
                 pkce: ProofKeyForCodeExchange(codeVerifier: "code", method: .plain)
             )
@@ -35,6 +36,7 @@ class GoogleOAuthTokenGetterTests: XCTestCase {
 
         let response = try await getter.getToken(
             clientId: GoogleClientId(string: "a.b.c")!,
+            audience: "audience",
             authCode: "abc",
             pkce: ProofKeyForCodeExchange(codeVerifier: "code", method: .plain)
         )

--- a/WordPressAuthenticatorTests/GoogleSignIn/GoogleOAuthTokenGettingStub.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/GoogleOAuthTokenGettingStub.swift
@@ -16,7 +16,12 @@ struct GoogleOAuthTokenGettingStub: GoogleOAuthTokenGetting {
         self.result = result
     }
 
-    func getToken(clientId: GoogleClientId, authCode: String, pkce: ProofKeyForCodeExchange) async throws -> OAuthTokenResponseBody {
+    func getToken(
+        clientId: GoogleClientId,
+        audience: String,
+        authCode: String,
+        pkce: ProofKeyForCodeExchange
+    ) async throws -> OAuthTokenResponseBody {
         switch result {
         case .success(let response): return response
         case .failure(let error): throw error

--- a/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
@@ -7,6 +7,7 @@ class OAuthRequestBodyGoogleSignInTests: XCTestCase {
         let pkce = ProofKeyForCodeExchange(codeVerifier: "test", method: .plain)
         let body = OAuthTokenRequestBody.googleSignInRequestBody(
             clientId: GoogleClientId(string: "com.app.123-abc")!,
+            audience: "audience",
             authCode: "codeValue",
             pkce: pkce
         )

--- a/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -34,7 +34,7 @@ class URLGoogleSignInTests: XCTestCase {
         assertQueryItems(
             for: url,
             includeItemNamed: "scope",
-            withValue: "https://www.googleapis.com/auth/userinfo.email"
+            withValue: "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
         )
         assertQueryItems(for: url, includeItemNamed: "response_type", withValue: "code")
     }

--- a/WordPressAuthenticatorTests/GoogleSignIn/URLRequest+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URLRequest+GoogleSignInTests.swift
@@ -6,6 +6,7 @@ class URLRequestOAuthTokenRequestTests: XCTestCase {
     let testBody = OAuthTokenRequestBody(
         clientId: "a",
         clientSecret: "b",
+        audience: "audience",
         code: "c",
         codeVerifier: "d",
         grantType: "e",

--- a/WordPressAuthenticatorTests/OAuth/OAuthTokenRequestBodyTests.swift
+++ b/WordPressAuthenticatorTests/OAuth/OAuthTokenRequestBodyTests.swift
@@ -7,6 +7,7 @@ class OAuthTokenRequestBodyTests: XCTestCase {
         let body = OAuthTokenRequestBody(
             clientId: "clientId",
             clientSecret: "clientSecret",
+            audience: "audience",
             code: "codeValue",
             codeVerifier: "codeVerifier",
             grantType: "grantType",


### PR DESCRIPTION
Just a few standalone changes and additions to the components for the Google SignIn SDK-less flow. 

See also #728 which also includes a list of next step items. 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
