### PR TITLE
Handle user canceled "error" in demo app

### DIFF
--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -97,9 +97,8 @@ extension ViewController {
                 )
             } catch let error as OAuthError {
                 presentAlert(title: "❌", message: error.errorDescription, onDismiss: {})
-            } catch let error as NSError where
-                error.domain == ASWebAuthenticationSessionError.errorDomain
-                && error.code == ASWebAuthenticationSessionError.Code.canceledLogin.rawValue {
+            } catch let error as ASWebAuthenticationSessionError
+                where error.code == ASWebAuthenticationSessionError.canceledLogin {
                 // In a production app, the UX would be better if we didn't present an alert.
                 // But here, it's useful to show it to make the error handling visible for reference.
                 presentAlert(title: "", message: "User cancelled", onDismiss: {})

--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import WebKit
 import WordPressAuthenticator
 import WordPressKit
@@ -96,6 +97,12 @@ extension ViewController {
                 )
             } catch let error as OAuthError {
                 presentAlert(title: "❌", message: error.errorDescription, onDismiss: {})
+            } catch let error as NSError where
+                error.domain == ASWebAuthenticationSessionError.errorDomain
+                && error.code == ASWebAuthenticationSessionError.Code.canceledLogin.rawValue {
+                // In a production app, the UX would be better if we didn't present an alert.
+                // But here, it's useful to show it to make the error handling visible for reference.
+                presentAlert(title: "", message: "User cancelled", onDismiss: {})
             } catch {
                 fatalError("Caught an error that was not of the expected `OAuthError` type: \(error)")
             }

--- a/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Google/GoogleAuthViewController.swift
@@ -1,3 +1,5 @@
+import SVProgressHUD
+
 /// View controller that handles the google authentication flow
 ///
 class GoogleAuthViewController: LoginViewController {
@@ -142,6 +144,7 @@ extension GoogleAuthViewController: GoogleAuthenticatorDelegate {
     }
 
     func googleAuthCancelled() {
+        SVProgressHUD.dismiss()
         navigationController?.popViewController(animated: true)
     }
 


### PR DESCRIPTION
While working on #761, I realized the demo app would crash when canceling ("Cancel" button) the web login.

This fixes it. 

## Testing

I verified this by running the app and pressing the "Cancel" button 😅

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. 
