### PR TITLE
Add type modeling Google SignIn "ID token"

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		3F338B6A289B877F0014ADC5 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B69289B877F0014ADC5 /* BuildkiteTestCollector */; };
 		3F4E646C2990B732000DB555 /* Data+Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E646B2990B732000DB555 /* Data+Base64URL.swift */; };
 		3F4E64702990B7B3000DB555 /* Data+Base64URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */; };
+		3F4E64722990B835000DB555 /* JWToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64712990B835000DB555 /* JWToken.swift */; };
+		3F4E64742990B92B000DB555 /* JWTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64732990B92B000DB555 /* JWTokenTests.swift */; };
 		3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */; };
 		3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */; };
 		3F550D5323DA4AC6007E5897 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5223DA4AC6007E5897 /* URLHandler.swift */; };
@@ -257,6 +259,8 @@
 		3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		3F4E646B2990B732000DB555 /* Data+Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64URL.swift"; sourceTree = "<group>"; };
 		3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64URLTests.swift"; sourceTree = "<group>"; };
+		3F4E64712990B835000DB555 /* JWToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWToken.swift; sourceTree = "<group>"; };
+		3F4E64732990B92B000DB555 /* JWTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTokenTests.swift; sourceTree = "<group>"; };
 		3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelectorTests.swift; sourceTree = "<group>"; };
 		3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkMailPresenter.swift; sourceTree = "<group>"; };
 		3F550D5223DA4AC6007E5897 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
@@ -552,6 +556,7 @@
 				3F879FED293A752A005C2B48 /* GoogleOAuthTokenGetter.swift */,
 				3F879FEB293A74E0005C2B48 /* GoogleOAuthTokenGetting.swift */,
 				3F88166F2983EB4A00AEC4C0 /* IDToken.swift */,
+				3F4E64712990B835000DB555 /* JWToken.swift */,
 				3F879FE0293A53CB005C2B48 /* OAuthRequestBody+GoogleSignIn.swift */,
 				3FE8072029365F6D0088420C /* URL+GoogleSignIn.swift */,
 				3F879FDC293A500D005C2B48 /* URLRequest+GoogleSignIn.swift */,
@@ -568,6 +573,7 @@
 				3F879FE7293A573E005C2B48 /* GoogleClientIdTests.swift */,
 				3F879FF3293A7F46005C2B48 /* GoogleOAuthTokenGetterTests.swift */,
 				3F879FF7293E222E005C2B48 /* GoogleOAuthTokenGettingStub.swift */,
+				3F4E64732990B92B000DB555 /* JWTokenTests.swift */,
 				3F879FE3293A545C005C2B48 /* OAuthRequestBody+GoogleSignInTests.swift */,
 				3FE8071E2936558F0088420C /* URL+GoogleSignInTests.swift */,
 				3F879FDE293A501D005C2B48 /* URLRequest+GoogleSignInTests.swift */,
@@ -1374,6 +1380,7 @@
 				988AD8A324CB839900BD045E /* TwoFAViewController.swift in Sources */,
 				3F879FD9293A48B2005C2B48 /* OAuthTokenResponseBody.swift in Sources */,
 				3F879FEE293A752A005C2B48 /* GoogleOAuthTokenGetter.swift in Sources */,
+				3F4E64722990B835000DB555 /* JWToken.swift in Sources */,
 				CE6BCD2E24A3A235001BCDC5 /* TextLabelTableViewCell.swift in Sources */,
 				B56090D3208A4F5400399AE4 /* NUXLinkAuthViewController.swift in Sources */,
 				B5609120208A555E00399AE4 /* SignupNavigationController.swift in Sources */,
@@ -1526,6 +1533,7 @@
 				3F879FF8293E222E005C2B48 /* GoogleOAuthTokenGettingStub.swift in Sources */,
 				3F879FE8293A573E005C2B48 /* GoogleClientIdTests.swift in Sources */,
 				3F879FE4293A545C005C2B48 /* OAuthRequestBody+GoogleSignInTests.swift in Sources */,
+				3F4E64742990B92B000DB555 /* JWTokenTests.swift in Sources */,
 				F12F9FB824D8A7FC00771BCE /* AnalyticsTrackerTests.swift in Sources */,
 				B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */,
 			);

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3F879FF6293E1F8E005C2B48 /* OAuthTokenResponseBody+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FF5293E1F8E005C2B48 /* OAuthTokenResponseBody+Fixture.swift */; };
 		3F879FF8293E222E005C2B48 /* GoogleOAuthTokenGettingStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FF7293E222E005C2B48 /* GoogleOAuthTokenGettingStub.swift */; };
 		3F881660298150FB00AEC4C0 /* URLSesison+DataGetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F88165F298150FB00AEC4C0 /* URLSesison+DataGetting.swift */; };
