### PR TITLE
Replace `AppleUser` with `SocialService.User`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- `SocialService` `apple` associated type is now `User` instead of `AppleUser`. [#763]
 
 ### New Features
 

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3F82E63929931D95003EFC16 /* CodeVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82E63829931D95003EFC16 /* CodeVerifierTests.swift */; };
 		3F82E63B29935E12003EFC16 /* Data+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82E63A29935E12003EFC16 /* Data+SHA256.swift */; };
 		3F82E63D29935E65003EFC16 /* Data+SHA256Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82E63C29935E65003EFC16 /* Data+SHA256Tests.swift */; };
+		3F86A84229D28473005D20C0 /* SocialUserCreating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84129D28473005D20C0 /* SocialUserCreating.swift */; };
 		3F879FD5293A3AB6005C2B48 /* OAuthTokenRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */; };
 		3F879FD7293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */; };
 		3F879FD9293A48B2005C2B48 /* OAuthTokenResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */; };
@@ -284,6 +285,7 @@
 		3F82E63829931D95003EFC16 /* CodeVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeVerifierTests.swift; sourceTree = "<group>"; };
 		3F82E63A29935E12003EFC16 /* Data+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SHA256.swift"; sourceTree = "<group>"; };
 		3F82E63C29935E65003EFC16 /* Data+SHA256Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SHA256Tests.swift"; sourceTree = "<group>"; };
+		3F86A84129D28473005D20C0 /* SocialUserCreating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserCreating.swift; sourceTree = "<group>"; };
 		3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBody.swift; sourceTree = "<group>"; };
 		3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBodyTests.swift; sourceTree = "<group>"; };
 		3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenResponseBody.swift; sourceTree = "<group>"; };
@@ -815,6 +817,7 @@
 				B5609104208A54F800399AE4 /* SafariCredentialsService.swift */,
 				B56090FE208A54F700399AE4 /* SignupService.swift */,
 				CE1B18C820EEC2C200BECC3F /* SocialService.swift */,
+				3F86A84129D28473005D20C0 /* SocialUserCreating.swift */,
 				B56090FF208A54F800399AE4 /* WordPressComAccountService.swift */,
 				B56090FC208A54F700399AE4 /* WordPressComBlogService.swift */,
 				B56090FD208A54F700399AE4 /* WordPressComOAuthClientFacade.h */,
@@ -1504,6 +1507,7 @@
 				CE9C5B4E24E31E03005A8BCF /* SignupMagicLinkViewController.swift in Sources */,
 				B56090E4208A4F9D00399AE4 /* WPNUXMainButton.m in Sources */,
 				3FFF2FC323D7F53200D38C77 /* AppSelector.swift in Sources */,
+				3F86A84229D28473005D20C0 /* SocialUserCreating.swift in Sources */,
 				3F9439BE27D6F9B60067183A /* LoginPrologueViewController.swift in Sources */,
 				B560913B208A563800399AE4 /* LoginSelfHostedViewController.swift in Sources */,
 				B5609136208A563800399AE4 /* Login2FAViewController.swift in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -33,7 +33,10 @@
 		3F82E63929931D95003EFC16 /* CodeVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82E63829931D95003EFC16 /* CodeVerifierTests.swift */; };
 		3F82E63B29935E12003EFC16 /* Data+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82E63A29935E12003EFC16 /* Data+SHA256.swift */; };
 		3F82E63D29935E65003EFC16 /* Data+SHA256Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82E63C29935E65003EFC16 /* Data+SHA256Tests.swift */; };
+		3F86A83E29D280D7005D20C0 /* AppleAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A83D29D280D7005D20C0 /* AppleAuthenticatorTests.swift */; };
 		3F86A84229D28473005D20C0 /* SocialUserCreating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84129D28473005D20C0 /* SocialUserCreating.swift */; };
+		3F86A84629D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84529D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift */; };
+		3F86A84829D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84729D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift */; };
 		3F879FD5293A3AB6005C2B48 /* OAuthTokenRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */; };
 		3F879FD7293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */; };
 		3F879FD9293A48B2005C2B48 /* OAuthTokenResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */; };
