### PR TITLE
Merge version 6.3.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ _None._
 
 ## 6.3.0
 
+_Note: This should have been 6.2.1 because it contained only a bug fix. Unfortunately we currently don't have automation in place to enfore SemVer. Given a beta had already been released, we went with 6.3.0 stable._
+
 ### Bug Fixes
 
 - Fix retain cycles by using `weak self` in action closures. [#775]

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.3.0-beta.1):
+  - WordPressAuthenticator (6.3.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 5e3514db04817d1ee24feda3e7e979984c991af8
+  WordPressAuthenticator: d77d347e638e0c80d5539b3d7bd12140ada16845
   WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '6.3.0-beta.1'
+  s.version       = '6.3.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS [22.9](https://github.com/wordpress-mobile/WordPress-iOS/milestone/252) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

_Note: This should have been 6.2.1 because it contained only a bug fix. Unfortunately we currently don't have automation in place to enfore SemVer. Given a beta had already been released, we went with 6.3.0 stable._
