### PR TITLE
Replace `GIDGoogleUser` with `SocialService.User` in case .google

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _None._
 ### Breaking Changes
 
 - `SocialService` `apple` associated type is now `User` instead of `AppleUser`. [#763]
+- `SocialService` `google` associated type is now `User` instead of `GIDGoogleUser`. [#764]
 
 ### New Features
 

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3F86A84229D28473005D20C0 /* SocialUserCreating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84129D28473005D20C0 /* SocialUserCreating.swift */; };
 		3F86A84629D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84529D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift */; };
 		3F86A84829D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84729D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift */; };
+		3F86A84A29D2A982005D20C0 /* LoginViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84929D2A982005D20C0 /* LoginViewControllerTests.swift */; };
 		3F879FD5293A3AB6005C2B48 /* OAuthTokenRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */; };
 		3F879FD7293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */; };
 		3F879FD9293A48B2005C2B48 /* OAuthTokenResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */; };
@@ -292,6 +293,7 @@
 		3F86A84129D28473005D20C0 /* SocialUserCreating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialUserCreating.swift; sourceTree = "<group>"; };
 		3F86A84529D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDelegateSpy.swift; sourceTree = "<group>"; };
 		3F86A84729D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAuthenticator+TestsUtils.swift"; sourceTree = "<group>"; };
+		3F86A84929D2A982005D20C0 /* LoginViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewControllerTests.swift; sourceTree = "<group>"; };
 		3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBody.swift; sourceTree = "<group>"; };
 		3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBodyTests.swift; sourceTree = "<group>"; };
 		3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenResponseBody.swift; sourceTree = "<group>"; };
@@ -557,6 +559,7 @@
 			isa = PBXGroup;
 			children = (
 				3F86A83D29D280D7005D20C0 /* AppleAuthenticatorTests.swift */,
+				3F86A84929D2A982005D20C0 /* LoginViewControllerTests.swift */,
 			);
 			path = SingIn;
 			sourceTree = "<group>";
@@ -1569,6 +1572,7 @@
 				3FEC44F9293A0F2900EBDECF /* ProofKeyForCodeExchangeTests.swift in Sources */,
 				3F107B0529A87AF0009B3658 /* CodeVerifier+Fixture.swift in Sources */,
 				CE16177821B70C1A00B82A47 /* WordPressAuthenticatorDisplayTextTests.swift in Sources */,
+				3F86A84A29D2A982005D20C0 /* LoginViewControllerTests.swift in Sources */,
 				3F86A84829D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift in Sources */,
 				3F879FF4293A7F46005C2B48 /* GoogleOAuthTokenGetterTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		3F86A84629D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84529D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift */; };
 		3F86A84829D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84729D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift */; };
 		3F86A84A29D2A982005D20C0 /* LoginViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84929D2A982005D20C0 /* LoginViewControllerTests.swift */; };
+		3F86A84E29D3B53D005D20C0 /* SocialServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F86A84D29D3B53D005D20C0 /* SocialServiceTests.swift */; };
 		3F879FD5293A3AB6005C2B48 /* OAuthTokenRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */; };
 		3F879FD7293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */; };
 		3F879FD9293A48B2005C2B48 /* OAuthTokenResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */; };
@@ -294,6 +295,7 @@
 		3F86A84529D2A306005D20C0 /* WordPressAuthenticatorDelegateSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorDelegateSpy.swift; sourceTree = "<group>"; };
 		3F86A84729D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAuthenticator+TestsUtils.swift"; sourceTree = "<group>"; };
 		3F86A84929D2A982005D20C0 /* LoginViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewControllerTests.swift; sourceTree = "<group>"; };
+		3F86A84D29D3B53D005D20C0 /* SocialServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialServiceTests.swift; sourceTree = "<group>"; };
 		3F879FD4293A3AB6005C2B48 /* OAuthTokenRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBody.swift; sourceTree = "<group>"; };
 		3F879FD6293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenRequestBodyTests.swift; sourceTree = "<group>"; };
 		3F879FD8293A48B2005C2B48 /* OAuthTokenResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenResponseBody.swift; sourceTree = "<group>"; };
@@ -717,6 +719,7 @@
 			isa = PBXGroup;
 			children = (
 				B501C040208FC52500D1E58F /* LoginFacadeTests.m */,