+		3F8816702983EB4A00AEC4C0 /* IDToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F88166F2983EB4A00AEC4C0 /* IDToken.swift */; };
 		3F9439BE27D6F9B60067183A /* LoginPrologueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */; };
 		3FE8071529364C410088420C /* Result+ConvenienceInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */; };
 		3FE80717293650190088420C /* Result+ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE80716293650190088420C /* Result+ConvenienceInit.swift */; };
@@ -272,6 +273,7 @@
 		3F879FF5293E1F8E005C2B48 /* OAuthTokenResponseBody+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OAuthTokenResponseBody+Fixture.swift"; sourceTree = "<group>"; };
 		3F879FF7293E222E005C2B48 /* GoogleOAuthTokenGettingStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleOAuthTokenGettingStub.swift; sourceTree = "<group>"; };
 		3F88165F298150FB00AEC4C0 /* URLSesison+DataGetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSesison+DataGetting.swift"; sourceTree = "<group>"; };
+		3F88166F2983EB4A00AEC4C0 /* IDToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDToken.swift; sourceTree = "<group>"; };
 		3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPrologueViewController.swift; sourceTree = "<group>"; };
 		3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInitTests.swift"; sourceTree = "<group>"; };
 		3FE80716293650190088420C /* Result+ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInit.swift"; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 				3F879FE5293A571B005C2B48 /* GoogleClientId.swift */,
 				3F879FED293A752A005C2B48 /* GoogleOAuthTokenGetter.swift */,
 				3F879FEB293A74E0005C2B48 /* GoogleOAuthTokenGetting.swift */,
+				3F88166F2983EB4A00AEC4C0 /* IDToken.swift */,
 				3F879FE0293A53CB005C2B48 /* OAuthRequestBody+GoogleSignIn.swift */,
 				3FE8072029365F6D0088420C /* URL+GoogleSignIn.swift */,
 				3F879FDC293A500D005C2B48 /* URLRequest+GoogleSignIn.swift */,
@@ -1447,6 +1450,7 @@
 				B56090EB208A51D000399AE4 /* LoginFields.swift in Sources */,
 				B56090FB208A533200399AE4 /* WordPressSupportSourceTag.swift in Sources */,
 				F1AF1BEF24E4A80F00BA453E /* LoginFacade.swift in Sources */,
+				3F8816702983EB4A00AEC4C0 /* IDToken.swift in Sources */,
 				B56090C6208A4F5400399AE4 /* NUXButtonViewController.swift in Sources */,
 				B5609121208A555E00399AE4 /* SignupEmailViewController.swift in Sources */,
 				B5609107208A54F800399AE4 /* WordPressComBlogService.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		1A4095182271AEFC009AA86D /* WPAuthenticator-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3108613125AFA4830022F75E /* PasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3108613025AFA4830022F75E /* PasteboardTests.swift */; };
 		3F338B6A289B877F0014ADC5 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B69289B877F0014ADC5 /* BuildkiteTestCollector */; };
+		3F4E646C2990B732000DB555 /* Data+Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E646B2990B732000DB555 /* Data+Base64URL.swift */; };
+		3F4E64702990B7B3000DB555 /* Data+Base64URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */; };
 		3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */; };
 		3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */; };
 		3F550D5323DA4AC6007E5897 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5223DA4AC6007E5897 /* URLHandler.swift */; };
@@ -253,6 +255,8 @@
 		33FEF45B466FF8EAAE5F3923 /* Pods-WordPressAuthenticator.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release.xcconfig"; sourceTree = "<group>"; };
 		37AFD4EF492B00CA7AEC11A3 /* Pods-WordPressAuthenticatorTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		3F4E646B2990B732000DB555 /* Data+Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64URL.swift"; sourceTree = "<group>"; };
+		3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64URLTests.swift"; sourceTree = "<group>"; };
 		3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelectorTests.swift; sourceTree = "<group>"; };
 		3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkMailPresenter.swift; sourceTree = "<group>"; };
 		3F550D5223DA4AC6007E5897 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
@@ -542,6 +546,7 @@
 		3FE8072229365F740088420C /* GoogleSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				3F4E646B2990B732000DB555 /* Data+Base64URL.swift */,
 				3F879FF1293A7F02005C2B48 /* DataGetting.swift */,
 				3F879FE5293A571B005C2B48 /* GoogleClientId.swift */,
 				3F879FED293A752A005C2B48 /* GoogleOAuthTokenGetter.swift */,
