### PR TITLE
Merge release 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## 6.2.0-beta.1
+## Unreleased
 
 ### Breaking Changes
 
@@ -42,11 +42,17 @@ _None._
 
 ### Bug Fixes
 
-- Remove the redundant and ambiguous config `enableSiteCredentialLoginForJetpackSites`. [#771]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 6.2.0
+
+### Bug Fixes
+
+- Remove the redundant and ambiguous config `enableSiteCredentialLoginForJetpackSites`. [#771]
 
 ## 6.1.0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.2.0-beta.1):
+  - WordPressAuthenticator (6.2.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 022b4354e9de3e43b1dc763e5fc88fe65497bc67
+  WordPressAuthenticator: 8a27a3c61ca0d740df66f260902aa2ca8528c61b
   WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '6.2.0-beta.1'
+  s.version       = '6.2.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WooCommerce iOS 13.4, and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

---

- [X] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