+				3F86A84D29D3B53D005D20C0 /* SocialServiceTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1549,6 +1552,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F4E64782990BBD4000DB555 /* IDTokenTests.swift in Sources */,
+				3F86A84E29D3B53D005D20C0 /* SocialServiceTests.swift in Sources */,
 				3F879FDB293A49AA005C2B48 /* NewGoogleAuthenticatorTests.swift in Sources */,
 				F18DF0E5252500A600D83AFE /* WordPressAuthenticatorTests-Bridging-Header.h in Sources */,
 				3FE8071529364C410088420C /* Result+ConvenienceInitTests.swift in Sources */,

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -152,7 +152,7 @@ public class LoginFieldsMeta: NSObject {
 
     @objc public var socialServiceIDToken: String?
 
-    var googleUser: GIDGoogleUser?
+    var googleUser: SocialService.User?
 
     var appleUser: SocialService.User?
 
@@ -165,7 +165,7 @@ public class LoginFieldsMeta: NSObject {
          requiredMultifactor: Bool = false,
          socialService: SocialServiceName? = nil,
          socialServiceIDToken: String? = nil,
-         googleUser: GIDGoogleUser? = nil,
+         googleUser: SocialService.User? = nil,
          appleUser: SocialService.User? = nil) {
         self.emailMagicLinkSource = emailMagicLinkSource
         self.jetpackLogin = jetpackLogin

--- a/WordPressAuthenticator/Services/SocialService.swift
+++ b/WordPressAuthenticator/Services/SocialService.swift
@@ -9,6 +9,13 @@ public enum SocialService {
         public let fullName: String
     }
 
+    public var user: User {
+        switch self {
+        case .google(let user): return user
+        case .apple(let user): return user
+        }
+    }
+
     /// Google's Signup Linked Account
     ///
     case google(user: User)

--- a/WordPressAuthenticator/Services/SocialService.swift
+++ b/WordPressAuthenticator/Services/SocialService.swift
@@ -11,7 +11,7 @@ public enum SocialService {
 
     /// Google's Signup Linked Account
     ///
-    case google(user: GIDGoogleUser)
+    case google(user: User)
 
     /// Apple's Signup Linked Account
     ///

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -132,8 +132,8 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             fatalError()
         }
 
-        let service = loginFields.meta.googleUser.flatMap {
-            return SocialService.google(user: $0)
+        let service: SocialService? = loginFields.meta.googleUser.map {
+            SocialService.google(user: $0)
         }
 
         authenticationDelegate.presentSignupEpilogue(in: navigationController, for: credentials, service: service)
@@ -425,10 +425,19 @@ extension LoginViewController {
     /// Updates the LoginFields structure, with the specified Google User + Token + Email.
     ///
     func updateLoginFields(googleUser: GIDGoogleUser, googleToken: String, googleEmail: String) {
-        loginFields.emailAddress = googleEmail
-        loginFields.username = googleEmail
+        updateLoginFields(
+            email: googleEmail,
+            username: googleEmail,
+            fullName: googleUser.profile?.name ?? "",
+            googleToken: googleToken
+        )
+    }
+
+    func updateLoginFields(email: String, username: String, fullName: String, googleToken: String) {
+        loginFields.emailAddress = email
+        loginFields.username = email
         loginFields.meta.socialServiceIDToken = googleToken
-        loginFields.meta.googleUser = googleUser
+        loginFields.meta.googleUser = SocialService.User(email: email, fullName: fullName)
     }
 
     // Used by SIWA when logging with with a passwordless, 2FA account.

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -422,24 +422,6 @@ extension LoginViewController {
         loginFacade.loginToWordPressDotCom(withSocialIDToken: token, service: SocialServiceName.apple.rawValue)
     }
 
-    /// Updates the LoginFields structure, with the specified Google User + Token + Email.
-    ///
-    func updateLoginFields(googleUser: GIDGoogleUser, googleToken: String, googleEmail: String) {
-        updateLoginFields(
-            email: googleEmail,
-            username: googleEmail,
-            fullName: googleUser.profile?.name ?? "",
-            googleToken: googleToken
-        )
-    }
-
-    func updateLoginFields(email: String, username: String, fullName: String, googleToken: String) {
-        loginFields.emailAddress = email
-        loginFields.username = email
-        loginFields.meta.socialServiceIDToken = googleToken
-        loginFields.meta.googleUser = SocialService.User(email: email, fullName: fullName)
-    }
-
     // Used by SIWA when logging with with a passwordless, 2FA account.
     //
     func socialNeedsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -145,7 +145,7 @@ class GoogleAuthenticator: NSObject {
                     loginFields: loginFields
                 )
 
-                didSignIn(token: token.token.rawValue, email: token.email)
+                didSignIn(token: token.token.rawValue, email: token.email, fullName: token.name)
             } catch {
                 failedToSignIn(error: error)
             }
@@ -216,15 +216,13 @@ private extension GoogleAuthenticator {
         // Get account information
         guard let user = user,
               let token = user.authentication.idToken,
-              let email = user.profile?.email else {
+              let email = user.profile?.email,
+              let fullName = user.profile?.name else {
             failedToSignIn(error: error)
             return
         }
 
-        // Set `googleUser` here, `didSignIn(token:, email:)` will do the rest.
-        loginFields.meta.googleUser = user
-
-        didSignIn(token: token, email: email)
+        didSignIn(token: token, email: email, fullName: fullName)
     }
 
     private func failedToSignIn(error: Error?) {
@@ -251,11 +249,12 @@ private extension GoogleAuthenticator {
         delegate?.googleAuthCancelled()
     }
 
-    private func didSignIn(token: String, email: String) {
+    private func didSignIn(token: String, email: String, fullName: String) {
         // Save account information to pass back to delegate later.
         loginFields.emailAddress = email
         loginFields.username = email
         loginFields.meta.socialServiceIDToken = token
+        loginFields.meta.googleUser = SocialService.User(email: email, fullName: fullName)
 
         guard authConfig.enableUnifiedAuth else {
             // Initiate separate WP login / signup paths.

--- a/WordPressAuthenticatorTests/Services/SocialServiceTests.swift
+++ b/WordPressAuthenticatorTests/Services/SocialServiceTests.swift
@@ -1,0 +1,19 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+class SocialServiceTests: XCTestCase {
+
+    func testSocialServiceUserApple() throws {
+        let socialService = SocialService.apple(user: .init(email: "test@email.com", fullName: "Full Name"))
+
+        XCTAssertEqual(socialService.user.fullName, "Full Name")
+        XCTAssertEqual(socialService.user.email, "test@email.com")
+    }
+
+    func testSocialServiceUserGoogle() throws {
+        let socialService = SocialService.google(user: .init(email: "email@test.com", fullName: "Name Full"))
+
+        XCTAssertEqual(socialService.user.fullName, "Name Full")
+        XCTAssertEqual(socialService.user.email, "email@test.com")
+    }
+}

--- a/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -1,0 +1,40 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+class LoginViewControllerTests: XCTestCase {
+
+    // showSignupEpilogue with loginFields.meta.appleUser set will pass SocialService.apple to
+    // the delegate
+    func testShowingSignupEpilogueWithGoogleUser() throws {
+        WordPressAuthenticator.initializeForTesting()
+        let delegateSpy = WordPressAuthenticatorDelegateSpy()
+        WordPressAuthenticator.shared.delegate = delegateSpy
+
+        // This might be unnecessary because delegateSpy should be deallocated once the test method finished.
+        // Leaving it here, just in case.
+        addTeardownBlock {
+            WordPressAuthenticator.shared.delegate = nil
+        }
+
+        let sut = LoginViewController()
+        // We need to embed the SUT in a navigation controller because it expects its
+        // navigationController property to not be nil.
+        _ = UINavigationController(rootViewController: sut)
+
+        sut.updateLoginFields(
+            email: "test@email.com",
+            username: "username",
+            fullName: "Full Name",
+            googleToken: "abcd"
+        )
+
+        sut.showSignupEpilogue(for: AuthenticatorCredentials())
+
+        let socialService = try XCTUnwrap(delegateSpy.socialService)
+        guard case .google(let user) = socialService else {
+            return XCTFail("Expected Google social service, got \(socialService) instead")
+        }
+        XCTAssertEqual(user.fullName, "Full Name")
+        XCTAssertEqual(user.email, "test@email.com")
+    }
+}

--- a/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -21,12 +21,7 @@ class LoginViewControllerTests: XCTestCase {
         // navigationController property to not be nil.
         _ = UINavigationController(rootViewController: sut)
 
-        sut.updateLoginFields(
-            email: "test@email.com",
-            username: "username",
-            fullName: "Full Name",
-            googleToken: "abcd"
-        )
+        sut.loginFields.meta.googleUser = SocialService.User(email: "test@email.com", fullName: "Full Name")
 
         sut.showSignupEpilogue(for: AuthenticatorCredentials())
 


### PR DESCRIPTION
Closes #759.

As described in #759, the idea with this PR is to remove the Google SDK-dependent type from the `SocialService` `google` `case` associated value and use the pure Swift `SocialService.User` instead. The new type was introduced in #763.

## To test

The code changes here are consumed via unit tests alone. The demo app doesn't read the `loginFields` metadata where `SocialService` lives.

The "real" test for this new code is in the Jetpack/WordPress iOS that uses it https://github.com/wordpress-mobile/WordPress-iOS/pull/20128

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
