### PR TITLE
Pass `UIViewController` for Google SDK-less auth presentation at call site instead init

### DIFF
--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -87,7 +87,7 @@ extension ViewController {
     func getAuthTokenFromGoogle() {
         Task { @MainActor in
             do {
-                let token = try await self.googleAuthenticator.getOAuthToken()
+                let token = try await self.googleAuthenticator.getOAuthToken(from: self)
 
                 presentAlert(
                     title: "🎉",

--- a/Demo/AuthenticatorDemo/ViewController.swift
+++ b/Demo/AuthenticatorDemo/ViewController.swift
@@ -35,7 +35,6 @@ class ViewController: UIViewController {
         clientId: GoogleClientId(string: APICredentials.googleLoginClientId)!,
         scheme: APICredentials.googleLoginSchemeId,
         audience: APICredentials.googleLoginServerClientId,
-        viewController: self,
         urlSession: URLSession.shared
     )
 

--- a/WordPressAuthenticator/GoogleSignIn/NewGoogleAuthenticator.swift
+++ b/WordPressAuthenticator/GoogleSignIn/NewGoogleAuthenticator.swift
@@ -56,9 +56,28 @@ public class NewGoogleAuthenticator: NSObject {
     }
 
     /// Get the user's OAuth token from their Google account. This token can be used to authenticate with the WordPress backend.
-    public func getOAuthToken() async throws -> IDToken {
+    ///
+    /// The app will present the browser to hand over authentication to Google from the given `UIViewController`.
+    public func getOAuthToken(from viewController: UIViewController) async throws -> IDToken {
+        return try await getOAuthToken(
+            from: WebAuthenticationPresentationContext(viewController: viewController)
+        )
+    }
+
+    /// Get the user's OAuth token from their Google account. This token can be used to authenticate with the WordPress backend.
+    ///
+    /// The app will present the browser to hand over authentication to Google using the given
+    /// `ASWebAuthenticationPresentationContextProviding`.
+    public func getOAuthToken(
+        from contextProvider: ASWebAuthenticationPresentationContextProviding
+    ) async throws -> IDToken {
         let pkce = try ProofKeyForCodeExchange()
-        let url = try await getURL(clientId: clientId, scheme: scheme, pkce: pkce, contextProvider: contextProvider)
+        let url = try await getURL(
+            clientId: clientId,
+            scheme: scheme,
+            pkce: pkce,
+            contextProvider: contextProvider
+        )
         return try await requestOAuthToken(url: url, clientId: clientId, audience: audience, pkce: pkce)
     }
 

--- a/WordPressAuthenticator/GoogleSignIn/NewGoogleAuthenticator.swift
+++ b/WordPressAuthenticator/GoogleSignIn/NewGoogleAuthenticator.swift
@@ -58,11 +58,16 @@ public class NewGoogleAuthenticator: NSObject {
     /// Get the user's OAuth token from their Google account. This token can be used to authenticate with the WordPress backend.
     public func getOAuthToken() async throws -> IDToken {
         let pkce = try ProofKeyForCodeExchange()
-        let url = try await getURL(clientId: clientId, scheme: scheme, pkce: pkce)
+        let url = try await getURL(clientId: clientId, scheme: scheme, pkce: pkce, contextProvider: contextProvider)
         return try await requestOAuthToken(url: url, clientId: clientId, audience: audience, pkce: pkce)
     }
 
-    func getURL(clientId: GoogleClientId, scheme: String, pkce: ProofKeyForCodeExchange) async throws -> URL {
+    func getURL(
+        clientId: GoogleClientId,
+        scheme: String,
+        pkce: ProofKeyForCodeExchange,
+        contextProvider: ASWebAuthenticationPresentationContextProviding
+    ) async throws -> URL {
         let url = try URL.googleSignInAuthURL(clientId: clientId, pkce: pkce)
         return try await withCheckedThrowingContinuation { continuation in
             let session = ASWebAuthenticationSession(

--- a/WordPressAuthenticator/GoogleSignIn/NewGoogleAuthenticator.swift
+++ b/WordPressAuthenticator/GoogleSignIn/NewGoogleAuthenticator.swift
@@ -5,38 +5,18 @@ public class NewGoogleAuthenticator: NSObject {
     let clientId: GoogleClientId
     let scheme: String
     let audience: String
-    let contextProvider: ASWebAuthenticationPresentationContextProviding
-
     let oauthTokenGetter: GoogleOAuthTokenGetting
 
     public convenience init(
         clientId: GoogleClientId,
         scheme: String,
         audience: String,
-        viewController: UIViewController,
         urlSession: URLSession
     ) {
         self.init(
             clientId: clientId,
             scheme: scheme,
             audience: audience,
-            contextProvider: WebAuthenticationPresentationContext(viewController: viewController),
-            oautTokenGetter: GoogleOAuthTokenGetter(dataGetter: urlSession)
-        )
-    }
-
-    public convenience init(
-        clientId: GoogleClientId,
-        scheme: String,
-        audience: String,
-        contextProvider: ASWebAuthenticationPresentationContextProviding,
-        urlSession: URLSession
-    ) {
-        self.init(
-            clientId: clientId,
-            scheme: scheme,
-            audience: audience,
-            contextProvider: contextProvider,
             oautTokenGetter: GoogleOAuthTokenGetter(dataGetter: urlSession)
         )
     }
@@ -45,14 +25,12 @@ public class NewGoogleAuthenticator: NSObject {
         clientId: GoogleClientId,
         scheme: String,
         audience: String,
-        contextProvider: ASWebAuthenticationPresentationContextProviding,
         oautTokenGetter: GoogleOAuthTokenGetting
     ) {
         self.clientId = clientId
         self.scheme = scheme
         self.audience = audience
         self.oauthTokenGetter = oautTokenGetter
-        self.contextProvider = contextProvider
     }
 
     /// Get the user's OAuth token from their Google account. This token can be used to authenticate with the WordPress backend.

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -307,14 +307,10 @@ extension GoogleAuthenticator {
 
         trackRequestAuthorizitation(type: authType)
 
-        // We might want to change this in subsequent iterations, perhaps by moving the
-        // `contextProvider` to the `getOAuthToken()` method so to allow it to be stored
-        // as a `lazy` property?
         let sdkLessGoogleAuthenticator = NewGoogleAuthenticator(
             clientId: authConfig.googleClientId,
             scheme: authConfig.googleLoginScheme,
             audience: authConfig.googleLoginServerClientId,
-            contextProvider: WebAuthenticationPresentationContext(viewController: viewController),
             urlSession: .shared
         )
 

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -319,7 +319,7 @@ extension GoogleAuthenticator {
         )
 
         await SVProgressHUD.show()
-        return try await sdkLessGoogleAuthenticator.getOAuthToken()
+        return try await sdkLessGoogleAuthenticator.getOAuthToken(from: viewController)
     }
 }
 

--- a/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
@@ -8,11 +8,10 @@ class NewGoogleAuthenticatorTests: XCTestCase {
     func testRequestingOAuthTokenThrowsIfCodeCannotBeExtractedFromURL() async throws {
         // Notice the use of a stub that returns a successful value.
         // This way, if we get an error, we can be more confident it's legit.
-        let authenticator = await NewGoogleAuthenticator(
+        let authenticator = NewGoogleAuthenticator(
             clientId: fakeClientId,
             scheme: "scheme",
             audience: "audience",
-            contextProvider: FakeContextProvider(),
             oautTokenGetter: GoogleOAuthTokenGettingStub(response: .fixture())
         )
         let url = URL(string: "https://test.com?without=code")!
@@ -35,11 +34,10 @@ class NewGoogleAuthenticatorTests: XCTestCase {
     }
 
     func testRequestingOAuthTokenRethrowsTheErrorItRecives() async throws {
-        let authenticator = await NewGoogleAuthenticator(
+        let authenticator = NewGoogleAuthenticator(
             clientId: fakeClientId,
             scheme: "scheme",
             audience: "audience",
-            contextProvider: FakeContextProvider(),
             oautTokenGetter: GoogleOAuthTokenGettingStub(error: TestError(id: 1))
         )
         let url = URL(string: "https://test.com?code=a_code")!
@@ -59,11 +57,10 @@ class NewGoogleAuthenticatorTests: XCTestCase {
     }
 
     func testRequestingOAuthTokenThrowsIfIdTokenMissingFromResponse() async throws {
-        let authenticator = await NewGoogleAuthenticator(
+        let authenticator = NewGoogleAuthenticator(
             clientId: fakeClientId,
             scheme: "scheme",
             audience: "audience",
-            contextProvider: FakeContextProvider(),
             oautTokenGetter: GoogleOAuthTokenGettingStub(response: .fixture(rawIDToken: .none))
         )
         let url = URL(string: "https://test.com?code=a_code")!
@@ -85,11 +82,10 @@ class NewGoogleAuthenticatorTests: XCTestCase {
     }
 
     func testRequestingOAuthTokenReturnsTokenIfSuccessful() async throws {
-        let authenticator = await NewGoogleAuthenticator(
+        let authenticator = NewGoogleAuthenticator(
             clientId: fakeClientId,
             scheme: "scheme",
             audience: "audience",
-            contextProvider: FakeContextProvider(),
             oautTokenGetter: GoogleOAuthTokenGettingStub(response: .fixture(rawIDToken: JSONWebToken.validJWTStringWithEmail))
         )
         let url = URL(string: "https://test.com?code=a_code")!
@@ -105,13 +101,5 @@ class NewGoogleAuthenticatorTests: XCTestCase {
         } catch {
             XCTFail("Expected value, got error '\(error)'")
         }
-    }
-}
-
-import AuthenticationServices
-
-class FakeContextProvider: UIViewController, ASWebAuthenticationPresentationContextProviding {
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return view.window!
     }
 }


### PR DESCRIPTION
See discussion at https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/743#discussion_r1130153010.

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
