### PR TITLE
Expose `name` property in `IDToken`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Google's `IDToken` now exposes the user's full name via `name`. [#761]
 
 ### Bug Fixes
 

--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -91,7 +91,7 @@ extension ViewController {
 
                 presentAlert(
                     title: "🎉",
-                    message: "Successfully authenticated with Google.\n\nEmail in received token: \(token.email)",
+                    message: "Successfully authenticated with Google.\n\nEmail in received token: \(token.email)\n\nName: \(token.name)",
                     onDismiss: {}
                 )
             } catch let error as OAuthError {

--- a/WordPressAuthenticator/GoogleSignIn/IDToken.swift
+++ b/WordPressAuthenticator/GoogleSignIn/IDToken.swift
@@ -2,15 +2,22 @@
 public struct IDToken {
 
     public let token: JSONWebToken
+    public let name: String
     public let email: String
 
     // TODO: Validate token! – https://developers.google.com/identity/openid-connect/openid-connect#validatinganidtoken
     init?(jwt: JSONWebToken) {
+        // Name and email might not be part of the JWT Google sent us if the scope used for the
+        // request didn't include them
         guard let email = jwt.payload["email"] as? String else {
+            return nil
+        }
+        guard let name = jwt.payload["name"] as? String else {
             return nil
         }
 
         self.token = jwt
+        self.name = name
         self.email = email
     }
 }

--- a/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
@@ -3,14 +3,23 @@ import XCTest
 
 class IDTokenTests: XCTestCase {
 
-    func testInitWithJWTWithoutEmail() throws {
+    func testInitWithJWTWithoutNameNorEmailFails() throws {
         XCTAssertNil(IDToken(jwt: try XCTUnwrap(JSONWebToken(encodedString: JSONWebToken.validJWTString))))
     }
 
-    func testInitWithJWTWithEmail() throws {
-        let jwt = try XCTUnwrap(JSONWebToken(encodedString: JSONWebToken.validJWTStringWithEmailOnly))
+    func testInitWithJWTWithoutEmailFails() throws {
+        XCTAssertNil(IDToken(jwt: try XCTUnwrap(JSONWebToken(encodedString: JSONWebToken.validJWTStringWithNameOnly))))
+    }
+
+    func testInitWithJWTWithoutNameFails() throws {
+        XCTAssertNil(IDToken(jwt: try XCTUnwrap(JSONWebToken(encodedString: JSONWebToken.validJWTStringWithEmailOnly))))
+    }
+
+    func testInitWithJWTWithNameAndEmailSucceeds() throws {
+        let jwt = try XCTUnwrap(JSONWebToken(encodedString: JSONWebToken.validJWTStringWithNameAndEmail))
         let token = try XCTUnwrap(IDToken(jwt: jwt))
 
+        XCTAssertEqual(token.name, JSONWebToken.nameFromValidJWTStringWithEmail)
         XCTAssertEqual(token.email, JSONWebToken.emailFromValidJWTStringWithEmail)
     }
 

--- a/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/IDTokenTests.swift
@@ -8,7 +8,7 @@ class IDTokenTests: XCTestCase {
     }
 
     func testInitWithJWTWithEmail() throws {
-        let jwt = try XCTUnwrap(JSONWebToken(encodedString: JSONWebToken.validJWTStringWithEmail))
+        let jwt = try XCTUnwrap(JSONWebToken(encodedString: JSONWebToken.validJWTStringWithEmailOnly))
         let token = try XCTUnwrap(IDToken(jwt: jwt))
 
         XCTAssertEqual(token.email, JSONWebToken.emailFromValidJWTStringWithEmail)

--- a/WordPressAuthenticatorTests/GoogleSignIn/JSONWebToken+Fixtures.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/JSONWebToken+Fixtures.swift
@@ -26,7 +26,33 @@ extension JSONWebToken {
     // }
     private(set) static var validJWTStringWithEmailOnly = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ2YWx1ZSIsImVtYWlsIjoidGVzdEBlbWFpbC5jb20ifQ.b-2oTvjpc_qHM5dU6akk_ESe3eWUZwL21pvTsCmW2gE"
 
-    // For convenience, this exposes the email value used in validJWTStringWithEmail.
+    // Created with https://jwt.io/ with input:
+    //
+    // header: {
+    //   "alg": "HS256",
+    //   "typ": "JWT"
+    // }
+    // payload: {
+    //   "name": "John Doe",
+    //   "key": "value"
+    // }
+    private(set) static var validJWTStringWithNameOnly = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJrZXkiOiJ2YWx1ZSJ9.P7Se5_EMlFBg5q8PV4C2IQ1YojTTSgitCBX7FgmXZzs"
+
+    // Created with https://jwt.io/ with input:
+    //
+    // header: {
+    //   "alg": "HS256",
+    //   "typ": "JWT"
+    // }
+    // payload: {
+    //   "name": "John Doe",
+    //   "key": "value",
+    //   "email": "test@email.com"
+    // }
+    private(set) static var validJWTStringWithNameAndEmail = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJrZXkiOiJ2YWx1ZSIsImVtYWlsIjoidGVzdEBlbWFpbC5jb20ifQ.-xzg0r5mMnSZ8hE3hk7S93iCZHhOez1QFYdheSmDlx4"
+
+    // For convenience, this exposes the email and name value used in the fixtures.
     // This allows us to use raw strings in tests, rather than having to implement encoding the JWT from an arbitrary string.
     private(set) static var emailFromValidJWTStringWithEmail = "test@email.com"
+    private(set) static var nameFromValidJWTStringWithEmail = "John Doe"
 }

--- a/WordPressAuthenticatorTests/GoogleSignIn/JSONWebToken+Fixtures.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/JSONWebToken+Fixtures.swift
@@ -24,7 +24,7 @@ extension JSONWebToken {
     //   "key": "value",
     //   "email": "test@email.com"
     // }
-    private(set) static var validJWTStringWithEmail = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ2YWx1ZSIsImVtYWlsIjoidGVzdEBlbWFpbC5jb20ifQ.b-2oTvjpc_qHM5dU6akk_ESe3eWUZwL21pvTsCmW2gE"
+    private(set) static var validJWTStringWithEmailOnly = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ2YWx1ZSIsImVtYWlsIjoidGVzdEBlbWFpbC5jb20ifQ.b-2oTvjpc_qHM5dU6akk_ESe3eWUZwL21pvTsCmW2gE"
 
     // For convenience, this exposes the email value used in validJWTStringWithEmail.
     // This allows us to use raw strings in tests, rather than having to implement encoding the JWT from an arbitrary string.

--- a/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
@@ -86,7 +86,7 @@ class NewGoogleAuthenticatorTests: XCTestCase {
             clientId: fakeClientId,
             scheme: "scheme",
             audience: "audience",
-            oautTokenGetter: GoogleOAuthTokenGettingStub(response: .fixture(rawIDToken: JSONWebToken.validJWTStringWithEmailOnly))
+            oautTokenGetter: GoogleOAuthTokenGettingStub(response: .fixture(rawIDToken: JSONWebToken.validJWTStringWithNameAndEmail))
         )
         let url = URL(string: "https://test.com?code=a_code")!
 

--- a/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
@@ -86,7 +86,7 @@ class NewGoogleAuthenticatorTests: XCTestCase {
             clientId: fakeClientId,
             scheme: "scheme",
             audience: "audience",
-            oautTokenGetter: GoogleOAuthTokenGettingStub(response: .fixture(rawIDToken: JSONWebToken.validJWTStringWithEmail))
+            oautTokenGetter: GoogleOAuthTokenGettingStub(response: .fixture(rawIDToken: JSONWebToken.validJWTStringWithEmailOnly))
         )
         let url = URL(string: "https://test.com?code=a_code")!
 


### PR DESCRIPTION
We need to expose the user's `name` (which corresponds to the full name) when signing in with Google as a prerequisite to Jetpack and WordPress being able to handle a new user signing up with this method.

See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/759 for more details.

## Testing

Other than via unit tests, I verified this by making the demo app print the name in the standalone SDK-Google sign in:

<img alt="image" src="https://user-images.githubusercontent.com/1218433/227934742-ea7283f7-8fc2-428f-9eef-154af976289c.png" width=300/>

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
