### PR TITLE
Remove ambiguous config `enableSiteCredentialLoginForJetpackSites`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## Unreleased
+## 6.2.0-beta.1
 
 ### Breaking Changes
 
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Remove the redundant and ambiguous config `enableSiteCredentialLoginForJetpackSites`. [#771]
 
 ### Internal Changes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.1.0):
+  - WordPressAuthenticator (6.2.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 9956582dabc0e98fc6f22ef960c52d8a3480b2d8
+  WordPressAuthenticator: 022b4354e9de3e43b1dc763e5fc88fe65497bc67
   WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '6.1.0'
+  s.version       = '6.2.0-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -174,11 +174,6 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSiteAddressLoginOnlyInPrologue: Bool
 
-    /// If enabled, the email login screen should not hide the site credential login CTA.
-    /// This is `true` by default.
-    ///
-    let enableSiteCredentialLoginForJetpackSites: Bool
-
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -215,7 +210,6 @@ public struct WordPressAuthenticatorConfiguration {
                  enableManualErrorHandlingForSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
                  enableSiteAddressLoginOnlyInPrologue: Bool = false,
-                 enableSiteCredentialLoginForJetpackSites: Bool = true,
                  googleLoginWithoutSDK: Bool = false
     ) {
 
@@ -254,6 +248,5 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableManualErrorHandlingForSiteCredentialLogin = enableManualErrorHandlingForSiteCredentialLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
-        self.enableSiteCredentialLoginForJetpackSites = enableSiteCredentialLoginForJetpackSites
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -810,13 +810,11 @@ private extension GetStartedViewController {
                                             accessibilityIdentifier: ButtonConfiguration.Continue.accessibilityIdentifier,
                                             onTap: handleSubmitButtonTapped)
 
-        if configuration.enableSiteCredentialLoginForJetpackSites {
-            // Setup Sign in with site credentials button
-            buttonViewController.setupBottomButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
-                                                   isPrimary: false,
-                                                   accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier,
-                                                   onTap: handleSiteCredentialsButtonTapped)
-        }
+        // Setup Sign in with site credentials button
+        buttonViewController.setupBottomButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
+                                               isPrimary: false,
+                                               accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier,
+                                               onTap: handleSiteCredentialsButtonTapped)
     }
 
     func configureButtonViewControllerWithoutSocialLogin() {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/9549

**Description**
Previously in #742 we added a new config `enableSiteCredentialLoginForJetpackSites` to hide the "Sign in with Site Credentials" button on the WPCom login screen during the site address login flow.

However, this button was introduced in #649 and can be hidden through the config `enableSiteCredentialsLoginForSelfHostedSites`.

This PR removes the redundant and ambiguous `enableSiteCredentialLoginForJetpackSites` - it seems that this config is [not used](https://github.com/wordpress-mobile/WordPress-iOS/search?q=enableSiteCredentialLoginForJetpackSites) by WordPress-iOS so I assume it's safe to remove this.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
