### PR TITLE
Use Xcode 14.2 in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   plugins: &common_plugins
   - automattic/bash-cache#2.12.0
   env: &common_env
-    IMAGE_ID: xcode-14.1
+    IMAGE_ID: xcode-14.2
 
 # This is the default pipeline – it will build and test the pod
 steps:


### PR DESCRIPTION
I noticed this hadn't been done yet due to an internal conversation, ref pdnsEh-YD-p2.

If the tests pass, this can be merged.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.