@@ -558,6 +563,7 @@
 		3FE8072329365FC20088420C /* GoogleSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */,
 				3F879FEF293A7EDE005C2B48 /* DataGettingStub.swift */,
 				3F879FE7293A573E005C2B48 /* GoogleClientIdTests.swift */,
 				3F879FF3293A7F46005C2B48 /* GoogleOAuthTokenGetterTests.swift */,
@@ -1419,6 +1425,7 @@
 				3F550D5323DA4AC6007E5897 /* URLHandler.swift in Sources */,
 				D8610CE82570A5B000A5DF27 /* NavigateToRoot.swift in Sources */,
 				98C9195B2308E3DA00A90E12 /* AppleAuthenticator.swift in Sources */,
+				3F4E646C2990B732000DB555 /* Data+Base64URL.swift in Sources */,
 				B56090F9208A533200399AE4 /* WordPressAuthenticator+Events.swift in Sources */,
 				CEDE0D93242011E000CB3345 /* NSObject+Helpers.swift in Sources */,
 				020DEF6428AA091100C85D51 /* MagicLinkRequester.swift in Sources */,
@@ -1501,6 +1508,7 @@
 				BA53D64624DFDE1D001F1ABF /* CredentialsTests.swift in Sources */,
 				3F879FF6293E1F8E005C2B48 /* OAuthTokenResponseBody+Fixture.swift in Sources */,
 				D85C36EC256E10EA00D56E34 /* MockNavigationController.swift in Sources */,
+				3F4E64702990B7B3000DB555 /* Data+Base64URLTests.swift in Sources */,
 				3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */,
 				BA53D64B24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift in Sources */,
 				4A1DEF4A29341B1F00322608 /* LoggingTests.m in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3F4E64702990B7B3000DB555 /* Data+Base64URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */; };
 		3F4E64722990B835000DB555 /* JWToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64712990B835000DB555 /* JWToken.swift */; };
 		3F4E64742990B92B000DB555 /* JWTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64732990B92B000DB555 /* JWTokenTests.swift */; };
+		3F4E64782990BBD4000DB555 /* IDTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64772990BBD4000DB555 /* IDTokenTests.swift */; };
 		3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */; };
 		3F550D5123DA4A9C007E5897 /* LinkMailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */; };
 		3F550D5323DA4AC6007E5897 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D5223DA4AC6007E5897 /* URLHandler.swift */; };
@@ -261,6 +262,7 @@
 		3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64URLTests.swift"; sourceTree = "<group>"; };
 		3F4E64712990B835000DB555 /* JWToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWToken.swift; sourceTree = "<group>"; };
 		3F4E64732990B92B000DB555 /* JWTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTokenTests.swift; sourceTree = "<group>"; };
+		3F4E64772990BBD4000DB555 /* IDTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTokenTests.swift; sourceTree = "<group>"; };
 		3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelectorTests.swift; sourceTree = "<group>"; };
 		3F550D5023DA4A9C007E5897 /* LinkMailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkMailPresenter.swift; sourceTree = "<group>"; };
 		3F550D5223DA4AC6007E5897 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
@@ -573,6 +575,7 @@
 				3F879FE7293A573E005C2B48 /* GoogleClientIdTests.swift */,
 				3F879FF3293A7F46005C2B48 /* GoogleOAuthTokenGetterTests.swift */,
 				3F879FF7293E222E005C2B48 /* GoogleOAuthTokenGettingStub.swift */,
+				3F4E64772990BBD4000DB555 /* IDTokenTests.swift */,
 				3F4E64732990B92B000DB555 /* JWTokenTests.swift */,
 				3F879FE3293A545C005C2B48 /* OAuthRequestBody+GoogleSignInTests.swift */,
 				3FE8071E2936558F0088420C /* URL+GoogleSignInTests.swift */,
@@ -1503,6 +1506,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F4E64782990BBD4000DB555 /* IDTokenTests.swift in Sources */,
 				F18DF0E5252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h in Sources */,
 				3FE8071529364C410088420C /* Result+ConvenienceInitTests.swift in Sources */,
 				3F879FF0293A7EDE005C2B48 /* DataGettingStub.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		3F338B6A289B877F0014ADC5 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B69289B877F0014ADC5 /* BuildkiteTestCollector */; };
 		3F4E646C2990B732000DB555 /* Data+Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E646B2990B732000DB555 /* Data+Base64URL.swift */; };
 		3F4E64702990B7B3000DB555 /* Data+Base64URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */; };
