### PR TITLE
Make `MailPresenter` public to external access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _None._
 ### New Features
 
 - Make `WordPressComAccountService` public to external access [#746]
+- Make `MailPresenter` and `AppSelector` public to external access [#749]
 
 ### Bug Fixes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.5.0-beta.1):
+  - WordPressAuthenticator (5.5.0-beta.2):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 986bd598aeaebd682b26f2fd343d95265494ab7a
+  WordPressAuthenticator: 59366c298e7cbee5dda3c88321c9164946798193
   WordPressKit: 08da0bc981f6398ef7a32e523fd054de7d7c7069
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.5.0-beta.1'
+  s.version       = '5.5.0-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Email Client Picker/AppSelector.swift
+++ b/WordPressAuthenticator/Email Client Picker/AppSelector.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// App selector that selects an app from a list and opens it
 /// Note: it's a wrapper of UIAlertController (which cannot be sublcassed)
-class AppSelector {
+public class AppSelector {
     // the action sheet that will contain the list of apps that can be called
     let alertController: UIAlertController
 
@@ -13,7 +13,7 @@ class AppSelector {
     ///   - defaultAction: default action, if not nil, will be the first element of the list
     ///   - sourceView: the sourceView to anchor the action sheet to
     ///   - urlHandler: object that handles app URL schemes; defaults to UIApplication.shared
-    init?(with appList: [String: String],
+    public init?(with appList: [String: String],
           defaultAction: UIAlertAction? = nil,
           sourceView: UIView,
           urlHandler: URLHandler = UIApplication.shared) {

--- a/WordPressAuthenticator/Email Client Picker/AppSelector.swift
+++ b/WordPressAuthenticator/Email Client Picker/AppSelector.swift
@@ -60,7 +60,7 @@ public class AppSelector {
 }
 
 /// Initializers for Email Picker
-extension AppSelector {
+public extension AppSelector {
     /// initializes the picker with a plist file in a specified bundle
     convenience init?(with plistFile: String,
                       in bundle: Bundle,

--- a/WordPressAuthenticator/Email Client Picker/LinkMailPresenter.swift
+++ b/WordPressAuthenticator/Email Client Picker/LinkMailPresenter.swift
@@ -1,11 +1,11 @@
 import MessageUI
 
 /// Email picker presenter
-class LinkMailPresenter {
+public class LinkMailPresenter {
 
     private let emailAddress: String
 
-    init(emailAddress: String) {
+    public init(emailAddress: String) {
         self.emailAddress = emailAddress
     }
 
@@ -16,7 +16,7 @@ class LinkMailPresenter {
     ///   - viewController: the UIViewController that will present the action sheet
     ///   - appSelector: the app picker that contains the available clients. Nil if no clients are available
     ///                  reads the supported email clients from EmailClients.plist
-    func presentEmailClients(on viewController: UIViewController,
+    public func presentEmailClients(on viewController: UIViewController,
                              appSelector: AppSelector?) {
 
         guard let picker = appSelector else {

--- a/WordPressAuthenticator/Email Client Picker/URLHandler.swift
+++ b/WordPressAuthenticator/Email Client Picker/URLHandler.swift
@@ -1,5 +1,5 @@
 /// Generic type that handles URL Schemes
-protocol URLHandler {
+public protocol URLHandler {
     /// checks if the specified URL can be opened
     func canOpenURL(_ url: URL) -> Bool
     /// opens the specified URL


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/pull/9021

## Description
This PR makes `MailPresenter` and `AppSelector` public for reuse in WCiOS when the Open Mail button is tapped on the magic link login screen.

## Testing
Please following the steps in https://github.com/woocommerce/woocommerce-ios/pull/9021 to test this.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
