### PR TITLE
Disable credential picker for site address login only

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.3.0-beta.1):
+  - WordPressAuthenticator (5.3.0-beta.2):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 959d99e67f51951e1cab1a2132aa0f113235236b
+  WordPressAuthenticator: b6725385948625ec7f8c6426bc22b0ebb9c8d0d4
   WordPressKit: 08da0bc981f6398ef7a32e523fd054de7d7c7069
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.3.0-beta.1'
+  s.version       = '5.3.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -112,7 +112,10 @@ class LoginPrologueViewController: LoginViewController {
             tracker.set(step: .prologue)
         }
 
-        showiCloudKeychainLoginFlow()
+        // Only enable auto fill if WPCom login is available
+        if configuration.enableSiteAddressLoginOnlyInPrologue == false {
+            showiCloudKeychainLoginFlow()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-ios/issues/8816.

**Description**
In WooCommerce, when the config `enableSiteAddressLoginOnlyInPrologue` is enabled, we allow users to log in only with site address. If the credentials are available for WPCom in Keychain, we'll let them login in with WPCom automatically.

To avoid this undefined behavior, this PR disables that case by not presenting the credential picker if  `enableSiteAddressLoginOnlyInPrologue` is on.

**Testing steps**
Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/8817.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