@@ -285,7 +288,10 @@
 		3F82E63829931D95003EFC16 /* CodeVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeVerifierTests.swift; sourceTree = "<group>"; };
 		3F82E63A29935E12003EFC16 /* Data+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SHA256.swift"; sourceTree = "<group>"; };
 		3F82E63C29935E65003EFC16 /* Data+SHA256Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SHA256Tests.swift"; sourceTree = "<group>"; };
+		3F86A83D29D280D7005D20C0 /* AppleAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthenticatorTests.swift; sourceTree = "<group>"; };
 		3F86A84129D28473005D20C0 /* SocialUserCreating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserCreating.swift; sourceTree = "<group>"; };
+		3F86A84529D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDelegateSpy.swift; sourceTree = "<group>"; };
+		3F86A84729D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAuthenticator+TestsUtils.swift"; sourceTree = "<group>"; };
 		3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBody.swift; sourceTree = "<group>"; };
 		3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBodyTests.swift; sourceTree = "<group>"; };
 		3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenResponseBody.swift; sourceTree = "<group>"; };
@@ -547,6 +553,14 @@
 			path = "Email Client Picker";
 			sourceTree = "<group>";
 		};
+		3F86A83F29D280DC005D20C0 /* SingIn */ = {
+			isa = PBXGroup;
+			children = (
+				3F86A83D29D280D7005D20C0 /* AppleAuthenticatorTests.swift */,
+			);
+			path = SingIn;
+			sourceTree = "<group>";
+		};
 		3FE8072229365F740088420C /* GoogleSignIn */ = {
 			isa = PBXGroup;
 			children = (
@@ -688,8 +702,9 @@
 			isa = PBXGroup;
 			children = (
 				3108613025AFA4830022F75E /* PasteboardTests.swift */,
-				B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */,
+				3F86A84729D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift */,
 				CE16177721B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift */,
+				B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */,
 				BA53D64724DFDF97001F1ABF /* WordPressSourceTagTests.swift */,
 			);
 			path = Authenticator;
@@ -932,6 +947,7 @@
 				B501C03B208FC52400D1E58F /* Model */,
 				D85C36E4256E0DAF00D56E34 /* Navigation */,
 				B501C03F208FC52500D1E58F /* Services */,
+				3F86A83F29D280DC005D20C0 /* SingIn */,
 				F18DF0E32525009200D83AFE /* SupportingFiles */,
 				3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */,
 			);
@@ -971,9 +987,10 @@
 		BA53D64924DFE06C001F1ABF /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
-				BA53D64C24DFE4E6001F1ABF /* ModalViewControllerPresentingSpy.swift */,
-				BA53D64A24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift */,
 				D85C36EB256E10EA00D56E34 /* MockNavigationController.swift */,
+				BA53D64C24DFE4E6001F1ABF /* ModalViewControllerPresentingSpy.swift */,
+				3F86A84529D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift */,
+				BA53D64A24DFE07D001F1ABF /* WordpressAuthenticatorProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1537,6 +1554,7 @@
 				BA53D64824DFDF97001F1ABF /* WordPressSourceTagTests.swift in Sources */,
 				3F30A6BA299F12E30004452F /* Character+URLSafeTests.swift in Sources */,
 				4A1DEF4B29341B1F00322608 /* LoggingTests.swift in Sources */,
+				3F86A83E29D280D7005D20C0 /* AppleAuthenticatorTests.swift in Sources */,
 				3F3694022991E244006E923E /* JSONWebToken+Fixtures.swift in Sources */,
 				3F879FDF293A501D005C2B48 /* URLRequest+GoogleSignInTests.swift in Sources */,
 				D8610CEC2570A60C00A5DF27 /* NavigationToRootTests.swift in Sources */,
@@ -1551,6 +1569,7 @@
 				3FEC44F9293A0F2900EBDECF /* ProofKeyForCodeExchangeTests.swift in Sources */,
 				3F107B0529A87AF0009B3658 /* CodeVerifier+Fixture.swift in Sources */,
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
+				3F86A84829D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift in Sources */,
 				3F879FF4293A7F46005C2B48 /* GoogleOAuthTokenGetterTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,
 				3F879FD7293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift in Sources */,
@@ -1558,6 +1577,7 @@
 				3FE8071F2936558F0088420C /* URL+GoogleSignInTests.swift in Sources */,
 				D85C36F0256E118D00D56E34 /* NavigationToEnterAccountTests.swift in Sources */,
 				D85C36E6256E0DDE00D56E34 /* NavigationToEnterSiteTests.swift in Sources */,
+				3F86A84629D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift in Sources */,
 				D85C3882256E3FEC00D56E34 /* WordPressComSiteInfoTests.swift in Sources */,
 				D8611A672576236800A5DF27 /* NavigateBackTests.swift in Sources */,
 				3F879FF8293E222E005C2B48 /* GoogleOAuthTokenGettingStub.swift in Sources */,

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -154,7 +154,7 @@ public class LoginFieldsMeta: NSObject {
 
     var googleUser: GIDGoogleUser?
 
-    var appleUser: AppleUser?
+    var appleUser: SocialService.User?
 
     init(emailMagicLinkSource: EmailMagicLinkSource? = nil,
          jetpackLogin: Bool = false,
@@ -166,7 +166,7 @@ public class LoginFieldsMeta: NSObject {
          socialService: SocialServiceName? = nil,
          socialServiceIDToken: String? = nil,
          googleUser: GIDGoogleUser? = nil,
-         appleUser: AppleUser? = nil) {
+         appleUser: SocialService.User? = nil) {
         self.emailMagicLinkSource = emailMagicLinkSource
         self.jetpackLogin = jetpackLogin
         self.userIsDotCom = userIsDotCom

--- a/WordPressAuthenticator/Services/SignupService.swift
+++ b/WordPressAuthenticator/Services/SignupService.swift
@@ -4,7 +4,7 @@ import WordPressKit
 
 /// SignupService: Responsible for creating a new WPCom user and blog.
 ///
-class SignupService {
+class SignupService: SocialUserCreating {
 
     /// Create a new WPcom account using Google signin token
     ///

--- a/WordPressAuthenticator/Services/SocialService.swift
+++ b/WordPressAuthenticator/Services/SocialService.swift
@@ -4,17 +4,16 @@ import GoogleSignIn
 //
 public enum SocialService {
 
+    public struct User {
+        public let email: String
+        public let fullName: String
+    }
+
     /// Google's Signup Linked Account
     ///
     case google(user: GIDGoogleUser)
 
     /// Apple's Signup Linked Account
     ///
-    case apple(user: AppleUser)
-}
-
-// Struct to contain information relevant to an Apple ID account.
-public struct AppleUser {
-    public var email: String
-    public var fullName: String
+    case apple(user: User)
 }

--- a/WordPressAuthenticator/Services/SocialUserCreating.swift
+++ b/WordPressAuthenticator/Services/SocialUserCreating.swift
@@ -1,0 +1,23 @@
+/// A type that can create WordPress.com users given a social users, either coming from Google or Apple.
+protocol SocialUserCreating: AnyObject {
+
+    func createWPComUserWithGoogle(
+        token: String,
+        success: @escaping (_ newAccount: Bool, _ username: String, _ wpcomToken: String) -> Void,
+        failure: @escaping (_ error: Error) -> Void
+    )
+
+    func createWPComUserWithApple(
+        token: String,
+        email: String,
+        fullName: String?,
+        success: @escaping (
+            _ newAccount: Bool,
+            _ existingNonSocialAccount: Bool,
+            _ existing2faAccount: Bool,
+            _ username: String,
+            _ wpcomToken: String
+        ) -> Void,
+        failure: @escaping (_ error: Error) -> Void
+    )
+}

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -225,8 +225,8 @@ extension AppleAuthenticator {
             fatalError()
         }
 
-        let service = loginFields.meta.appleUser.flatMap {
-            return SocialService.apple(user: $0)
+        let service = loginFields.meta.appleUser.map {
+            SocialService.apple(user: $0)
         }
 
         authenticationDelegate.presentSignupEpilogue(in: navigationController, for: credentials, service: service)

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -166,7 +166,7 @@ private extension AppleAuthenticator {
     func updateLoginFields(email: String, fullName: String, token: String) {
         updateLoginEmail(email)
         loginFields.meta.socialServiceIDToken = token
-        loginFields.meta.appleUser = AppleUser(email: email, fullName: fullName)
+        loginFields.meta.appleUser = SocialService.User(email: email, fullName: fullName)
     }
 
     func updateLoginEmail(_ email: String) {

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -81,58 +81,12 @@ private extension AppleAuthenticator {
                 return
         }
 
-        tracker.set(flow: .signupWithApple)
-        tracker.track(step: .start) {
-            track(.createAccountInitiated)
-        }
-
-        SVProgressHUD.show(withStatus: NSLocalizedString("Continuing with Apple", comment: "Shown while logging in with Apple and the app waits for the site creation process to complete."))
-
-        let email = appleCredentials.email ?? ""
-        let name = fullName(from: appleCredentials.fullName)
-
-        updateLoginFields(email: email, fullName: name, token: token)
-
-        signupService.createWPComUserWithApple(token: token, email: email, fullName: name,
-                                         success: { [weak self] accountCreated,
-                                            existingNonSocialAccount,
-                                            existing2faAccount,
-                                            wpcomUsername,
-                                            wpcomToken in
-                                            SVProgressHUD.dismiss()
-
-                                            // Notify host app of successful Apple authentication
-                                            self?.authenticationDelegate.userAuthenticatedWithAppleUserID(appleCredentials.user)
-
-                                            guard !existingNonSocialAccount else {
-                                                self?.tracker.set(flow: .loginWithApple)
-
-                                                if existing2faAccount {
-                                                    self?.show2FA()
-                                                    return
-                                                }
-
-                                                self?.updateLoginEmail(wpcomUsername)
-                                                self?.logInInstead()
-                                                return
-                                            }
-
-                                            let wpcom = WordPressComCredentials(authToken: wpcomToken, isJetpackLogin: false, multifactor: false, siteURL: self?.loginFields.siteAddress ?? "")
-                                            let credentials = AuthenticatorCredentials(wpcom: wpcom)
-
-                                            if accountCreated {
-                                                self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
-                                                self?.signupSuccessful(with: credentials)
-                                            } else {
-                                                self?.authenticationDelegate.sync(credentials: credentials) {
-                                                    self?.loginSuccessful(with: credentials)
-                                                }
-                                            }
-
-            }, failure: { [weak self] error in
-                SVProgressHUD.dismiss()
-                self?.signupFailed(with: error)
-        })
+        createWordPressComUser(
+            appleUserId: appleCredentials.user,
+            email: appleCredentials.email ?? "",
+            name: fullName(from: appleCredentials.fullName),
+            token: token
+        )
     }
 
     func signupSuccessful(with credentials: AuthenticatorCredentials) {
@@ -157,18 +111,6 @@ private extension AppleAuthenticator {
         }
 
         showLoginEpilogue(for: credentials)
-    }
-
-    func showSignupEpilogue(for credentials: AuthenticatorCredentials) {
-        guard let navigationController = showFromViewController?.navigationController else {
-            fatalError()
-        }
-
-        let service = loginFields.meta.appleUser.flatMap {
-            return SocialService.apple(user: $0)
-        }
-
-        authenticationDelegate.presentSignupEpilogue(in: navigationController, for: credentials, service: service)
     }
 
     func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
@@ -269,5 +211,82 @@ extension AppleAuthenticator {
     func getAppleIDCredentialState(for userID: String,
                                    completion: @escaping (ASAuthorizationAppleIDProvider.CredentialState, Error?) -> Void) {
         ASAuthorizationAppleIDProvider().getCredentialState(forUserID: userID, completion: completion)
+    }
+}
+
+// This needs to be internal, at this point in time, to allow testing.
+//
+// Notice that none of this code was previously tested. A small encapsulation breach like this is
+// worth the testability we gain from it.
+extension AppleAuthenticator {
+
+    func showSignupEpilogue(for credentials: AuthenticatorCredentials) {
+        guard let navigationController = showFromViewController?.navigationController else {
+            fatalError()
+        }
+
+        let service = loginFields.meta.appleUser.flatMap {
+            return SocialService.apple(user: $0)
+        }
+
+        authenticationDelegate.presentSignupEpilogue(in: navigationController, for: credentials, service: service)
+    }
+
+    func createWordPressComUser(appleUserId: String, email: String, name: String, token: String) {
+        tracker.set(flow: .signupWithApple)
+        tracker.track(step: .start) {
+            track(.createAccountInitiated)
+        }
+
+        SVProgressHUD.show(
+            withStatus: NSLocalizedString(
+                "Continuing with Apple",
+                comment: "Shown while logging in with Apple and the app waits for the site creation process to complete."
+            )
+        )
+
+        updateLoginFields(email: email, fullName: name, token: token)
+
+        signupService.createWPComUserWithApple(
+            token: token,
+            email: email,
+            fullName: name,
+            success: { [weak self] accountCreated, existingNonSocialAccount, existing2faAccount, wpcomUsername, wpcomToken in
+                SVProgressHUD.dismiss()
+
+                // Notify host app of successful Apple authentication
+                self?.authenticationDelegate.userAuthenticatedWithAppleUserID(appleUserId)
+
+                guard !existingNonSocialAccount else {
+                    self?.tracker.set(flow: .loginWithApple)
+
+                    if existing2faAccount {
+                        self?.show2FA()
+                        return
+                    }
+
+                    self?.updateLoginEmail(wpcomUsername)
+                    self?.logInInstead()
+                    return
+                }
+
+                let wpcom = WordPressComCredentials(authToken: wpcomToken, isJetpackLogin: false, multifactor: false, siteURL: self?.loginFields.siteAddress ?? "")
+                let credentials = AuthenticatorCredentials(wpcom: wpcom)
+
+                if accountCreated {
+                    self?.authenticationDelegate.createdWordPressComAccount(username: wpcomUsername, authToken: wpcomToken)
+                    self?.signupSuccessful(with: credentials)
+                } else {
+                    self?.authenticationDelegate.sync(credentials: credentials) {
+                        self?.loginSuccessful(with: credentials)
+                    }
+                }
+
+            },
+            failure: { [weak self] error in
+                SVProgressHUD.dismiss()
+                self?.signupFailed(with: error)
+            }
+        )
     }
 }

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -14,10 +14,15 @@ class AppleAuthenticator: NSObject {
     // MARK: - Properties
 
     static var sharedInstance: AppleAuthenticator = AppleAuthenticator()
-    private override init() {}
     private var showFromViewController: UIViewController?
     private let loginFields = LoginFields()
     weak var delegate: AppleAuthenticatorDelegate?
+    let signupService: SignupService
+
+    init(signupService: SignupService = SignupService()) {
+        self.signupService = signupService
+        super.init()
+    }
 
     static let credentialRevokedNotification = ASAuthorizationAppleIDProvider.credentialRevokedNotification
 
@@ -88,8 +93,7 @@ private extension AppleAuthenticator {
 
         updateLoginFields(email: email, fullName: name, token: token)
 
-        let service = SignupService()
-        service.createWPComUserWithApple(token: token, email: email, fullName: name,
+        signupService.createWPComUserWithApple(token: token, email: email, fullName: name,
                                          success: { [weak self] accountCreated,
                                             existingNonSocialAccount,
                                             existing2faAccount,

--- a/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -17,9 +17,9 @@ class AppleAuthenticator: NSObject {
     private var showFromViewController: UIViewController?
     private let loginFields = LoginFields()
     weak var delegate: AppleAuthenticatorDelegate?
-    let signupService: SignupService
+    let signupService: SocialUserCreating
 
-    init(signupService: SignupService = SignupService()) {
+    init(signupService: SocialUserCreating = SignupService()) {
         self.signupService = signupService
         super.init()
     }

--- a/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticator+TestsUtils.swift
+++ b/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticator+TestsUtils.swift
@@ -1,0 +1,51 @@
+@testable import WordPressAuthenticator
+
+extension WordPressAuthenticator {
+
+    static func initializeForTesting() {
+        WordPressAuthenticator.initialize(
+            configuration: WordPressAuthenticatorConfiguration(
+                wpcomClientId: "a",
+                wpcomSecret: "b",
+                wpcomScheme: "c",
+                wpcomTermsOfServiceURL: "d",
+                googleLoginClientId: "e",
+                googleLoginServerClientId: "f",
+                googleLoginScheme: "g",
+                userAgent: "h"
+            ),
+            style: WordPressAuthenticatorStyle(
+                primaryNormalBackgroundColor: .red,
+                primaryNormalBorderColor: .none,
+                primaryHighlightBackgroundColor: .orange,
+                primaryHighlightBorderColor: .none,
+                secondaryNormalBackgroundColor: .yellow,
+                secondaryNormalBorderColor: .green,
+                secondaryHighlightBackgroundColor: .blue,
+                secondaryHighlightBorderColor: .systemIndigo,
+                disabledBackgroundColor: .purple,
+                disabledBorderColor: .red,
+                primaryTitleColor: .orange,
+                secondaryTitleColor: .yellow,
+                disabledTitleColor: .green,
+                disabledButtonActivityIndicatorColor: .blue,
+                textButtonColor: .systemIndigo,
+                textButtonHighlightColor: .purple,
+                instructionColor: .red,
+                subheadlineColor: .orange,
+                placeholderColor: .yellow,
+                viewControllerBackgroundColor: .green,
+                textFieldBackgroundColor: .blue,
+                navBarImage: UIImage(),
+                navBarBadgeColor: .systemIndigo,
+                navBarBackgroundColor: .purple
+            ),
+            unifiedStyle: .none,
+            displayImages: WordPressAuthenticatorDisplayImages(
+                magicLink: UIImage(),
+                siteAddressModalPlaceholder: UIImage()
+            ),
+            displayStrings: WordPressAuthenticatorDisplayStrings()
+        )
+    }
+}

--- a/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
+++ b/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
@@ -1,0 +1,72 @@
+@testable import WordPressAuthenticator
+
+class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
+    var dismissActionEnabled: Bool = true
+    var supportActionEnabled: Bool = true
+    var wpcomTermsOfServiceEnabled: Bool = true
+    var showSupportNotificationIndicator: Bool = true
+    var supportEnabled: Bool = true
+    var allowWPComLogin: Bool = true
+
+    private(set) var socialService: SocialService?
+
+    func createdWordPressComAccount(username: String, authToken: String) {
+        // no-op
+    }
+
+    func userAuthenticatedWithAppleUserID(_ appleUserID: String) {
+        // no-op
+    }
+
+    func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
+        // no-op
+    }
+
+    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
+        // no-op
+    }
+
+    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, source: SignInSource?, onDismiss: @escaping () -> Void) {
+        // no-op
+    }
+
+    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
+        socialService = service
+    }
+
+    func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, lastStep: AuthenticatorAnalyticsTracker.Step, lastFlow: AuthenticatorAnalyticsTracker.Flow) {
+        // no-op
+    }
+
+    func shouldPresentLoginEpilogue(isJetpackLogin: Bool) -> Bool {
+        true
+    }
+
+    func shouldHandleError(_ error: Error) -> Bool {
+        true
+    }
+
+    func handleError(_ error: Error, onCompletion: @escaping (UIViewController) -> Void) {
+        // no-op
+    }
+
+    func shouldPresentSignupEpilogue() -> Bool {
+        true
+    }
+
+    func sync(credentials: AuthenticatorCredentials, onCompletion: @escaping () -> Void) {
+        // no-op
+    }
+
+    func track(event: WPAnalyticsStat) {
+        // no-op
+    }
+
+    func track(event: WPAnalyticsStat, properties: [AnyHashable: Any]) {
+        // no-op
+    }
+
+    func track(event: WPAnalyticsStat, error: Error) {
+        // no-op
+    }
+}

--- a/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
+++ b/WordPressAuthenticatorTests/Mocks/WordPressAuthenticatorDelegateSpy.swift
@@ -8,6 +8,7 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     var supportEnabled: Bool = true
     var allowWPComLogin: Bool = true
 
+    private(set) var presentSignupEpilogueCalled = false
     private(set) var socialService: SocialService?
 
     func createdWordPressComAccount(username: String, authToken: String) {
@@ -31,6 +32,7 @@ class WordPressAuthenticatorDelegateSpy: WordPressAuthenticatorDelegate {
     }
 
     func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
+        presentSignupEpilogueCalled = true
         socialService = service
     }
 

--- a/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
@@ -1,0 +1,9 @@
+//
+//  AppleAuthenticatorTests.swift
+//  WordPressAuthenticatorTests
+//
+//  Created by Gio Lodi on 28/3/2023.
+//  Copyright © 2023 Automattic. All rights reserved.
+//
+
+import Foundation

--- a/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
@@ -10,7 +10,7 @@ class AppleAuthenticatorTests: XCTestCase {
         let delegateSpy = WordPressAuthenticatorDelegateSpy()
         WordPressAuthenticator.shared.delegate = delegateSpy
 
-        // This might be unnecessary because delegateSpy shoudl be deallocated once the test method finished.
+        // This might be unnecessary because delegateSpy should be deallocated once the test method finished.
         // Leaving it here, just in case.
         addTeardownBlock {
             WordPressAuthenticator.shared.delegate = nil
@@ -47,7 +47,7 @@ class AppleAuthenticatorTests: XCTestCase {
         let delegateSpy = WordPressAuthenticatorDelegateSpy()
         WordPressAuthenticator.shared.delegate = delegateSpy
 
-        // This might be unnecessary because delegateSpy shoudl be deallocated once the test method finished.
+        // This might be unnecessary because delegateSpy should be deallocated once the test method finished.
         // Leaving it here, just in case.
         addTeardownBlock {
             WordPressAuthenticator.shared.delegate = nil

--- a/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
+++ b/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
@@ -1,9 +1,79 @@
-//
-//  AppleAuthenticatorTests.swift
-//  WordPressAuthenticatorTests
-//
-//  Created by Gio Lodi on 28/3/2023.
-//  Copyright © 2023 Automattic. All rights reserved.
-//
+import AuthenticationServices
+@testable import WordPressAuthenticator
+import XCTest
 
-import Foundation
+class AppleAuthenticatorTests: XCTestCase {
+
+    // showSignupEpilogue with loginFields.meta.appleUser set will pass SocialService.apple to
+    // the delegate
+    func testShowingSignupEpilogueWithApple() throws {
+        WordPressAuthenticator.initializeForTesting()
+        let delegateSpy = WordPressAuthenticatorDelegateSpy()
+        WordPressAuthenticator.shared.delegate = delegateSpy
+
+        // This might be unnecessary because delegateSpy shoudl be deallocated once the test method finished.
+        // Leaving it here, just in case.
+        addTeardownBlock {
+            WordPressAuthenticator.shared.delegate = nil
+        }
+
+        let socialUserCreatingStub = SocialUserCreatingStub(appleResult: .success((true, true, true, "a", "b")))
+        let sut = AppleAuthenticator(signupService: socialUserCreatingStub)
+
+        // before acting on the SUT, we need to ensure the login fields are set as we expect
+        let presenterViewController = UIViewController()
+        // we need to create this because it's accessed by showFrom(viewController:)
+        _ = UINavigationController(rootViewController: presenterViewController)
+        sut.showFrom(viewController: presenterViewController)
+        sut.createWordPressComUser(
+            appleUserId: "apple-user-id",
+            email: "test@email.com",
+            name: "Full Name",
+            token: "abcd"
+        )
+
+        sut.showSignupEpilogue(for: AuthenticatorCredentials())
+
+        let socialService = try XCTUnwrap(delegateSpy.socialService)
+        guard case .apple(let user) = socialService else {
+            return XCTFail("Expected Apple social service, got \(socialService) instead")
+        }
+        XCTAssertEqual(user.fullName, "Full Name")
+        XCTAssertEqual(user.email, "test@email.com")
+    }
+}
+
+// This doesn't live in a dedicated file because we currently only need it for this test.
+class SocialUserCreatingStub: SocialUserCreating {
+
+    // is new account, user name, WPCom token
+    private let googleResult: Result<(Bool, String, String), Error>
+    // is new account, existing non-social account, existing MFA account, user name, WPCom token
+    private let appleResult: Result<(Bool, Bool, Bool, String, String), Error>
+
+    init(
+        appleResult: Result<(Bool, Bool, Bool, String, String), Error> = .failure(TestError(id: 1)),
+        googleResult: Result<(Bool, String, String), Error> = .failure(TestError(id: 2))
+    ) {
+        self.appleResult = appleResult
+        self.googleResult = googleResult
+    }
+
+    func createWPComUserWithGoogle(token: String, success: @escaping (Bool, String, String) -> Void, failure: @escaping (Error) -> Void) {
+        switch googleResult {
+        case .success((let isNewAccount, let userName, let wpComToken)):
+            success(isNewAccount, userName, wpComToken)
+        case .failure(let error):
+            failure(error)
+        }
+    }
+
+    func createWPComUserWithApple(token: String, email: String, fullName: String?, success: @escaping (Bool, Bool, Bool, String, String) -> Void, failure: @escaping (Error) -> Void) {
+        switch appleResult {
+        case .success((let isNewAccount, let existingNonSocialAccount, let existing2FAAccount, let username, let wpComToken)):
+            success(isNewAccount, existingNonSocialAccount, existing2FAAccount, username, wpComToken)
+        case .failure(let error):
+            failure(error)
+        }
+    }
+}


### PR DESCRIPTION
Instead of using a type with "Apple" in its name as the associated type for `SocialService` `case .apple`, we can use a general purpose type, `SocialService.User`. After all, there is nothing Apple-specific in the email, full name pair and the information that the service used was Google or Apple is already encoded in the `case` name.

The next step for this will be to make `case .google` use `User`, too, as described in #759. But I need #761 first.

The bulk of this PR is actually code to enable testing the change.

@ScoutHarris @jaclync, I asked for your review as suggested by GitHub. I assume that's because you worked on Sing In with Apple? If so, your input would be much appreciated 🙇‍♂️ 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
