### PR TITLE
Add new config to remove XMLRPC check for site address login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+-  Add new config to remove XMLRPC check for site address login [#736]
 
 ### Bug Fixes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.2.0):
+  - WordPressAuthenticator (5.3.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 8bfe947d011c1e207eb1c4e3d62d3e3f9ca4721a
+  WordPressAuthenticator: 959d99e67f51951e1cab1a2132aa0f113235236b
   WordPressKit: 08da0bc981f6398ef7a32e523fd054de7d7c7069
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.2.0'
+  s.version       = '5.3.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -142,7 +142,7 @@ public struct WordPressAuthenticatorConfiguration {
 
     /// If enabled, the library will trigger the delegate method `handleSiteCredentialLogin`
     /// instead of using the XMLRPC API for handling site credential login.
-    let manualSiteCredentialLogin: Bool
+    let enableManualSiteCredentialLogin: Bool
 
     /// Used to determine the `step` value for `unified_login_step` analytics event in `GetStartedViewController`
     ///
@@ -190,7 +190,7 @@ public struct WordPressAuthenticatorConfiguration {
                  wpcomPasswordInstructions: String? = nil,
                  skipXMLRPCCheckForSiteDiscovery: Bool = false,
                  skipXMLRPCCheckForSiteAddressLogin: Bool = false,
-                 manualSiteCredentialLogin: Bool = false,
+                 enableManualSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
                  enableSiteAddressLoginOnlyInPrologue: Bool = false) {
 
@@ -224,7 +224,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
         self.skipXMLRPCCheckForSiteAddressLogin = skipXMLRPCCheckForSiteAddressLogin
-        self.manualSiteCredentialLogin = manualSiteCredentialLogin
+        self.enableManualSiteCredentialLogin = enableManualSiteCredentialLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
     }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -136,6 +136,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let skipXMLRPCCheckForSiteDiscovery: Bool
 
+    /// If enabled, site address login will not check for XMLRPC URL.
+    ///
+    let skipXMLRPCCheckForSiteAddressLogin: Bool
+
     /// Used to determine the `step` value for `unified_login_step` analytics event in `GetStartedViewController`
     ///
     ///  - If disabled `start` will be used as `step` value
@@ -181,6 +185,7 @@ public struct WordPressAuthenticatorConfiguration {
                  emphasizeEmailForWPComPassword: Bool = false,
                  wpcomPasswordInstructions: String? = nil,
                  skipXMLRPCCheckForSiteDiscovery: Bool = false,
+                 skipXMLRPCCheckForSiteAddressLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
                  enableSiteAddressLoginOnlyInPrologue: Bool = false) {
 
@@ -213,6 +218,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.emphasizeEmailForWPComPassword = emphasizeEmailForWPComPassword
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
+        self.skipXMLRPCCheckForSiteAddressLogin = skipXMLRPCCheckForSiteAddressLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
     }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -136,11 +136,13 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let skipXMLRPCCheckForSiteDiscovery: Bool
 
-    /// If enabled, site address login will not check for XMLRPC URL or use XMLRPC API to handle login.
-    /// Important: make sure to implement the delegate method `handleSiteCredentialLogin` when enabling this config.
-    ///
+    /// If enabled, site address login will not check for XMLRPC URL.
     ///
     let skipXMLRPCCheckForSiteAddressLogin: Bool
+
+    /// If enabled, the library will trigger the delegate method `handleSiteCredentialLogin`
+    /// instead of using the XMLRPC API for handling site credential login.
+    let manualSiteCredentialLogin: Bool
 
     /// Used to determine the `step` value for `unified_login_step` analytics event in `GetStartedViewController`
     ///
@@ -188,6 +190,7 @@ public struct WordPressAuthenticatorConfiguration {
                  wpcomPasswordInstructions: String? = nil,
                  skipXMLRPCCheckForSiteDiscovery: Bool = false,
                  skipXMLRPCCheckForSiteAddressLogin: Bool = false,
+                 manualSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
                  enableSiteAddressLoginOnlyInPrologue: Bool = false) {
 
@@ -221,6 +224,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.wpcomPasswordInstructions = wpcomPasswordInstructions
         self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
         self.skipXMLRPCCheckForSiteAddressLogin = skipXMLRPCCheckForSiteAddressLogin
+        self.manualSiteCredentialLogin = manualSiteCredentialLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
     }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -136,7 +136,9 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let skipXMLRPCCheckForSiteDiscovery: Bool
 
-    /// If enabled, site address login will not check for XMLRPC URL.
+    /// If enabled, site address login will not check for XMLRPC URL or use XMLRPC API to handle login.
+    /// Important: make sure to implement the delegate method `handleSiteCredentialLogin` when enabling this config.
+    ///
     ///
     let skipXMLRPCCheckForSiteAddressLogin: Bool
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -115,9 +115,14 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     /// - Parameters:
     ///     - credentials: WordPress.org credentials submitted in the site credentials form.
+    ///     - navigationController: the current navigation stack of the site credential login flow.
     ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
+    ///     - onSuccess: the block to finish the login flow after login succeeds.
     ///
-    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials, onLoading: (Bool) -> Void)
+    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
+                                   in navigationController: UINavigationController?,
+                                   onLoading: (Bool) -> Void,
+                                   onSuccess: () -> Void)
 
     /// Signals to the Host App to navigate to the site creation flow.
     /// This method is currently used only in the simplified login flow
