### PR TITLE
Add configuration to disable site credential login on Get Started screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+-  New configuration to disable site credential login on Get Started screen for the site address login flow [#742]
 
 ### Bug Fixes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.3.0):
+  - WordPressAuthenticator (5.4.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: d33383ff4e813d23d7891168668322abc10be77c
+  WordPressAuthenticator: cb33aace25e044c96b40957826df5e9060cb0924
   WordPressKit: 08da0bc981f6398ef7a32e523fd054de7d7c7069
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.3.0'
+  s.version       = '5.4.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -168,6 +168,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSiteAddressLoginOnlyInPrologue: Bool
 
+    /// If enabled, the email login screen should not hide the site credential login CTA.
+    ///
+    let enableSiteCredentialLoginForJetpackSites: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -203,6 +207,7 @@ public struct WordPressAuthenticatorConfiguration {
                  enableManualSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
                  enableSiteAddressLoginOnlyInPrologue: Bool = false,
+                 enableSiteCredentialLoginForJetpackSites: Bool = true,
                  googleLoginWithoutSDK: Bool = false
     ) {
 
@@ -240,5 +245,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableManualSiteCredentialLogin = enableManualSiteCredentialLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
+        self.enableSiteCredentialLoginForJetpackSites = enableSiteCredentialLoginForJetpackSites
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -169,6 +169,7 @@ public struct WordPressAuthenticatorConfiguration {
     let enableSiteAddressLoginOnlyInPrologue: Bool
 
     /// If enabled, the email login screen should not hide the site credential login CTA.
+    /// This is `true` by default.
     ///
     let enableSiteCredentialLoginForJetpackSites: Bool
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -810,11 +810,13 @@ private extension GetStartedViewController {
                                             accessibilityIdentifier: ButtonConfiguration.Continue.accessibilityIdentifier,
                                             onTap: handleSubmitButtonTapped)
 
-        // Setup Sign in with site credentials button
-        buttonViewController.setupBottomButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
-                                               isPrimary: false,
-                                               accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier,
-                                               onTap: handleSiteCredentialsButtonTapped)
+        if configuration.enableSiteCredentialLoginForJetpackSites {
+            // Setup Sign in with site credentials button
+            buttonViewController.setupBottomButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
+                                                   isPrimary: false,
+                                                   accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier,
+                                                   onTap: handleSiteCredentialsButtonTapped)
+        }
     }
 
     func configureButtonViewControllerWithoutSocialLogin() {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/8845.

**Description**
This PR adds a new config `enableSiteCredentialLoginForJetpackSites` - which is `true` by default. When this is set to `false`, the site credential login button will not be displayed on the WPCom email login screen of the site address login flow.

**Testing steps**
Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/8846.

**Screenshot**
<img src="https://user-images.githubusercontent.com/5533851/218428242-fa3445a2-5e37-4259-a513-670d0f6cd5a2.png" width=320 />

---
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