-		3F4E64722990B835000DB555 /* JWToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64712990B835000DB555 /* JWToken.swift */; };
+		3F4E64722990B835000DB555 /* JSONWebToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64712990B835000DB555 /* JSONWebToken.swift */; };
 		3F4E64742990B92B000DB555 /* JWTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64732990B92B000DB555 /* JWTokenTests.swift */; };
 		3F4E64782990BBD4000DB555 /* IDTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E64772990BBD4000DB555 /* IDTokenTests.swift */; };
 		3F550D4E23DA429B007E5897 /* AppSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */; };
@@ -260,7 +260,7 @@
 		3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		3F4E646B2990B732000DB555 /* Data+Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64URL.swift"; sourceTree = "<group>"; };
 		3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Base64URLTests.swift"; sourceTree = "<group>"; };
-		3F4E64712990B835000DB555 /* JWToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWToken.swift; sourceTree = "<group>"; };
+		3F4E64712990B835000DB555 /* JSONWebToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONWebToken.swift; sourceTree = "<group>"; };
 		3F4E64732990B92B000DB555 /* JWTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTokenTests.swift; sourceTree = "<group>"; };
 		3F4E64772990BBD4000DB555 /* IDTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTokenTests.swift; sourceTree = "<group>"; };
 		3F550D4D23DA429B007E5897 /* AppSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelectorTests.swift; sourceTree = "<group>"; };
@@ -558,7 +558,7 @@
 				3F879FED293A752A005C2B48 /* GoogleOAuthTokenGetter.swift */,
 				3F879FEB293A74E0005C2B48 /* GoogleOAuthTokenGetting.swift */,
 				3F88166F2983EB4A00AEC4C0 /* IDToken.swift */,
-				3F4E64712990B835000DB555 /* JWToken.swift */,
+				3F4E64712990B835000DB555 /* JSONWebToken.swift */,
 				3F879FE0293A53CB005C2B48 /* OAuthRequestBody+GoogleSignIn.swift */,
 				3FE8072029365F6D0088420C /* URL+GoogleSignIn.swift */,
 				3F879FDC293A500D005C2B48 /* URLRequest+GoogleSignIn.swift */,
@@ -1383,7 +1383,7 @@
 				988AD8A324CB839900BD045E /* TwoFAViewController.swift in Sources */,
 				3F879FD9293A48B2005C2B48 /* OAuthTokenResponseBody.swift in Sources */,
 				3F879FEE293A752A005C2B48 /* GoogleOAuthTokenGetter.swift in Sources */,
-				3F4E64722990B835000DB555 /* JWToken.swift in Sources */,
+				3F4E64722990B835000DB555 /* JSONWebToken.swift in Sources */,
 				CE6BCD2E24A3A235001BCDC5 /* TextLabelTableViewCell.swift in Sources */,
 				B56090D3208A4F5400399AE4 /* NUXLinkAuthViewController.swift in Sources */,
 				B5609120208A555E00399AE4 /* SignupNavigationController.swift in Sources */,

--- a/WordPressAuthenticator/GoogleSignIn/Data+Base64URL.swift
+++ b/WordPressAuthenticator/GoogleSignIn/Data+Base64URL.swift
@@ -1,0 +1,24 @@
+extension Data {
+
+    /// "base64url" is an encoding that is safe to use with URLs.
+    /// It is defined in RFC 4648, section 5.
+    ///
+    /// See:
+    /// - https://tools.ietf.org/html/rfc4648#section-5
+    /// - https://tools.ietf.org/html/rfc7515#appendix-C
+    init(base64URLDecode: String) {
+        let base64 = base64URLDecode
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+        let requiredLength = 4 * ceil(length / 4.0)
+        let paddingLength = requiredLength - length
+        if paddingLength > 0 {
+            let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+            self.init(base64Encoded: base64 + padding, options: .ignoreUnknownCharacters)!
+        } else {
+            self.init(base64Encoded: base64, options: .ignoreUnknownCharacters)!
+        }
+    }
+}