@@ -152,7 +157,10 @@ public extension WordPressAuthenticatorDelegate {
         // No-op
     }
 
-    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials, onLoading: (Bool) -> Void) {
+    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
+                                   in navigationController: UINavigationController?,
+                                   onLoading: (Bool) -> Void,
+                                   onSuccess: () -> Void) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -114,12 +114,14 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// This method is only triggered when the config `skipXMLRPCCheckForSiteAddressLogin` is enabled.
     ///
     /// - Parameters:
+    ///     - siteURL: The site to log in to
     ///     - credentials: WordPress.org credentials submitted in the site credentials form.
     ///     - navigationController: the current navigation stack of the site credential login flow.
     ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
     ///     - onSuccess: the block to finish the login flow after login succeeds.
     ///
-    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
+    func handleSiteCredentialLogin(siteURL: String,
+                                   credentials: WordPressOrgCredentials,
                                    in navigationController: UINavigationController?,
                                    onLoading: (Bool) -> Void,
                                    onSuccess: () -> Void)
@@ -157,7 +159,8 @@ public extension WordPressAuthenticatorDelegate {
         // No-op
     }
 
-    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
+    func handleSiteCredentialLogin(siteURL: String,
+                                   credentials: WordPressOrgCredentials,
                                    in navigationController: UINavigationController?,
                                    onLoading: (Bool) -> Void,
                                    onSuccess: () -> Void) {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -110,6 +110,15 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     func troubleshootSite(_ siteInfo: WordPressComSiteInfo?, in navigationController: UINavigationController?)
 
+    /// Sends site credentials to the host app so that it can handle login locally.
+    /// This method is only triggered when the config `skipXMLRPCCheckForSiteAddressLogin` is enabled.
+    ///
+    /// - Parameters:
+    ///     - credentials: WordPress.org credentials submitted in the site credentials form.
+    ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
+    ///
+    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials, onLoading: (Bool) -> Void)
+
     /// Signals to the Host App to navigate to the site creation flow.
     /// This method is currently used only in the simplified login flow
     /// when the configs `enableSimplifiedLoginI1` and `enableSiteCreationForSimplifiedLoginI1` is enabled
@@ -140,6 +149,10 @@ public extension WordPressAuthenticatorDelegate {
     }
 
     func showSiteCreation(in navigationController: UINavigationController) {
+        // No-op
+    }
+
+    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials, onLoading: (Bool) -> Void) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -116,15 +116,15 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// - Parameters:
     ///     - siteURL: The site to log in to
     ///     - credentials: WordPress.org credentials submitted in the site credentials form.
-    ///     - navigationController: the current navigation stack of the site credential login flow.
     ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
     ///     - onSuccess: the block to finish the login flow after login succeeds.
+    ///     - onFailure: the block to trigger error handling
     ///
     func handleSiteCredentialLogin(siteURL: String,
                                    credentials: WordPressOrgCredentials,
-                                   in navigationController: UINavigationController?,
                                    onLoading: (Bool) -> Void,
-                                   onSuccess: () -> Void)
+                                   onSuccess: () -> Void,
+                                   onFailure: (Error) -> Void)
 
     /// Signals to the Host App to navigate to the site creation flow.
     /// This method is currently used only in the simplified login flow
@@ -161,9 +161,9 @@ public extension WordPressAuthenticatorDelegate {
 
     func handleSiteCredentialLogin(siteURL: String,
                                    credentials: WordPressOrgCredentials,
-                                   in navigationController: UINavigationController?,
                                    onLoading: (Bool) -> Void,
-                                   onSuccess: () -> Void) {
+                                   onSuccess: () -> Void,
+                                   onFailure: (Error) -> Void) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -117,12 +117,12 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///     - credentials: WordPress.org credentials submitted in the site credentials form.
     ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
     ///     - onSuccess: the block to finish the login flow after login succeeds.
-    ///     - onFailure: the block to trigger error handling
+    ///     - onFailure: the block to trigger error handling. The closure accepts an error and a boolean indicating if the login failed with incorrect credentials.
     ///
     func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
-                                   onFailure: @escaping (Error) -> Void)
+                                   onFailure: @escaping (Error, Bool) -> Void)
 
     /// Signals to the Host App to navigate to the site creation flow.
     /// This method is currently used only in the simplified login flow
