### PR TITLE
Support navigation to WPCom login with an existing email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## Unreleased
+## 6.1.0
 
 ### Breaking Changes
 
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Support navigating to the WPCom login flow with an existing email through `NavigateToEnterAccount`. [#767]
 
 ### Bug Fixes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.0.0):
+  - WordPressAuthenticator (6.1.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: b93b797eae278f7cda42693a652329173f1d5423
+  WordPressAuthenticator: b517ee75b9ce3731dfa6ffd0a655838c9f4990cb
   WordPressKit: d5bff8713aa7c0092ff6e2a58623e46a99fc897c
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.1.0):
+  - WordPressAuthenticator (6.1.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: b517ee75b9ce3731dfa6ffd0a655838c9f4990cb
+  WordPressAuthenticator: e632aa8afeb4583d0c7c0818e2add2bffce47ef2
   WordPressKit: d5bff8713aa7c0092ff6e2a58623e46a99fc897c
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '6.0.0'
+  s.version       = '6.1.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '6.1.0'
+  s.version       = '6.1.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -4,9 +4,11 @@ import Foundation
 ///
 public struct NavigateToEnterAccount: NavigationCommand {
     private let signInSource: SignInSource
+    private let email: String?
 
-    public init(signInSource: SignInSource) {
+    public init(signInSource: SignInSource, email: String? = nil) {
         self.signInSource = signInSource
+        self.email = email
     }
 
     public func execute(from: UIViewController?) {
@@ -15,12 +17,13 @@ public struct NavigateToEnterAccount: NavigationCommand {
 }
 
 private extension NavigateToEnterAccount {
-    private func continueWithDotCom(navigationController: UINavigationController?) {
+    private func continueWithDotCom(email: String? = nil, navigationController: UINavigationController?) {
         guard let vc = GetStartedViewController.instantiate(from: .getStarted) else {
             WPAuthenticatorLogError("Failed to navigate from LoginPrologueViewController to GetStartedViewController")
             return
         }
         vc.source = signInSource
+        vc.loginFields.username = email ?? ""
 
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterAccount.swift
@@ -12,7 +12,7 @@ public struct NavigateToEnterAccount: NavigationCommand {
     }
 
     public func execute(from: UIViewController?) {
-        continueWithDotCom(navigationController: from?.navigationController)
+        continueWithDotCom(email: email, navigationController: from?.navigationController)
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/9407

## Description
This PR updates `NavigateToEnterAccount` to support opening the WPCom login flow with an existing email address.

## Testing
Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/9411 to test this PR.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
