### PR TITLE
Use `CodeVerifier` in `OAuthTokenRequestBody` for better encapsulation

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1A21EE9822832BC300C940C6 /* WordPressComOAuthClientFacade+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A21EE9722832BC200C940C6 /* WordPressComOAuthClientFacade+Swift.swift */; };
 		1A4095182271AEFC009AA86D /* WPAuthenticator-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4095152271AEFC009AA86D /* WPAuthenticator-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3108613125AFA4830022F75E /* PasteboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3108613025AFA4830022F75E /* PasteboardTests.swift */; };
+		3F107B0529A87AF0009B3658 /* CodeVerifier+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F107B0429A87AF0009B3658 /* CodeVerifier+Fixture.swift */; };
 		3F30A6B4299F10BD0004452F /* Character+URLSafe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F30A6B3299F10BD0004452F /* Character+URLSafe.swift */; };
 		3F30A6BA299F12E30004452F /* Character+URLSafeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F30A6B9299F12E30004452F /* Character+URLSafeTests.swift */; };
 		3F338B6A289B877F0014ADC5 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B69289B877F0014ADC5 /* BuildkiteTestCollector */; };
@@ -262,6 +263,7 @@
 		3108613025AFA4830022F75E /* PasteboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardTests.swift; sourceTree = "<group>"; };
 		33FEF45B466FF8EAAE5F3923 /* Pods-WordPressAuthenticator.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release.xcconfig"; sourceTree = "<group>"; };
 		37AFD4EF492B00CA7AEC11A3 /* Pods-WordPressAuthenticatorTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		3F107B0429A87AF0009B3658 /* CodeVerifier+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CodeVerifier+Fixture.swift"; sourceTree = "<group>"; };
 		3F30A6B3299F10BD0004452F /* Character+URLSafe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+URLSafe.swift"; sourceTree = "<group>"; };
 		3F30A6B9299F12E30004452F /* Character+URLSafeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Character+URLSafeTests.swift"; sourceTree = "<group>"; };
 		3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
@@ -582,6 +584,8 @@
 		3FE8072329365FC20088420C /* GoogleSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				3F30A6B9299F12E30004452F /* Character+URLSafeTests.swift */,
+				3F107B0429A87AF0009B3658 /* CodeVerifier+Fixture.swift */,
 				3F82E63829931D95003EFC16 /* CodeVerifierTests.swift */,
 				3F4E646F2990B7B3000DB555 /* Data+Base64URLTests.swift */,
 				3F82E63C29935E65003EFC16 /* Data+SHA256Tests.swift */,
@@ -594,7 +598,6 @@
 				3F879FE3293A545C005C2B48 /* OAuthRequestBody+GoogleSignInTests.swift */,
 				3FE8071E2936558F0088420C /* URL+GoogleSignInTests.swift */,
 				3F879FDE293A501D005C2B48 /* URLRequest+GoogleSignInTests.swift */,
-				3F30A6B9299F12E30004452F /* Character+URLSafeTests.swift */,
 			);
 			path = GoogleSignIn;
 			sourceTree = "<group>";
@@ -1542,6 +1545,7 @@
 				BA53D64B24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift in Sources */,
 				4A1DEF4A29341B1F00322608 /* LoggingTests.m in Sources */,
 				3FEC44F9293A0F2900EBDECF /* ProofKeyForCodeExchangeTests.swift in Sources */,
