### PR TITLE
Bump version from 5.4.0-beta.1 to 5.4.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
--  New configuration to disable site credential login on Get Started screen for the site address login flow [#742]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,12 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 5.4.0
+
+### New Features
+
+-  New configuration to disable site credential login on Get Started screen for the site address login flow [#742]
 
 ## 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this document is inspired by [Keep a Changelog](https://keepachang
 When releasing a new version:
 
 1. Remove any empty section (those with `_None._`)
-2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/<version_number>)`
+2. Update the `## Unreleased` header to `## <version_number>`
 3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
 
 ## Unreleased
@@ -48,19 +48,19 @@ _None._
 
 _None._
 
-## [5.3.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/5.3.0)
+## 5.3.0
 
 ### New Features
 
 -  Add new config to remove XMLRPC check for site address login [#736]
 
-## [5.2.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/5.2.0)
+## 5.2.0
 
 ### Internal Changes
 
 - Change minimum version of WordPressKit to 6.0.
 
-## [5.1.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/5.1.0)
+## 5.1.0
 
 ### New Features
 
@@ -71,26 +71,26 @@ _None._
 - Fix unresponsive issue in Onboading Questions screen. [#719]
 - Use configuration flag to log custom `step` event for `GetStartedViewController`. [#724]
 
-## [5.0.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/5.0.0)
+## 5.0.0
 
 ### Breaking Changes
 
 - Remove CocoaLumberjack. Use `WPAuthenticatorSetLoggingDelegate` to assign a logger to this library. [#708]
 
-## [4.3.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.3.0)
+## 4.3.0
 
 ### New Features
 
 - Make XMLRPC URL optional when verifying WP.com email [#711]
 - A new config is added to skip the XMLRPC check for the site discovery flow [#711]
 
-## [4.2.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.2.0)
+## 4.2.0
 
 ### New Features
 
 - New tracking event for XMLRPC related failure. by @selanthiraiyan [#701]
 
-## [4.1.1](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.1.1)
+## 4.1.1
 
 ### New Features
 
@@ -101,7 +101,7 @@ _None._
 
 - There have been [new changes to how `UIPasteboard` works](https://sarunw.com/posts/uipasteboard-privacy-change-ios16/) in iOS 16.0. This makes the unit tests from `PasteboardTests` fail. I have [skipped those tests for iOS 16.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/695/files#diff-ba468f6db6f592cdacdb632f7783a721c5eb856e8ab66765e8e59aabc2c1a7b4R13-R16) and created a GH issue [here](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/696) to keep track of this. by @selanthiraiyan [#695]
 
-## [4.0.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/4.0.0)
+## 4.0.0
 
 ### Breaking Changes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.4.0-beta.1):
+  - WordPressAuthenticator (5.4.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: cb33aace25e044c96b40957826df5e9060cb0924
+  WordPressAuthenticator: 2ec9da019874f1fbf6d500f1de21e7f9be2bc466
   WordPressKit: 08da0bc981f6398ef7a32e523fd054de7d7c7069
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.4.0-beta.1'
+  s.version       = '5.4.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 21.8 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.