### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,11 @@ _None._
 
 ### Breaking Changes
 
-- `SocialService` `apple` associated type is now `User` instead of `AppleUser`. [#763]
-- `SocialService` `google` associated type is now `User` instead of `GIDGoogleUser`. [#764]
+_None._
 
 ### New Features
 
-- Google's `IDToken` now exposes the user's full name via `name`. [#761]
+_None._
 
 ### Bug Fixes
 
@@ -48,6 +47,17 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 6.0.0
+
+### Breaking Changes
+
+- `SocialService` `apple` associated type is now `User` instead of `AppleUser`. [#763]
+- `SocialService` `google` associated type is now `User` instead of `GIDGoogleUser`. [#764]
+
+### New Features
+
+- Google's `IDToken` now exposes the user's full name via `name`. [#761]
 
 ## 5.7.0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (5.7.0):
+  - WordPressAuthenticator (6.0.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 51627ce18a62d29f71c9d01dc1e54b3c077fcc7a
+  WordPressAuthenticator: b93b797eae278f7cda42693a652329173f1d5423
   WordPressKit: d5bff8713aa7c0092ff6e2a58623e46a99fc897c
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '5.7.0'
+  s.version       = '6.0.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 22.2, see https://github.com/wordpress-mobile/WordPress-iOS/pull/20128, and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.
