### PR TITLE
Bump version to 5.7.0 stable and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- New configuration and delegate method to handle site credential login failure manually. [#758]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,12 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 5.7.0
+
+### New Features
+
+- New configuration and delegate method to handle site credential login failure manually. [#758]
 
 ## 5.6.0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.7.0-beta.1):
+  - WordPressAuthenticator (5.7.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 505fdd48ded1c4de945f29e375b6a9c3dfe0a53e
+  WordPressAuthenticator: 51627ce18a62d29f71c9d01dc1e54b3c077fcc7a
   WordPressKit: d5bff8713aa7c0092ff6e2a58623e46a99fc897c
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.7.0-beta.1'
+  s.version       = '5.7.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WooCommerece iOS 12.9 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.