+				3F107B0529A87AF0009B3658 /* CodeVerifier+Fixture.swift in Sources */,
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
 				3F879FF4293A7F46005C2B48 /* GoogleOAuthTokenGetterTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,

--- a/WordPressAuthenticator/GoogleSignIn/OAuthRequestBody+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/OAuthRequestBody+GoogleSignIn.swift
@@ -16,7 +16,7 @@ extension OAuthTokenRequestBody {
             clientSecret: "",
             audience: audience,
             code: authCode,
-            codeVerifier: pkce.codeVerifier.rawValue,
+            codeVerifier: pkce.codeVerifier,
             // As defined in the OAuth 2.0 specification, this field's value must be set to authorization_code.
             // – https://developers.google.com/identity/protocols/oauth2/native-app#exchange-authorization-code
             grantType: "authorization_code",

--- a/WordPressAuthenticator/OAuth/OAuthTokenRequestBody.swift
+++ b/WordPressAuthenticator/OAuth/OAuthTokenRequestBody.swift
@@ -6,16 +6,34 @@ struct OAuthTokenRequestBody: Encodable {
     let clientSecret: String
     let audience: String
     let code: String
-    let codeVerifier: String
+    let rawCodeVerifier: String
     let grantType: String
     let redirectURI: String
+
+    init(
+        clientId: String,
+        clientSecret: String,
+        audience: String,
+        code: String,
+        codeVerifier: ProofKeyForCodeExchange.CodeVerifier,
+        grantType: String,
+        redirectURI: String
+    ) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.audience = audience
+        self.code = code
+        self.rawCodeVerifier = codeVerifier.rawValue
+        self.grantType = grantType
+        self.redirectURI = redirectURI
+    }
 
     enum CodingKeys: String, CodingKey {
         case clientId = "client_id"
         case clientSecret = "client_secret"
         case audience
         case code
-        case codeVerifier = "code_verifier"
+        case rawCodeVerifier = "code_verifier"
         case grantType = "grant_type"
         case redirectURI = "redirect_uri"
     }
@@ -25,7 +43,7 @@ struct OAuthTokenRequestBody: Encodable {
             (CodingKeys.clientId.rawValue, clientId),
             (CodingKeys.clientSecret.rawValue, clientSecret),
             (CodingKeys.code.rawValue, code),
-            (CodingKeys.codeVerifier.rawValue, codeVerifier),
+            (CodingKeys.rawCodeVerifier.rawValue, rawCodeVerifier),
             (CodingKeys.grantType.rawValue, grantType),
             (CodingKeys.redirectURI.rawValue, redirectURI),
             // This is not in the spec at

--- a/WordPressAuthenticator/OAuth/OAuthTokenRequestBody.swift
+++ b/WordPressAuthenticator/OAuth/OAuthTokenRequestBody.swift
@@ -1,39 +1,21 @@
 /// Models the request to send for an OAuth token
 ///
 /// - Note: See documentation at https://developers.google.com/identity/protocols/oauth2/native-app#exchange-authorization-code
-struct OAuthTokenRequestBody: Encodable {
+struct OAuthTokenRequestBody {
     let clientId: String
     let clientSecret: String
     let audience: String
     let code: String
-    let rawCodeVerifier: String
+    let codeVerifier: ProofKeyForCodeExchange.CodeVerifier
     let grantType: String
     let redirectURI: String
-
-    init(
-        clientId: String,
-        clientSecret: String,
-        audience: String,
-        code: String,
-        codeVerifier: ProofKeyForCodeExchange.CodeVerifier,
-        grantType: String,
-        redirectURI: String
-    ) {
-        self.clientId = clientId
-        self.clientSecret = clientSecret
-        self.audience = audience
-        self.code = code
-        self.rawCodeVerifier = codeVerifier.rawValue
-        self.grantType = grantType
-        self.redirectURI = redirectURI
-    }
 
     enum CodingKeys: String, CodingKey {
         case clientId = "client_id"
         case clientSecret = "client_secret"
         case audience
         case code
-        case rawCodeVerifier = "code_verifier"
+        case codeVerifier = "code_verifier"
         case grantType = "grant_type"
         case redirectURI = "redirect_uri"
     }
@@ -43,7 +25,7 @@ struct OAuthTokenRequestBody: Encodable {
             (CodingKeys.clientId.rawValue, clientId),
             (CodingKeys.clientSecret.rawValue, clientSecret),
             (CodingKeys.code.rawValue, code),
-            (CodingKeys.rawCodeVerifier.rawValue, rawCodeVerifier),
+            (CodingKeys.codeVerifier.rawValue, codeVerifier.rawValue),
             (CodingKeys.grantType.rawValue, grantType),
             (CodingKeys.redirectURI.rawValue, redirectURI),
             // This is not in the spec at

--- a/WordPressAuthenticatorTests/GoogleSignIn/CodeVerifier+Fixture.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/CodeVerifier+Fixture.swift
@@ -1,0 +1,12 @@
+@testable import WordPressAuthenticator
+
+extension ProofKeyForCodeExchange.CodeVerifier {
+
+    /// A code verifier for testing purposes that is guaranteed to be valid and deterministic.
+    ///
+    /// The reason we care about it being deterministic is because we don't want implicit randomness test.
+    /// The only place were we want to use random values in the `CodeVerifier` tests which explicitly check the random generation.
+    static func fixture() -> Self {
+        .init(value: (0..<allowedLengthRange.lowerBound).map { _ in "a" }.joined())!
+    }
+}

--- a/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
@@ -15,7 +15,7 @@ class OAuthRequestBodyGoogleSignInTests: XCTestCase {
 
         XCTAssertEqual(body.clientId, "com.app.123-abc")
         XCTAssertEqual(body.clientSecret, "")
-        XCTAssertEqual(body.codeVerifier, codeVerifier.rawValue)
+        XCTAssertEqual(body.rawCodeVerifier, codeVerifier.rawValue)
         XCTAssertEqual(body.grantType, "authorization_code")
         XCTAssertEqual(body.redirectURI, "123-abc.app.com:/oauth2callback")
     }

--- a/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class OAuthRequestBodyGoogleSignInTests: XCTestCase {
 
     func testGoogleSignInTokenRequestBody() throws {
-        let codeVerifier = try ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier()
+        let codeVerifier = ProofKeyForCodeExchange.CodeVerifier.fixture()
         let pkce = ProofKeyForCodeExchange(codeVerifier: codeVerifier, method: .plain)
         let body = OAuthTokenRequestBody.googleSignInRequestBody(
             clientId: GoogleClientId(string: "com.app.123-abc")!,

--- a/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/OAuthRequestBody+GoogleSignInTests.swift
@@ -15,7 +15,7 @@ class OAuthRequestBodyGoogleSignInTests: XCTestCase {
 
         XCTAssertEqual(body.clientId, "com.app.123-abc")
         XCTAssertEqual(body.clientSecret, "")
-        XCTAssertEqual(body.rawCodeVerifier, codeVerifier.rawValue)
+        XCTAssertEqual(body.codeVerifier, codeVerifier)
         XCTAssertEqual(body.grantType, "authorization_code")
         XCTAssertEqual(body.redirectURI, "123-abc.app.com:/oauth2callback")
     }

--- a/WordPressAuthenticatorTests/GoogleSignIn/URLRequest+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URLRequest+GoogleSignInTests.swift
@@ -8,7 +8,7 @@ class URLRequestOAuthTokenRequestTests: XCTestCase {
         clientSecret: "b",
         audience: "audience",
         code: "c",
-        codeVerifier: ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier(),
+        codeVerifier: ProofKeyForCodeExchange.CodeVerifier.fixture(),
         grantType: "e",
         redirectURI: "f"
     )

--- a/WordPressAuthenticatorTests/GoogleSignIn/URLRequest+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URLRequest+GoogleSignInTests.swift
@@ -8,7 +8,7 @@ class URLRequestOAuthTokenRequestTests: XCTestCase {
         clientSecret: "b",
         audience: "audience",
         code: "c",
-        codeVerifier: "d",
+        codeVerifier: ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier(),
         grantType: "e",
         redirectURI: "f"
     )

--- a/WordPressAuthenticatorTests/OAuth/OAuthTokenRequestBodyTests.swift
+++ b/WordPressAuthenticatorTests/OAuth/OAuthTokenRequestBodyTests.swift
@@ -4,12 +4,13 @@ import XCTest
 class OAuthTokenRequestBodyTests: XCTestCase {
 
     func testURLEncodedDataConversion() throws {
+        let codeVerifier = (0..<43).map { _ in "a" }.joined()
         let body = OAuthTokenRequestBody(
             clientId: "clientId",
             clientSecret: "clientSecret",
             audience: "audience",
             code: "codeValue",
-            codeVerifier: "codeVerifier",
+            codeVerifier: try XCTUnwrap(ProofKeyForCodeExchange.CodeVerifier(value: codeVerifier)),
             grantType: "grantType",
             redirectURI: "redirectUri"
         )
@@ -20,7 +21,7 @@ class OAuthTokenRequestBodyTests: XCTestCase {
 
         XCTAssertTrue(decodedData.contains("client_id=clientId"))
         XCTAssertTrue(decodedData.contains("client_secret=clientSecret"))
-        XCTAssertTrue(decodedData.contains("code_verifier=codeVerifier"))
+        XCTAssertTrue(decodedData.contains("code_verifier=\(codeVerifier)"))
         XCTAssertTrue(decodedData.contains("grant_type=grantType"))
         XCTAssertTrue(decodedData.contains("redirect_uri=redirectUri"))
     }

--- a/WordPressAuthenticatorTests/OAuth/OAuthTokenRequestBodyTests.swift
+++ b/WordPressAuthenticatorTests/OAuth/OAuthTokenRequestBodyTests.swift
@@ -4,13 +4,13 @@ import XCTest
 class OAuthTokenRequestBodyTests: XCTestCase {
 
     func testURLEncodedDataConversion() throws {
-        let codeVerifier = (0..<43).map { _ in "a" }.joined()
+        let codeVerifier = ProofKeyForCodeExchange.CodeVerifier.fixture()
         let body = OAuthTokenRequestBody(
             clientId: "clientId",
             clientSecret: "clientSecret",
             audience: "audience",
             code: "codeValue",
-            codeVerifier: try XCTUnwrap(ProofKeyForCodeExchange.CodeVerifier(value: codeVerifier)),
+            codeVerifier: codeVerifier,
             grantType: "grantType",
             redirectURI: "redirectUri"
         )
@@ -21,7 +21,7 @@ class OAuthTokenRequestBodyTests: XCTestCase {
 
         XCTAssertTrue(decodedData.contains("client_id=clientId"))
         XCTAssertTrue(decodedData.contains("client_secret=clientSecret"))
-        XCTAssertTrue(decodedData.contains("code_verifier=\(codeVerifier)"))
+        XCTAssertTrue(decodedData.contains("code_verifier=\(codeVerifier.rawValue)"))
         XCTAssertTrue(decodedData.contains("grant_type=grantType"))
         XCTAssertTrue(decodedData.contains("redirect_uri=redirectUri"))
     }

--- a/WordPressAuthenticatorTests/OAuth/ProofKeyForCodeExchangeTests.swift
+++ b/WordPressAuthenticatorTests/OAuth/ProofKeyForCodeExchangeTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class ProofKeyForCodeExchangeTests: XCTestCase {
 
     func testCodeChallengeInPlainModeIsTheSameAsCodeVerifier() throws {
-        let codeVerifier = try ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier()
+        let codeVerifier = ProofKeyForCodeExchange.CodeVerifier.fixture()
 
         XCTAssertEqual(
             ProofKeyForCodeExchange(codeVerifier: codeVerifier, method: .plain).codeChallenge,


### PR DESCRIPTION
See discussion at https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/740#discussion_r1110440264


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
