### PR TITLE
Config to manually handle errors for site credential login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- New configuration and delegate method to handle site credential login failure manually. [#758]
 
 ### Bug Fixes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.6.0):
+  - WordPressAuthenticator (5.7.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 345994ee66093283ccca7e2c279c87957d9a1ec8
+  WordPressAuthenticator: 505fdd48ded1c4de945f29e375b6a9c3dfe0a53e
   WordPressKit: d5bff8713aa7c0092ff6e2a58623e46a99fc897c
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.6.0'
+  s.version       = '5.7.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -154,6 +154,11 @@ public struct WordPressAuthenticatorConfiguration {
     /// instead of using the XMLRPC API for handling site credential login.
     let enableManualSiteCredentialLogin: Bool
 
+    /// If enabled, the library will not show any alert or inline error message
+    /// when site credential login fails.
+    ///
+    let enableManualErrorHandlingForSiteCredentialLogin: Bool
+
     /// Used to determine the `step` value for `unified_login_step` analytics event in `GetStartedViewController`
     ///
     ///  - If disabled `start` will be used as `step` value
@@ -206,6 +211,7 @@ public struct WordPressAuthenticatorConfiguration {
                  skipXMLRPCCheckForSiteDiscovery: Bool = false,
                  skipXMLRPCCheckForSiteAddressLogin: Bool = false,
                  enableManualSiteCredentialLogin: Bool = false,
+                 enableManualErrorHandlingForSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
                  enableSiteAddressLoginOnlyInPrologue: Bool = false,
                  enableSiteCredentialLoginForJetpackSites: Bool = true,
@@ -244,6 +250,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.skipXMLRPCCheckForSiteDiscovery = skipXMLRPCCheckForSiteDiscovery
         self.skipXMLRPCCheckForSiteAddressLogin = skipXMLRPCCheckForSiteAddressLogin
         self.enableManualSiteCredentialLogin = enableManualSiteCredentialLogin
+        self.enableManualErrorHandlingForSiteCredentialLogin = enableManualErrorHandlingForSiteCredentialLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
         self.enableSiteCredentialLoginForJetpackSites = enableSiteCredentialLoginForJetpackSites

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -156,6 +156,7 @@ public struct WordPressAuthenticatorConfiguration {
 
     /// If enabled, the library will not show any alert or inline error message
     /// when site credential login fails.
+    /// Instead, the delegate method `handleSiteCredentialLoginFailure` will be called.
     ///
     let enableManualErrorHandlingForSiteCredentialLogin: Bool
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -115,16 +115,25 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     /// - Parameters:
     ///     - credentials: WordPress.org credentials submitted in the site credentials form.
-    ///     - viewController: the view controller containing the site credential input.
     ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
     ///     - onSuccess: the block to finish the login flow after login succeeds.
     ///     - onFailure: the block to trigger error handling. The closure accepts an error and a boolean indicating if the login failed with incorrect credentials.
     ///
     func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
-                                   in viewController: UIViewController,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error, Bool) -> Void)
+
+    /// Signals to the Host App to handle an error for site credential login.
+    ///
+    /// - Parameters:
+    ///     - error: The site credential login failure.
+    ///     - siteURL: The site URL of the login failure.
+    ///     - viewController: the view controller containing the site credential input.
+    ///
+    func handleSiteCredentialLoginFailure(error: Error,
+                                          for siteURL: String,
+                                          in viewController: UIViewController)
 
     /// Signals to the Host App to navigate to the site creation flow.
     /// This method is currently used only in the simplified login flow
@@ -160,10 +169,15 @@ public extension WordPressAuthenticatorDelegate {
     }
 
     func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
-                                   in viewController: UIViewController,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error, Bool) -> Void) {
+        // No-op
+    }
+
+    func handleSiteCredentialLoginFailure(error: Error,
+                                          for siteURL: String,
+                                          in viewController: UIViewController) {
         // No-op
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -115,11 +115,13 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     /// - Parameters:
     ///     - credentials: WordPress.org credentials submitted in the site credentials form.
+    ///     - viewController: the view controller containing the site credential input.
     ///     - onLoading: the block to update the loading state on the site credentials form when necessary.
     ///     - onSuccess: the block to finish the login flow after login succeeds.
     ///     - onFailure: the block to trigger error handling. The closure accepts an error and a boolean indicating if the login failed with incorrect credentials.
     ///
     func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
+                                   in viewController: UIViewController,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error, Bool) -> Void)
@@ -158,6 +160,7 @@ public extension WordPressAuthenticatorDelegate {
     }
 
     func handleSiteCredentialLogin(credentials: WordPressOrgCredentials,
+                                   in viewController: UIViewController,
                                    onLoading: @escaping (Bool) -> Void,
                                    onSuccess: @escaping () -> Void,
                                    onFailure: @escaping (Error, Bool) -> Void) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -18,6 +18,7 @@ final class SiteCredentialsViewController: LoginViewController {
 
     private let isDismissible: Bool
     private let completionHandler: ((WordPressOrgCredentials) -> Void)?
+    private let configuration = WordPressAuthenticator.shared.configuration
 
     init?(coder: NSCoder, isDismissible: Bool, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
         self.isDismissible = isDismissible
@@ -265,7 +266,7 @@ private extension SiteCredentialsViewController {
             rows.append(.errorMessage)
         }
 
-        if WordPressAuthenticator.shared.configuration.displayHintButtons {
+        if configuration.displayHintButtons {
             rows.append(.forgotPassword)
         }
     }
@@ -466,6 +467,9 @@ private extension SiteCredentialsViewController {
 
     func handleLoginFailure(error: Error, incorrectCredentials: Bool) {
         configureViewLoading(false)
+        guard configuration.enableManualErrorHandlingForSiteCredentialLogin == false else {
+            return
+        }
         if incorrectCredentials {
             let message = NSLocalizedString("It looks like this username/password isn't associated with this site.",
                                             comment: "An error message shown during log in when the username or password is incorrect.")
@@ -520,7 +524,7 @@ extension SiteCredentialsViewController {
     /// proceeds with the submit action.
     ///
     @objc func validateForm() {
-        guard WordPressAuthenticator.shared.configuration.enableManualSiteCredentialLogin else {
+        guard configuration.enableManualSiteCredentialLogin else {
             return validateFormAndLogin() // handles login with XMLRPC normally
         }
 
@@ -536,7 +540,7 @@ extension SiteCredentialsViewController {
         let wporg = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
         let credentials = AuthenticatorCredentials(wporg: wporg)
 
-        guard WordPressAuthenticator.shared.configuration.isWPComLoginRequiredForSiteCredentialsLogin else {
+        guard configuration.isWPComLoginRequiredForSiteCredentialsLogin else {
             // Client didn't explicitly ask for WPCOM credentials. (`isWPComLoginRequiredForSiteCredentialsLogin` is false)
             // So, sync the available credentials and finish sign in.
             //

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -453,7 +453,7 @@ private extension SiteCredentialsViewController {
                                             password: loginFields.password,
                                             xmlrpc: xmlrpc,
                                             options: [:])
-        delegate.handleSiteCredentialLogin(credentials: wporg, onLoading: { [weak self] shouldShowLoading in
+        delegate.handleSiteCredentialLogin(credentials: wporg, in: self, onLoading: { [weak self] shouldShowLoading in
             self?.configureViewLoading(shouldShowLoading)
         }, onSuccess: { [weak self] in
             self?.finishedLogin(withUsername: wporg.username,

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -453,7 +453,7 @@ private extension SiteCredentialsViewController {
                                             password: loginFields.password,
                                             xmlrpc: xmlrpc,
                                             options: [:])
-        delegate.handleSiteCredentialLogin(credentials: wporg, in: self, onLoading: { [weak self] shouldShowLoading in
+        delegate.handleSiteCredentialLogin(credentials: wporg, onLoading: { [weak self] shouldShowLoading in
             self?.configureViewLoading(shouldShowLoading)
         }, onSuccess: { [weak self] in
             self?.finishedLogin(withUsername: wporg.username,
@@ -468,6 +468,7 @@ private extension SiteCredentialsViewController {
     func handleLoginFailure(error: Error, incorrectCredentials: Bool) {
         configureViewLoading(false)
         guard configuration.enableManualErrorHandlingForSiteCredentialLogin == false else {
+            WordPressAuthenticator.shared.delegate?.handleSiteCredentialLoginFailure(error: error, for: loginFields.siteAddress, in: self)
             return
         }
         if incorrectCredentials {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/9186

**Description**
This PR adds a new config to enable manual error handling for site credential login. The new delegate method for site credential login error handling will be triggered when this is enabled. The host app is responsible for implementing the method to show any necessary alert.

**Testing**
Please follow https://github.com/woocommerce/woocommerce-ios/pull/9187 for testing instructions.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
