### PR TITLE
Simplify `scope` parameter used for asking OAuth token to Google

### DIFF
--- a/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
@@ -18,11 +18,9 @@ extension URL {
             ("code_challenge_method", pkce.method.urlQueryParameterValue),
             ("redirect_uri", clientId.defaultRedirectURI),
             ("response_type", "code"),
-            // The Google Sign-In SDK use "profile email", but we only need the user's email address.
-            //
-            // See:
+            // See what the Google SDK does:
             // https://github.com/google/GoogleSignIn-iOS/blob/7.0.0/GoogleSignIn/Sources/GIDScopes.m#L58-L61
-            ("scope", "email")
+            ("scope", "profile email")
         ].map { URLQueryItem(name: $0.0, value: $0.1) }
 
         if #available(iOS 16.0, *) {

--- a/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/URL+GoogleSignIn.swift
@@ -18,9 +18,11 @@ extension URL {
             ("code_challenge_method", pkce.method.urlQueryParameterValue),
             ("redirect_uri", clientId.defaultRedirectURI),
             ("response_type", "code"),
-            // TODO: We might want to add some of these or them configurable
-            // See https://developers.google.com/identity/protocols/oauth2/scopes
-            ("scope", "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile")
+            // The Google Sign-In SDK use "profile email", but we only need the user's email address.
+            //
+            // See:
+            // https://github.com/google/GoogleSignIn-iOS/blob/7.0.0/GoogleSignIn/Sources/GIDScopes.m#L58-L61
+            ("scope", "email")
         ].map { URLQueryItem(name: $0.0, value: $0.1) }
 
         if #available(iOS 16.0, *) {

--- a/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -34,7 +34,7 @@ class URLGoogleSignInTests: XCTestCase {
         assertQueryItems(
             for: url,
             includeItemNamed: "scope",
-            withValue: "email"
+            withValue: "profile email"
         )
         assertQueryItems(for: url, includeItemNamed: "response_type", withValue: "code")
     }

--- a/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -34,7 +34,7 @@ class URLGoogleSignInTests: XCTestCase {
         assertQueryItems(
             for: url,
             includeItemNamed: "scope",
-            withValue: "openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+            withValue: "email"
         )
         assertQueryItems(for: url, includeItemNamed: "response_type", withValue: "code")
     }


### PR DESCRIPTION
See discussion at https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/735#discussion_r1094342966

To test this, I run the app and verified the authentication was still successful and that my email was sent back from Google in the token to pass to the WordPress.com backend.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
