### PR TITLE
Remove some WordPressKit imports that were not used

### DIFF
--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -1,7 +1,6 @@
 import AuthenticationServices
 import WebKit
 import WordPressAuthenticator
-import WordPressKit
 
 extension ViewController {
 

--- a/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
+++ b/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressKit
 
 struct StackedButton {
     enum StackView {

--- a/WordPressAuthenticator/Services/LoginFacade.m
+++ b/WordPressAuthenticator/Services/LoginFacade.m
@@ -3,10 +3,7 @@
 #import "WordPressComOAuthClientFacade.h"
 #import "WordPressXMLRPCAPIFacade.h"
 #import "WPAuthenticator-Swift.h"
-
 @import WordPressKit;
-
-
 
 @implementation LoginFacade
 

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.m
@@ -1,9 +1,6 @@
 #import "WordPressComOAuthClientFacade.h"
 #import "WPAuthenticator-Swift.h"
-
 @import WordPressKit;
-
-
 
 @interface WordPressComOAuthClientFacade ()
 


### PR DESCRIPTION
That's it, just a few deletions. If CI is green, we're good.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
