### PR TITLE
Track `signed_in` event during delegated site credential login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Track `signed_in` event when the site credential login is handled by the client. [#748]
 
 ### Internal Changes
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -455,6 +455,7 @@ private extension SiteCredentialsViewController {
         delegate.handleSiteCredentialLogin(credentials: wporg, onLoading: { [weak self] shouldShowLoading in
             self?.configureViewLoading(shouldShowLoading)
         }, onSuccess: { [weak self] in
+            self?.trackSignIn(credentials: AuthenticatorCredentials(wporg: wporg))
             self?.finishedLogin(withUsername: wporg.username,
                                 password: wporg.password,
                                 xmlrpc: wporg.xmlrpc,


### PR DESCRIPTION
## Description

This PR starts tracking the `signed_in` tracks event when the client handles the site credential login. 

**Why?**
- When the client WooCommerce-iOS handles the site credential login, the user doesn't have to login using WPCOM credentials if the self-hosted site doesn't have Jetpack. 
- So, we must consider that the user has been logged in and track the `signed_in` event.

Internal discussion about the impact of this event on Tracks funnels - p1677669246532249/1677588582.228569-slack-C046HDZL87J

## Testing steps

Please follow the testing instructions from https://github.com/woocommerce/woocommerce-ios/pull/9014 to test this PR.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.