@@ -160,7 +160,7 @@ public extension WordPressAuthenticatorDelegate {
     func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
-                                   onFailure: @escaping (Error) -> Void) {
+                                   onFailure: @escaping (Error, Bool) -> Void) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -114,14 +114,12 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     /// This method is only triggered when the config `skipXMLRPCCheckForSiteAddressLogin` is enabled.
     ///
     /// - Parameters:
-    ///     - siteURL: The site to log in to
     ///     - credentials: WordPress.org credentials submitted in the site credentials form.
     ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
     ///     - onSuccess: the block to finish the login flow after login succeeds.
     ///     - onFailure: the block to trigger error handling
     ///
-    func handleSiteCredentialLogin(siteURL: String,
-                                   credentials: WordPressOrgCredentials,
+    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error) -> Void)
@@ -159,8 +157,7 @@ public extension WordPressAuthenticatorDelegate {
         // No-op
     }
 
-    func handleSiteCredentialLogin(siteURL: String,
-                                   credentials: WordPressOrgCredentials,
+    func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error) -> Void) {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -122,9 +122,9 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     func handleSiteCredentialLogin(siteURL: String,
                                    credentials: WordPressOrgCredentials,
-                                   onLoading: (Bool) -> Void,
-                                   onSuccess: () -> Void,
-                                   onFailure: (Error) -> Void)
+                                   onLoading: @escaping (Bool) -> Void,
+                                   onSuccess: @escaping () -> Void,
+                                   onFailure: @escaping (Error) -> Void)
 
     /// Signals to the Host App to navigate to the site creation flow.
     /// This method is currently used only in the simplified login flow