--- a/WordPressAuthenticator/GoogleSignIn/Data+Base64URL.swift
+++ b/WordPressAuthenticator/GoogleSignIn/Data+Base64URL.swift
@@ -6,8 +6,8 @@ extension Data {
     /// See:
     /// - https://tools.ietf.org/html/rfc4648#section-5
     /// - https://tools.ietf.org/html/rfc7515#appendix-C
-    init(base64URLDecode: String) {
-        let base64 = base64URLDecode
+    init?(base64URLEncoded: String) {
+        let base64 = base64URLEncoded
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
 
@@ -16,9 +16,9 @@ extension Data {
         let paddingLength = requiredLength - length
         if paddingLength > 0 {
             let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
-            self.init(base64Encoded: base64 + padding, options: .ignoreUnknownCharacters)!
+            self.init(base64Encoded: base64 + padding, options: .ignoreUnknownCharacters)
         } else {
-            self.init(base64Encoded: base64, options: .ignoreUnknownCharacters)!
+            self.init(base64Encoded: base64, options: .ignoreUnknownCharacters)
         }
     }
 }

--- a/WordPressAuthenticator/GoogleSignIn/IDToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/IDToken.swift
@@ -1,46 +1,14 @@
 /// See https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo
 public struct IDToken {
 
+    let email: String
+
     // TODO: Validate token! – https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken
-    public let encodedValue: String
+    init?(jwt: JWToken) {
+        guard let email = jwt.payload["email"] as? String else {
+            return nil
+        }
 
-    private let decodedValue: [String: Any]
-
-    public let email: String?
-
-    public init(jwt: String) {
-        encodedValue = jwt
-        decodedValue = decode(jwtToken: jwt)
-        email = decodedValue["email"] as? String
+        self.email = email
     }
-}
-
-// Credits: https://stackoverflow.com/a/40915703/809944
-private func decode(jwtToken jwt: String) -> [String: Any] {
-    let segments = jwt.components(separatedBy: ".")
-    return decodeJWTPart(segments[1]) ?? [:]
-}
-
-private func base64UrlDecode(_ value: String) -> Data? {
-    var base64 = value
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-
-    let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
-    let requiredLength = 4 * ceil(length / 4.0)
-    let paddingLength = requiredLength - length
-    if paddingLength > 0 {
-        let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
-        base64 = base64 + padding
-    }
-    return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
-}
-
-private func decodeJWTPart(_ value: String) -> [String: Any]? {
-    guard let bodyData = base64UrlDecode(value),
-          let json = try? JSONSerialization.jsonObject(with: bodyData, options: []), let payload = json as? [String: Any] else {
-        return nil
-    }
-
-    return payload
 }

--- a/WordPressAuthenticator/GoogleSignIn/IDToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/IDToken.swift
@@ -1,7 +1,7 @@
 /// See https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo
 public struct IDToken {
 
-    public let token: String
+    public let token: JSONWebToken
     public let email: String
 
     // TODO: Validate token! – https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken
@@ -10,7 +10,7 @@ public struct IDToken {
             return nil
         }
 
-        self.token = jwt.rawValue
+        self.token = jwt
         self.email = email
     }
 }

--- a/WordPressAuthenticator/GoogleSignIn/IDToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/IDToken.swift
@@ -1,0 +1,46 @@
+/// See https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo
+public struct IDToken {
+
+    // TODO: Validate token! – https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken
+    public let encodedValue: String
+
+    private let decodedValue: [String: Any]
+
+    public let email: String?
+
+    public init(jwt: String) {
+        encodedValue = jwt
+        decodedValue = decode(jwtToken: jwt)
+        email = decodedValue["email"] as? String
+    }
+}
+
+// Credits: https://stackoverflow.com/a/40915703/809944
+private func decode(jwtToken jwt: String) -> [String: Any] {
+    let segments = jwt.components(separatedBy: ".")
+    return decodeJWTPart(segments[1]) ?? [:]
+}
+
+private func base64UrlDecode(_ value: String) -> Data? {
+    var base64 = value
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+
+    let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+    let requiredLength = 4 * ceil(length / 4.0)
+    let paddingLength = requiredLength - length
+    if paddingLength > 0 {
+        let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+        base64 = base64 + padding
+    }
+    return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+}
+
+private func decodeJWTPart(_ value: String) -> [String: Any]? {
+    guard let bodyData = base64UrlDecode(value),
+          let json = try? JSONSerialization.jsonObject(with: bodyData, options: []), let payload = json as? [String: Any] else {
+        return nil
+    }
+
+    return payload
+}

--- a/WordPressAuthenticator/GoogleSignIn/IDToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/IDToken.swift
@@ -10,7 +10,7 @@ public struct IDToken {
             return nil
         }
 
-        self.token = jwt.encodedValue
+        self.token = jwt.rawValue
         self.email = email
     }
 }

