### PR TITLE
Add VS Code settings to `.gitignore` and track project settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,17 @@ fastlane/test_output
 !.configure-files/*.enc
 # If the user created a local secrets file, ignore it
 Demo/Secrets.swift
+
+# VS Code settings
+#
+# See https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Global/VisualStudioCode.gitignore
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+# Local History for Visual Studio Code
+.history/
+# Built Visual Studio Code Extensions
+*.vsix

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "vknabel.vscode-swiftlint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "swiftlint.path": "../Pods/SwiftLint/swiftlint"
+}


### PR DESCRIPTION
Notice how the path for SwiftLint is to the Pod-installed version, to ensure consistency.

Been working with Copilot via VS Code a lot recently. These are useful `.gitignore` and `.vscode/settings.json` configurations for this project.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. – N.A.