@@ -161,9 +161,9 @@ public extension WordPressAuthenticatorDelegate {
 
     func handleSiteCredentialLogin(siteURL: String,
                                    credentials: WordPressOrgCredentials,
-                                   onLoading: (Bool) -> Void,
-                                   onSuccess: () -> Void,
-                                   onFailure: (Error) -> Void) {
+                                   onLoading: @escaping (Bool) -> Void,
+                                   onSuccess: @escaping () -> Void,
+                                   onFailure: @escaping (Error) -> Void) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -443,7 +443,7 @@ private extension SiteAddressViewController {
         // Checks that the site exists
         checkSiteExistence(url: url) { [weak self] in
             guard let self = self else { return }
-            // skips XMLRPC check for site discovery if needed
+            // skips XMLRPC check for site discovery or site address login if needed
             if (self.isSiteDiscovery && self.configuration.skipXMLRPCCheckForSiteDiscovery) ||
                 self.configuration.skipXMLRPCCheckForSiteAddressLogin {
                 self.fetchSiteInfo()

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -444,7 +444,8 @@ private extension SiteAddressViewController {
         checkSiteExistence(url: url) { [weak self] in
             guard let self = self else { return }
             // skips XMLRPC check for site discovery if needed
-            if self.isSiteDiscovery && self.configuration.skipXMLRPCCheckForSiteDiscovery {
+            if (self.isSiteDiscovery && self.configuration.skipXMLRPCCheckForSiteDiscovery) ||
+                self.configuration.skipXMLRPCCheckForSiteAddressLogin {
                 self.fetchSiteInfo()
                 return
             }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -450,7 +450,8 @@ private extension SiteCredentialsViewController {
                                             password: loginFields.password,
                                             xmlrpc: "",
                                             options: [:])
-        delegate.handleSiteCredentialLogin(credentials: wporg,
+        delegate.handleSiteCredentialLogin(siteURL: loginFields.siteAddress,
+                                           credentials: wporg,
                                            in: navigationController,
                                            onLoading: { [weak self] shouldShowLoading in
             self?.configureViewLoading(shouldShowLoading)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -459,11 +459,21 @@ private extension SiteCredentialsViewController {
                                 password: wporg.password,
                                 xmlrpc: wporg.xmlrpc,
                                 options: wporg.options)
-        }, onFailure: { [weak self] error in
-            self?.displayRemoteError(error)
+        }, onFailure: { [weak self] error, incorrectCredentials in
+            self?.handleLoginFailure(error: error, incorrectCredentials: incorrectCredentials)
         })
     }
 
+    func handleLoginFailure(error: Error, incorrectCredentials: Bool) {
+        configureViewLoading(false)
+        if incorrectCredentials {
+            let message = NSLocalizedString("It looks like this username/password isn't associated with this site.",
+                                            comment: "An error message shown during log in when the username or password is incorrect.")
+            displayError(message: message, moveVoiceOverFocus: true)
+        } else {
+            displayError(error as NSError, sourceTag: sourceTag)
+        }
+    }
     // MARK: - Private Constants
 
     /// Rows listed in the order they were created.
@@ -556,7 +566,7 @@ extension SiteCredentialsViewController {
     override func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
         let err = error as NSError
-        if err.code == 403 || err.code == 401 {
+        if err.code == 403 {
             let message = NSLocalizedString("It looks like this username/password isn't associated with this site.",
                                             comment: "An error message shown during log in when the username or password is incorrect.")
             displayError(message: message, moveVoiceOverFocus: true)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -446,13 +446,13 @@ private extension SiteCredentialsViewController {
         guard let delegate = WordPressAuthenticator.shared.delegate else {
             fatalError("Error: Where did the delegate go?")
         }
+        // manually construct the XMLRPC since this is needed to get the site address later
+        let xmlrpc = loginFields.siteAddress + "/xmlrpc.php"
         let wporg = WordPressOrgCredentials(username: loginFields.username,
                                             password: loginFields.password,
-                                            xmlrpc: "",
+                                            xmlrpc: xmlrpc,
                                             options: [:])
-        delegate.handleSiteCredentialLogin(siteURL: loginFields.siteAddress,
-                                           credentials: wporg,
-                                           onLoading: { [weak self] shouldShowLoading in
+        delegate.handleSiteCredentialLogin(credentials: wporg, onLoading: { [weak self] shouldShowLoading in
             self?.configureViewLoading(shouldShowLoading)
         }, onSuccess: { [weak self] in
             self?.finishedLogin(withUsername: wporg.username,

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -510,7 +510,7 @@ extension SiteCredentialsViewController {
     /// proceeds with the submit action.
     ///
     @objc func validateForm() {
-        guard WordPressAuthenticator.shared.configuration.skipXMLRPCCheckForSiteAddressLogin else {
+        guard WordPressAuthenticator.shared.configuration.manualSiteCredentialLogin else {
             return validateFormAndLogin() // handles login with XMLRPC normally
         }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -450,8 +450,15 @@ private extension SiteCredentialsViewController {
                                             password: loginFields.password,
                                             xmlrpc: "",
                                             options: [:])
-        delegate.handleSiteCredentialLogin(credentials: wporg, onLoading: { [weak self] shouldShowLoading in
+        delegate.handleSiteCredentialLogin(credentials: wporg,
+                                           in: navigationController,
+                                           onLoading: { [weak self] shouldShowLoading in
             self?.configureViewLoading(shouldShowLoading)
+        }, onSuccess: { [weak self] in
+            self?.finishedLogin(withUsername: wporg.username,
+                                password: wporg.password,
+                                xmlrpc: wporg.xmlrpc,
+                                options: wporg.options)
         })
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -520,7 +520,7 @@ extension SiteCredentialsViewController {
     /// proceeds with the submit action.
     ///
     @objc func validateForm() {
-        guard WordPressAuthenticator.shared.configuration.manualSiteCredentialLogin else {
+        guard WordPressAuthenticator.shared.configuration.enableManualSiteCredentialLogin else {
             return validateFormAndLogin() // handles login with XMLRPC normally
         }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -452,7 +452,6 @@ private extension SiteCredentialsViewController {
                                             options: [:])
         delegate.handleSiteCredentialLogin(siteURL: loginFields.siteAddress,
                                            credentials: wporg,
-                                           in: navigationController,
                                            onLoading: { [weak self] shouldShowLoading in
             self?.configureViewLoading(shouldShowLoading)
         }, onSuccess: { [weak self] in
@@ -460,6 +459,8 @@ private extension SiteCredentialsViewController {
                                 password: wporg.password,
                                 xmlrpc: wporg.xmlrpc,
                                 options: wporg.options)
+        }, onFailure: { [weak self] error in
+            self?.displayRemoteError(error)
         })
     }
 
@@ -555,7 +556,7 @@ extension SiteCredentialsViewController {
     override func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
         let err = error as NSError
-        if err.code == 403 {
+        if err.code == 403 || err.code == 401 {
             let message = NSLocalizedString("It looks like this username/password isn't associated with this site.",
                                             comment: "An error message shown during log in when the username or password is incorrect.")
             displayError(message: message, moveVoiceOverFocus: true)


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8770.

**Description**
This PR adds a new config to remove XMLRPC checks for site address login. When this is enabled, the library will trigger a new delegate method `handleSiteCredentialLogin`, so that the host app will need to handle the login with the input credentials. This allows the login to be handled without the need of using XMLRPC API.

**Testing steps**
Please follow https://github.com/woocommerce/woocommerce-ios/pull/8790 to test this new change.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