--- a/WordPressAuthenticator/GoogleSignIn/IDToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/IDToken.swift
@@ -5,7 +5,7 @@ public struct IDToken {
     public let email: String
 
     // TODO: Validate token! – https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken
-    init?(jwt: JWToken) {
+    init?(jwt: JSONWebToken) {
         guard let email = jwt.payload["email"] as? String else {
             return nil
         }

--- a/WordPressAuthenticator/GoogleSignIn/IDToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/IDToken.swift
@@ -1,7 +1,8 @@
 /// See https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo
 public struct IDToken {
 
-    let email: String
+    public let token: String
+    public let email: String
 
     // TODO: Validate token! – https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken
     init?(jwt: JWToken) {
@@ -9,6 +10,7 @@ public struct IDToken {
             return nil
         }
 
+        self.token = jwt.encodedValue
         self.email = email
     }
 }

--- a/WordPressAuthenticator/GoogleSignIn/JSONWebToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/JSONWebToken.swift
@@ -2,7 +2,7 @@
 ///
 /// See https://jwt.io/introduction
 struct JSONWebToken {
-    let encodedValue: String
+    let rawValue: String
 
     let header: [String: Any]
     let payload: [String: Any]
@@ -39,7 +39,7 @@ struct JSONWebToken {
             return nil
         }
 
-        self.encodedValue = encodedString
+        self.rawValue = encodedString
         self.header = header
         self.payload = payload
         self.signature = segments[2]

--- a/WordPressAuthenticator/GoogleSignIn/JSONWebToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/JSONWebToken.swift
@@ -1,7 +1,7 @@
 /// Represents a JSON Web Token (JWT)
 ///
 /// See https://jwt.io/introduction
-struct JWToken {
+struct JSONWebToken {
     let encodedValue: String
 
     let header: [String: Any]

--- a/WordPressAuthenticator/GoogleSignIn/JSONWebToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/JSONWebToken.swift
@@ -1,7 +1,7 @@
 /// Represents a JSON Web Token (JWT)
 ///
 /// See https://jwt.io/introduction
-struct JSONWebToken {
+public struct JSONWebToken {
     let rawValue: String
 
     let header: [String: Any]

--- a/WordPressAuthenticator/GoogleSignIn/JWToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/JWToken.swift
@@ -2,6 +2,8 @@
 ///
 /// See https://jwt.io/introduction
 struct JWToken {
+    let encodedValue: String
+
     let header: [String: Any]
     let payload: [String: Any]
     let signature: String
@@ -37,6 +39,7 @@ struct JWToken {
             return nil
         }
 
+        self.encodedValue = encodedString
         self.header = header
         self.payload = payload
         self.signature = segments[2]

--- a/WordPressAuthenticator/GoogleSignIn/JWToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/JWToken.swift
@@ -1,0 +1,38 @@
+/// Represents a JSON Web Token (JWT)
+///
+/// See https://jwt.io/introduction
+struct JWToken {
+    let header: [String: Any]
+    let payload: [String: Any]
+    let signature: String
+
+    init?(encodedString: String) {
+        let segments = encodedString.components(separatedBy: ".")
+
+        // JWT has three segments: header, payload, and signature
+        guard segments.count == 3 else {
+            return nil
+        }
+
+        // Notice that JWT uses base64url encoding, not base64.
+        //
+        // See:
+        // - https://tools.ietf.org/html/rfc7515#appendix-C
+        // - https://jwt.io/introduction
+        let headerData = Data(base64URLDecode: segments[0])
+        let payloadData = Data(base64URLDecode: segments[1])
+
+        // Note: Splitting the guards is useful to know which one fails
+        guard let header = try? JSONSerialization.jsonObject(with: headerData, options: []) as? [String: Any] else {
+            return nil
+        }
+
+        guard let payload = try? JSONSerialization.jsonObject(with: payloadData, options: []) as? [String: Any] else {
+            return nil
+        }
+
+        self.header = header
+        self.payload = payload
+        self.signature = segments[2]
+    }
+}

--- a/WordPressAuthenticator/GoogleSignIn/JWToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/JWToken.swift
@@ -19,10 +19,16 @@ struct JWToken {
         // See:
         // - https://tools.ietf.org/html/rfc7515#appendix-C
         // - https://jwt.io/introduction
-        let headerData = Data(base64URLDecode: segments[0])
-        let payloadData = Data(base64URLDecode: segments[1])
 
         // Note: Splitting the guards is useful to know which one fails
+        guard let headerData = Data(base64URLEncoded: segments[0]) else {
+            return nil
+        }
+
+        guard let payloadData = Data(base64URLEncoded: segments[1]) else {
+            return nil
+        }
+
         guard let header = try? JSONSerialization.jsonObject(with: headerData, options: []) as? [String: Any] else {
             return nil
         }

--- a/WordPressAuthenticatorTests/GoogleSignIn/Data+Base64URLTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/Data+Base64URLTests.swift
@@ -5,35 +5,35 @@ class DataBase64URLDecoding: XCTestCase {
 
     func testBase64URLDecoding() {
         XCTAssertEqual(
-            Data(base64URLDecode: "aGVsbG8gd29ybGQ"),
+            Data(base64URLEncoded: "aGVsbG8gd29ybGQ"),
             "hello world".data(using: .utf8)
         )
     }
 
     func testBase64URLDecodingWithPadding() {
         XCTAssertEqual(
-            Data(base64URLDecode: "dGVzdA="),
+            Data(base64URLEncoded: "dGVzdA="),
             "test".data(using: .utf8)
         )
     }
 
     func testBase64URLDecodingWithDoublePadding() {
         XCTAssertEqual(
-            Data(base64URLDecode: "dGVzdA=="),
+            Data(base64URLEncoded: "dGVzdA=="),
             "test".data(using: .utf8)
         )
     }
 
     func testBase64URLDecodingWithNonAlphaNumericCharacters() {
         XCTAssertEqual(
-            Data(base64URLDecode: "V2lsbCB0aGlzIHdvcmsgZm9yIGEgc3RyaW5nIHdpdGggbm9uLWFscGhhbnVtZXJpYyBjaGFyYWN0ZXJzPyE/JiU="),
+            Data(base64URLEncoded: "V2lsbCB0aGlzIHdvcmsgZm9yIGEgc3RyaW5nIHdpdGggbm9uLWFscGhhbnVtZXJpYyBjaGFyYWN0ZXJzPyE/JiU="),
             "Will this work for a string with non-alphanumeric characters?!?&%".data(using: .utf8)
         )
     }
 
     func testBase64URLDecodingWithEmptyString() {
         XCTAssertEqual(
-            Data(base64URLDecode: ""),
+            Data(base64URLEncoded: ""),
             Data()
         )
     }

--- a/WordPressAuthenticatorTests/GoogleSignIn/Data+Base64URLTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/Data+Base64URLTests.swift
@@ -1,0 +1,40 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+class DataBase64URLDecoding: XCTestCase {
+
+    func testBase64URLDecoding() {
+        XCTAssertEqual(
+            Data(base64URLDecode: "aGVsbG8gd29ybGQ"),
+            "hello world".data(using: .utf8)
+        )
+    }
+
+    func testBase64URLDecodingWithPadding() {
+        XCTAssertEqual(
+            Data(base64URLDecode: "dGVzdA="),
+            "test".data(using: .utf8)
+        )
+    }
+
+    func testBase64URLDecodingWithDoublePadding() {
+        XCTAssertEqual(
+            Data(base64URLDecode: "dGVzdA=="),
+            "test".data(using: .utf8)
+        )
+    }
+
+    func testBase64URLDecodingWithNonAlphaNumericCharacters() {
+        XCTAssertEqual(
+            Data(base64URLDecode: "V2lsbCB0aGlzIHdvcmsgZm9yIGEgc3RyaW5nIHdpdGggbm9uLWFscGhhbnVtZXJpYyBjaGFyYWN0ZXJzPyE/JiU="),
+            "Will this work for a string with non-alphanumeric characters?!?&%".data(using: .utf8)
+        )
+    }
+
+    func testBase64URLDecodingWithEmptyString() {
+        XCTAssertEqual(
+            Data(base64URLDecode: ""),
+            Data()
+        )
+    }
+}

--- a/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
@@ -1,0 +1,29 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+class IDTokenTests: XCTestCase {
+
+    func testInitWithJWTWithoutEmail() throws {
+        XCTAssertNil(IDToken(jwt: try XCTUnwrap(JWToken(encodedString: validJWTString))))
+    }
+
+    func testInitWithJWTWithEmail() throws {
+        let jwt = try XCTUnwrap(JWToken(encodedString: validJWTStringWithEmail))
+        let token = try XCTUnwrap(IDToken(jwt: jwt))
+
+        XCTAssertEqual(token.email, "test@email.com")
+    }
+
+}
+
+// Created with https://jwt.io/ with input:
+//
+// header: {
+//   "alg": "HS256",
+//   "typ": "JWT"
+// }
+// payload: {
+//   "key": "value",
+//   "email": "test@email.com"
+// }
+let validJWTStringWithEmail = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ2YWx1ZSIsImVtYWlsIjoidGVzdEBlbWFpbC5jb20ifQ.b-2oTvjpc_qHM5dU6akk_ESe3eWUZwL21pvTsCmW2gE"

--- a/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
@@ -4,11 +4,11 @@ import XCTest
 class IDTokenTests: XCTestCase {
 
     func testInitWithJWTWithoutEmail() throws {
-        XCTAssertNil(IDToken(jwt: try XCTUnwrap(JWToken(encodedString: validJWTString))))
+        XCTAssertNil(IDToken(jwt: try XCTUnwrap(JSONWebToken(encodedString: validJWTString))))
     }
 
     func testInitWithJWTWithEmail() throws {
-        let jwt = try XCTUnwrap(JWToken(encodedString: validJWTStringWithEmail))
+        let jwt = try XCTUnwrap(JSONWebToken(encodedString: validJWTStringWithEmail))
         let token = try XCTUnwrap(IDToken(jwt: jwt))
 
         XCTAssertEqual(token.email, "test@email.com")

--- a/WordPressAuthenticatorTests/GoogleSignIn/JWTokenTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/JWTokenTests.swift
@@ -26,16 +26,16 @@ class JWTokenTests: XCTestCase {
             ["key": "value", "other_key": "other_value"]
         )
     }
-
-    // Created with https://jwt.io/ with input:
-    //
-    // header: {
-    //   "alg": "HS256",
-    //   "typ": "JWT"
-    // }
-    // payload: {
-    //   "key": "value",
-    //   "other_key": "other_value"
-    // }
-    let validJWTString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ2YWx1ZSIsIm90aGVyX2tleSI6Im90aGVyX3ZhbHVlIn0.Koc07zTGuATtQK7EvfAuwgZ-Nsr6P6J3HV4h3QLlXpM"
 }
+
+// Created with https://jwt.io/ with input:
+//
+// header: {
+//   "alg": "HS256",
+//   "typ": "JWT"
+// }
+// payload: {
+//   "key": "value",
+//   "other_key": "other_value"
+// }
+let validJWTString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ2YWx1ZSIsIm90aGVyX2tleSI6Im90aGVyX3ZhbHVlIn0.Koc07zTGuATtQK7EvfAuwgZ-Nsr6P6J3HV4h3QLlXpM"

--- a/WordPressAuthenticatorTests/GoogleSignIn/JWTokenTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/JWTokenTests.swift
@@ -4,17 +4,17 @@ import XCTest
 class JWTokenTests: XCTestCase {
 
     func testJWTokenDecodingFromInvalidStringFails() {
-        XCTAssertNil(JWToken(encodedString: "invalid"))
+        XCTAssertNil(JSONWebToken(encodedString: "invalid"))
     }
 
     func tsetJWTokenDecodingWithoutHeaderFails() {
         // split validJWTString by . and remove the first
         let inputWithoutHeader = validJWTString.split(separator: ".").dropFirst().joined(separator: ".")
-        XCTAssertNil(JWToken(encodedString: inputWithoutHeader))
+        XCTAssertNil(JSONWebToken(encodedString: inputWithoutHeader))
     }
 
     func testJWTokenDecodingFromValidString() throws {
-        let token = try XCTUnwrap(JWToken(encodedString: validJWTString))
+        let token = try XCTUnwrap(JSONWebToken(encodedString: validJWTString))
 
         XCTAssertEqual(
             token.header as? [String: String],

--- a/WordPressAuthenticatorTests/GoogleSignIn/JWTokenTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/JWTokenTests.swift
@@ -1,0 +1,41 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+class JWTokenTests: XCTestCase {
+
+    func testJWTokenDecodingFromInvalidStringFails() {
+        XCTAssertNil(JWToken(encodedString: "invalid"))
+    }
+
+    func tsetJWTokenDecodingWithoutHeaderFails() {
+        // split validJWTString by . and remove the first
+        let inputWithoutHeader = validJWTString.split(separator: ".").dropFirst().joined(separator: ".")
+        XCTAssertNil(JWToken(encodedString: inputWithoutHeader))
+    }
+
+    func testJWTokenDecodingFromValidString() throws {
+        let token = try XCTUnwrap(JWToken(encodedString: validJWTString))
+
+        XCTAssertEqual(
+            token.header as? [String: String],
+            ["alg": "HS256", "typ": "JWT"]
+        )
+
+        XCTAssertEqual(
+            token.payload as? [String: String],
+            ["key": "value", "other_key": "other_value"]
+        )
+    }
+
+    // Created with https://jwt.io/ with input:
+    //
+    // header: {
+    //   "alg": "HS256",
+    //   "typ": "JWT"
+    // }
+    // payload: {
+    //   "key": "value",
+    //   "other_key": "other_value"
+    // }
+    let validJWTString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ2YWx1ZSIsIm90aGVyX2tleSI6Im90aGVyX3ZhbHVlIn0.Koc07zTGuATtQK7EvfAuwgZ-Nsr6P6J3HV4h3QLlXpM"
+}


### PR DESCRIPTION
The OAuth process with Google returns, among other info, an [`id_token` field](https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo). This is a JSON web token (JWT) with in its payload the information accessible by the `scope` request parameter. In our case, what we want is only the `email`.

The next step will be to return this type from the new flow in `GoogleAuthenticator`, so that `email` can be passed together with the OAuth token to the WordPress.com backend.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
