### PR TITLE
Site credentials: Always trigger `completionHandler` when login finishes if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## Unreleased
+## 6.0.1
 
 ### Breaking Changes
 
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Always trigger `completionHandler` if possible when site credential login finishes. [#768]
 
 ### Internal Changes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.0.0):
+  - WordPressAuthenticator (6.0.1-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: b93b797eae278f7cda42693a652329173f1d5423
+  WordPressAuthenticator: 3b05690984590e0c97e44fec89bd06ab16a2da1f
   WordPressKit: d5bff8713aa7c0092ff6e2a58623e46a99fc897c
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '6.0.0'
+  s.version       = '6.0.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -479,6 +479,38 @@ private extension SiteCredentialsViewController {
             displayError(error as NSError, sourceTag: sourceTag)
         }
     }
+
+    func syncDataOrPresentWPComLogin(with wporgCredentials: WordPressOrgCredentials) {
+        if configuration.isWPComLoginRequiredForSiteCredentialsLogin {
+            presentWPComLogin(wporgCredentials: wporgCredentials)
+            return
+        }
+        // Client didn't explicitly ask for WPCOM credentials. (`isWPComLoginRequiredForSiteCredentialsLogin` is false)
+        // So, sync the available credentials and finish sign in.
+        //
+        let credentials = AuthenticatorCredentials(wporg: wporgCredentials)
+        WordPressAuthenticator.shared.delegate?.sync(credentials: credentials) { [weak self] in
+            NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
+            self?.showLoginEpilogue(for: credentials)
+        }
+    }
+
+    func presentWPComLogin(wporgCredentials: WordPressOrgCredentials) {
+        // Try to get the jetpack email from XML-RPC response dictionary.
+        //
+        guard let loginFields = makeLoginFieldsUsing(xmlrpc: wporgCredentials.xmlrpc,
+                                                     options: wporgCredentials.options) else {
+            WPAuthenticatorLogError("Unexpected response from .org site credentials sign in using XMLRPC.")
+            let credentials = AuthenticatorCredentials(wporg: wporgCredentials)
+            showLoginEpilogue(for: credentials)
+            return
+        }
+
+        // Present verify email instructions screen. Passing loginFields will prefill the jetpack email in `VerifyEmailViewController`
+        //
+        presentVerifyEmail(loginFields: loginFields)
+    }
+
     // MARK: - Private Constants
 
     /// Rows listed in the order they were created.
@@ -534,40 +566,13 @@ extension SiteCredentialsViewController {
     }
 
     func finishedLogin(withUsername username: String, password: String, xmlrpc: String, options: [AnyHashable: Any]) {
-        guard let delegate = WordPressAuthenticator.shared.delegate else {
-            fatalError("Error: Where did the delegate go?")
-        }
-
         let wporg = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
-        let credentials = AuthenticatorCredentials(wporg: wporg)
-
         /// If `completionHandler` is available, return early with the credentials.
         if let completionHandler = completionHandler {
-            return completionHandler(wporg)
+            completionHandler(wporg)
+        } else {
+            syncDataOrPresentWPComLogin(with: wporg)
         }
-
-        guard configuration.isWPComLoginRequiredForSiteCredentialsLogin else {
-            // Client didn't explicitly ask for WPCOM credentials. (`isWPComLoginRequiredForSiteCredentialsLogin` is false)
-            // So, sync the available credentials and finish sign in.
-            //
-            delegate.sync(credentials: credentials) { [weak self] in
-                NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
-                self?.showLoginEpilogue(for: credentials)
-            }
-            return
-        }
-
-        // Try to get the jetpack email from XML-RPC response dictionary.
-        //
-        guard let loginFields = makeLoginFieldsUsing(xmlrpc: xmlrpc, options: options) else {
-            WPAuthenticatorLogError("Unexpected response from .org site credentials sign in using XMLRPC.")
-            showLoginEpilogue(for: credentials)
-            return
-        }
-
-        // Present verify email instructions screen. Passing loginFields will prefill the jetpack email in `VerifyEmailViewController`
-        //
-        presentVerifyEmail(loginFields: loginFields)
     }
 
     override func displayRemoteError(_ error: Error) {

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -541,6 +541,11 @@ extension SiteCredentialsViewController {
         let wporg = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
         let credentials = AuthenticatorCredentials(wporg: wporg)
 
+        /// If `completionHandler` is available, return early with the credentials.
+        if let completionHandler = completionHandler {
+            return completionHandler(wporg)
+        }
+
         guard configuration.isWPComLoginRequiredForSiteCredentialsLogin else {
             // Client didn't explicitly ask for WPCOM credentials. (`isWPComLoginRequiredForSiteCredentialsLogin` is false)
             // So, sync the available credentials and finish sign in.
@@ -555,9 +560,6 @@ extension SiteCredentialsViewController {
         // Try to get the jetpack email from XML-RPC response dictionary.
         //
         guard let loginFields = makeLoginFieldsUsing(xmlrpc: xmlrpc, options: options) else {
-            if let completionHandler = completionHandler {
-                return completionHandler(wporg)
-            }
             WPAuthenticatorLogError("Unexpected response from .org site credentials sign in using XMLRPC.")
             showLoginEpilogue(for: credentials)
             return


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/9427

**Description**
This PR fixes the issue for custom site credential login by always triggering `completionHandler` if it's available, regardless of the configurations.

**Testing**
Please follow https://github.com/woocommerce/woocommerce-ios/pull/9440 for the testing steps.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
