### PR TITLE
Remove GoogleSignIn dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ _None._
 
 ## 7.0.0
 
+### Breaking Changes
+
+- Removed dependency GoogleSignIn SDK and flags to configure it [#777]
+
 ## 6.3.0
 
 _Note: This should have been 6.2.1 because it contained only a bug fix. Unfortunately we currently don't have automation in place to enfore SemVer. Given a beta had already been released, we went with 6.3.0 stable._

--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -29,8 +29,7 @@ extension ViewController {
                 enableUnifiedCarousel: true,
                 // Notice that this is required as well as `enableSignupWithGoogle` to show the
                 // option to login with Google.
-                enableSocialLogin: true,
-                googleLoginWithoutSDK: withGoogleSDK == false
+                enableSocialLogin: true
             ),
             style: WordPressAuthenticatorStyle(
                 // Primary (normal and highlight) is the color of buttons such as "Log in or signup

--- a/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
+++ b/Demo/AuthenticatorDemo/ViewController+WordPressAuthenticator.swift
@@ -4,7 +4,7 @@ import WordPressAuthenticator
 
 extension ViewController {
 
-    func initializeWordPressAuthenticator(withGoogleSDK: Bool) {
+    func initializeWordPressAuthenticator() {
         // In a proper app, we'd want to split this call to keep the code readable. Here, it's
         // useful to keep it all in one block to show how insanely long it is.
         WordPressAuthenticator.initialize(

--- a/Demo/AuthenticatorDemo/ViewController.swift
+++ b/Demo/AuthenticatorDemo/ViewController.swift
@@ -8,22 +8,16 @@ class ViewController: UIViewController {
 
     /// Add `CellConfiguration` items to add new actionable rows to the table view in `ViewController`.
     lazy var configuration: [CellConfiguration] = [
-        CellConfiguration(text: "Show Login - With Google SDK") { [weak self] in
+        CellConfiguration(text: "Show Login") { [weak self] in
             guard let self else { fatalError() }
 
-            self.initializeWordPressAuthenticator(withGoogleSDK: true)
+            self.initializeWordPressAuthenticator()
             WordPressAuthenticator.showLoginFromPresenter(self, animated: true)
         },
-        CellConfiguration(text: "Show Login - Without Google SDK") { [weak self] in
+        CellConfiguration(text: "Get Google token only") { [weak self] in
             guard let self else { fatalError() }
 
-            self.initializeWordPressAuthenticator(withGoogleSDK: false)
-            WordPressAuthenticator.showLoginFromPresenter(self, animated: true)
-        },
-        CellConfiguration(text: "Get Google token only - Standalone, Wihout SDK") { [weak self] in
-            guard let self else { fatalError() }
-
-            self.initializeWordPressAuthenticator(withGoogleSDK: false)
+            self.initializeWordPressAuthenticator()
             self.getAuthTokenFromGoogle()
         }
     ]

--- a/Podfile
+++ b/Podfile
@@ -17,7 +17,6 @@ workspace 'WordPressAuthenticator.xcworkspace'
 ## =====================
 ##
 def third_party_pods
-  pod 'GoogleSignIn', '6.0.1'
   pod 'NSURL+IDN', '0.4'
   pod 'SVProgressHUD', '2.2.5'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,7 @@
 PODS:
   - Alamofire (4.8.2)
-  - AppAuth (1.4.0):
-    - AppAuth/Core (= 1.4.0)
-    - AppAuth/ExternalUserAgent (= 1.4.0)
-  - AppAuth/Core (1.4.0)
-  - AppAuth/ExternalUserAgent (1.4.0)
   - Expecta (1.0.6)
-  - GoogleSignIn (6.0.1):
-    - AppAuth (~> 1.4)
-    - GTMAppAuth (~> 1.0)
-    - GTMSessionFetcher/Core (~> 1.1)
   - Gridicons (1.0.1)
-  - GTMAppAuth (1.2.2):
-    - AppAuth/Core (~> 1.4)
-    - GTMSessionFetcher/Core (~> 1.5)
-  - GTMSessionFetcher/Core (1.6.1)
   - NSObject-SafeExpectations (0.0.6)
   - "NSURL+IDN (0.4)"
   - OCMock (3.8.1)
@@ -22,8 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.3.0):
-    - GoogleSignIn (~> 6.0.1)
+  - WordPressAuthenticator (7.0.0-beta.1):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -42,7 +28,6 @@ PODS:
 
 DEPENDENCIES:
   - Expecta (= 1.0.6)
-  - GoogleSignIn (= 6.0.1)
   - Gridicons (~> 1.0)
   - "NSURL+IDN (= 0.4)"
   - OCMock (~> 3.4)
@@ -57,12 +42,8 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Alamofire
-    - AppAuth
     - Expecta
-    - GoogleSignIn
     - Gridicons
-    - GTMAppAuth
-    - GTMSessionFetcher
     - NSObject-SafeExpectations
     - "NSURL+IDN"
     - OCMock
@@ -81,12 +62,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  GoogleSignIn: 1b0c4ec33a6fe282f4fa35d8ac64263230ddaf36
   Gridicons: 8e19276b20bb15d1fda1d4d0db96d066d170135b
-  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
-  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
   NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
@@ -94,12 +71,12 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: d77d347e638e0c80d5539b3d7bd12140ada16845
+  WordPressAuthenticator: 31b2b358ec1b5c724998f3944b20c29be9be1c95
   WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: c9f023378cc56b2cc3b60aae45af6fea750fe085
+PODFILE CHECKSUM: 39d49f77667f2645b9a7575b7288487421a70c5d
 
 COCOAPODS: 1.11.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -36,7 +36,6 @@ Pod::Spec.new do |s|
   s.dependency 'NSURL+IDN', '0.4'
   s.dependency 'SVProgressHUD', '~> 2.2.5'
   s.dependency 'Gridicons', '~> 1.0'
-  s.dependency 'GoogleSignIn', '~> 6.0.1'
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -1362,10 +1362,6 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/AppAuth/AppAuth.framework",
-				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
-				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleSignIn/GoogleSignIn.framework",
 				"${BUILT_PRODUCTS_DIR}/Gridicons/Gridicons.framework",
 				"${BUILT_PRODUCTS_DIR}/NSObject-SafeExpectations/NSObject_SafeExpectations.framework",
 				"${BUILT_PRODUCTS_DIR}/NSURL+IDN/NSURL_IDN.framework",
@@ -1382,10 +1378,6 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppAuth.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Gridicons.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSObject_SafeExpectations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSURL_IDN.framework",

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -1,5 +1,4 @@
 import AuthenticationServices
-import GoogleSignIn
 import NSURL_IDN
 import UIKit
 import WordPressShared
@@ -132,7 +131,8 @@ import WordPressKit
     /// Attempts to process the specified URL as a Google Authentication Link. Returns *true* on success.
     ///
     @objc public func handleGoogleAuthUrl(_ url: URL, sourceApplication: String?, annotation: Any?) -> Bool {
-        return GIDSignIn.sharedInstance.handle(url)
+        // FIXME: How can we replicate what Google does with its GIDSignIn.sharedInstance.handle(url) method. And should we?
+        return false
     }
 
     /// Attempts to process the specified URL as a WordPress Authentication Link. Returns *true* on success.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -128,13 +128,6 @@ import WordPressKit
         return url.absoluteString.hasPrefix(expectedPrefix)
     }
 
-    /// Attempts to process the specified URL as a Google Authentication Link. Returns *true* on success.
-    ///
-    @objc public func handleGoogleAuthUrl(_ url: URL, sourceApplication: String?, annotation: Any?) -> Bool {
-        // FIXME: How can we replicate what Google does with its GIDSignIn.sharedInstance.handle(url) method. And should we?
-        return false
-    }
-
     /// Attempts to process the specified URL as a WordPress Authentication Link. Returns *true* on success.
     ///
     @objc public func handleWordPressAuthUrl(_ url: URL, rootViewController: UIViewController, automatedTesting: Bool = false) -> Bool {

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -1,4 +1,3 @@
-import GoogleSignIn
 import WordPressKit
 
 // MARK: - WordPressAuthenticator Configuration

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -54,8 +54,6 @@ public struct WordPressAuthenticatorConfiguration {
         return clientId
     }
 
-    let googleLoginWithoutSDK: Bool
-
     /// UserAgent
     ///
     let userAgent: String
@@ -208,8 +206,7 @@ public struct WordPressAuthenticatorConfiguration {
                  enableManualSiteCredentialLogin: Bool = false,
                  enableManualErrorHandlingForSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
-                 enableSiteAddressLoginOnlyInPrologue: Bool = false,
-                 googleLoginWithoutSDK: Bool = false
+                 enableSiteAddressLoginOnlyInPrologue: Bool = false
     ) {
 
         self.wpcomClientId = wpcomClientId
@@ -222,7 +219,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginClientId =  googleLoginClientId
         self.googleLoginServerClientId = googleLoginServerClientId
         self.googleLoginScheme = googleLoginScheme
-        self.googleLoginWithoutSDK = googleLoginWithoutSDK
         self.userAgent = userAgent
         self.showLoginOptions = showLoginOptions
         self.enableSignUp = enableSignUp

--- a/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WordPressAuthenticator/Model/LoginFields.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GoogleSignIn
 import WordPressKit
 
 /// LoginFields is a state container for user textfield input on the login screens

--- a/WordPressAuthenticator/Services/SocialService.swift
+++ b/WordPressAuthenticator/Services/SocialService.swift
@@ -1,7 +1,4 @@
-import GoogleSignIn
-
-// MARK: - Social Services Metadata
-//
+/// Social service metadata.
 public enum SocialService {
 
     public struct User {

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import SVProgressHUD
-import GoogleSignIn
 import WordPressShared
 import WordPressKit
 
@@ -164,9 +163,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         let wpcom = WordPressComCredentials(authToken: authToken, isJetpackLogin: isJetpackLogin, multifactor: true, siteURL: loginFields.siteAddress)
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
         syncWPComAndPresentEpilogue(credentials: credentials)
-
-        // Disconnect now that we're done with Google.
-        GIDSignIn.sharedInstance.disconnect()
 
         // This stat is part of a funnel that provides critical information.  Please
         // consult with your lead before removing this event.

--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -1,6 +1,5 @@
 import WordPressShared
 import WordPressKit
-import GoogleSignIn
 
 /// View Controller for login-specific screens
 open class LoginViewController: NUXViewController, LoginFacadeDelegate {

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -130,11 +130,6 @@ class GoogleAuthenticator: NSObject {
         self.loginFields.meta.socialService = SocialServiceName.google
         self.authType = authType
 
-        guard authConfig.googleLoginWithoutSDK else {
-            // FIXME: We'll need to remove the config option, too
-            return
-        }
-
         Task { @MainActor in
             do {
                 let token = try await requestAuthorization(

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import GoogleSignIn
 import WordPressKit
 import SVProgressHUD
 
@@ -132,8 +131,7 @@ class GoogleAuthenticator: NSObject {
         self.authType = authType
 
         guard authConfig.googleLoginWithoutSDK else {
-            // Use method that depends on SDK
-            requestAuthorization(from: viewController)
+            // FIXME: We'll need to remove the config option, too
             return
         }
 
@@ -174,24 +172,6 @@ class GoogleAuthenticator: NSObject {
 
 private extension GoogleAuthenticator {
 
-    /// Initiates the Google authentication flow.
-    ///   - viewController: The UIViewController that Google is being presented from.
-    ///                     Required by Google SDK.
-    func requestAuthorization(from viewController: UIViewController) {
-        trackRequestAuthorizitation(type: authType)
-
-        let googleInstance = GIDSignIn.sharedInstance
-        let configuration = GIDConfiguration(clientID: authConfig.googleLoginClientId, serverClientID: authConfig.googleLoginServerClientId)
-
-        googleInstance.disconnect()
-
-        // Start the Google auth process. This presents the Google account selection view.
-        // Assigning the view controller has no effect since we don't use Google UI, but it's is required, so here we are.
-        googleInstance.signIn(with: configuration, presenting: viewController) { user, error in
-            self.didSignIn(for: user, error: error)
-        }
-    }
-
     private func trackRequestAuthorizitation(type: GoogleAuthType) {
         switch type {
         case .login:
@@ -208,21 +188,6 @@ private extension GoogleAuthenticator {
         var trackProperties = properties
         trackProperties["source"] = "google"
         WordPressAuthenticator.track(event, properties: trackProperties)
-    }
-
-    /// Handles when the sign in process is either succeeded or failed.
-    /// This is invoked after signing in through `GIDSignIn`'s `signIn` method.
-    func didSignIn(for user: GIDGoogleUser?, error: Error?) {
-        // Get account information
-        guard let user = user,
-              let token = user.authentication.idToken,
-              let email = user.profile?.email,
-              let fullName = user.profile?.name else {
-            failedToSignIn(error: error)
-            return
-        }
-
-        didSignIn(token: token, email: email, fullName: fullName)
     }
 
     private func failedToSignIn(error: Error?) {
@@ -325,7 +290,6 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
     // Google account login was successful.
     func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
         SVProgressHUD.dismiss()
-        GIDSignIn.sharedInstance.disconnect()
 
         // This stat is part of a funnel that provides critical information.  Please
         // consult with your lead before removing this event.
@@ -348,7 +312,6 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
     // Google account login was successful, but a WP 2FA code is required.
     func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
         SVProgressHUD.dismiss()
-        GIDSignIn.sharedInstance.disconnect()
 
         loginFields.nonceInfo = nonceInfo
         loginFields.nonceUserID = userID
@@ -364,7 +327,6 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
     // Google account login was successful, but a WP password is required.
     func existingUserNeedsConnection(_ email: String) {
         SVProgressHUD.dismiss()
-        GIDSignIn.sharedInstance.disconnect()
 
         loginFields.username = email
         loginFields.emailAddress = email
@@ -380,7 +342,6 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
     // Google account login failed.
     func displayRemoteError(_ error: Error) {
         SVProgressHUD.dismiss()
-        GIDSignIn.sharedInstance.disconnect()
 
         var errorTitle = LocalizedText.googleUnableToConnect
         var errorDescription = error.localizedDescription


### PR DESCRIPTION
Notice this points to release/7.0.0 instead of `trunk`. I have at least a followup PR I want to open on top of this, and I want to merge a single breaking change into `trunk`.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
