### PR TITLE
Bump version from 5.5.0-beta.2 to 5.5.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,7 @@ _None._
 
 ### New Features
 
-- Make `WordPressComAccountService` public to external access [#746]
-- Make `MailPresenter` and `AppSelector` public to external access [#749]
+_None._
 
 ### Bug Fixes
 
@@ -48,6 +47,13 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 5.5.0
+
+### New Features
+
+- Make `WordPressComAccountService` public to external access [#746]
+- Make `MailPresenter` and `AppSelector` public to external access [#749]
 
 ## 5.4.0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.5.0-beta.2):
+  - WordPressAuthenticator (5.5.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 59366c298e7cbee5dda3c88321c9164946798193
+  WordPressAuthenticator: fb233ed409d2cf86edf01ce5616dd15d4e9c9ca4
   WordPressKit: 08da0bc981f6398ef7a32e523fd054de7d7c7069
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.5.0-beta.2'
+  s.version       = '5.5.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WooCommerce iOS 12.6 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.