### PR TITLE
Update prologue buttons style when site creation is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Update button style and position on the prologue screen when `enableSiteCreation` config is enabled.
+- Update button style and position on the prologue screen when `enableSiteCreation` and `enableSiteAddressLoginOnlyInPrologue` configs are enabled.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## Unreleased
+## 6.4.0
 
 ### Breaking Changes
 
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Update button style and position on the prologue screen when `enableSiteCreation` config is enabled.
 
 ### Bug Fixes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (6.3.0):
+  - WordPressAuthenticator (6.4.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -94,7 +94,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: d77d347e638e0c80d5539b3d7bd12140ada16845
+  WordPressAuthenticator: 0406143755a661b818b80d1e926a206b234f99f6
   WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '6.3.0'
+  s.version       = '6.4.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -500,7 +500,7 @@
 		F1DE08CB24F4266A007AE6B3 /* StoredCredentialsAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCredentialsAuthenticator.swift; sourceTree = "<group>"; };
 		F5C817E62582B2F300BD5A3B /* UIPasteboard+Detect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Detect.swift"; sourceTree = "<group>"; };
 		FF475C5056EB60A277696BA9 /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
-		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; };
+		FF629D9522393500004C4106 /* WordPressAuthenticator.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WordPressAuthenticator.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -273,18 +273,24 @@ class LoginPrologueViewController: LoginViewController {
                                                  accessibilityIdentifier: "Prologue Continue Button",
                                                  style: primaryButtonStyle,
                                                  onTap: loginTapCallback())
-        let enterYourSiteAddressButton = StackedButton(title: displayStrings.enterYourSiteAddressButtonTitle,
-                                                       isPrimary: configuration.enableSiteAddressLoginOnlyInPrologue,
-                                                       configureBodyFontForTitle: true,
-                                                       accessibilityIdentifier: "Prologue Self Hosted Button",
-                                                       style: secondaryButtonStyle,
-                                                       onTap: siteAddressTapCallback())
-        let createSiteButton = StackedButton(title: displayStrings.siteCreationButtonTitle,
-                                             isPrimary: false,
-                                             configureBodyFontForTitle: true,
-                                             accessibilityIdentifier: "Prologue Create Site Button",
-                                             style: secondaryButtonStyle,
-                                             onTap: simplifiedLoginSiteCreationCallback())
+        let enterYourSiteAddressButton: StackedButton = {
+            let isPrimary = configuration.enableSiteAddressLoginOnlyInPrologue && !configuration.enableSiteCreation
+            return StackedButton(title: displayStrings.enterYourSiteAddressButtonTitle,
+                                 isPrimary: isPrimary,
+                                 configureBodyFontForTitle: true,
+                                 accessibilityIdentifier: "Prologue Self Hosted Button",
+                                 style: secondaryButtonStyle,
+                                 onTap: siteAddressTapCallback())
+        }()
+        let createSiteButton: StackedButton = {
+            let isPrimary = !configuration.enableSiteAddressLoginOnlyInPrologue
+            return StackedButton(title: displayStrings.siteCreationButtonTitle,
+                                 isPrimary: isPrimary,
+                                 configureBodyFontForTitle: true,
+                                 accessibilityIdentifier: "Prologue Create Site Button",
+                                 style: secondaryButtonStyle,
+                                 onTap: simplifiedLoginSiteCreationCallback())
+        }()
 
         if configuration.enableWPComLoginOnlyInPrologue && configuration.enableSiteCreation {
             buttons = [continueWithWPButton,
@@ -292,7 +298,7 @@ class LoginPrologueViewController: LoginViewController {
         } else if configuration.enableWPComLoginOnlyInPrologue {
             buttons = [continueWithWPButton]
         } else if configuration.enableSiteAddressLoginOnlyInPrologue && configuration.enableSiteCreation {
-            buttons = [enterYourSiteAddressButton, createSiteButton]
+            buttons = [createSiteButton, enterYourSiteAddressButton]
         } else if configuration.enableSiteAddressLoginOnlyInPrologue {
             buttons = [enterYourSiteAddressButton]
         } else if configuration.enableSiteCreation {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -283,7 +283,7 @@ class LoginPrologueViewController: LoginViewController {
                                  onTap: siteAddressTapCallback())
         }()
         let createSiteButton: StackedButton = {
-            let isPrimary = !configuration.enableSiteAddressLoginOnlyInPrologue
+            let isPrimary = configuration.enableSiteAddressLoginOnlyInPrologue
             return StackedButton(title: displayStrings.siteCreationButtonTitle,
                                  isPrimary: isPrimary,
                                  configureBodyFontForTitle: true,


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-ios/issues/10374

**Description**
This PR updates the style and position of the prologue screen. The update concerns 2 configs: `siteCreationEnabled` and `enableSiteAddressLoginOnlyInPrologue` - which are currently used only in WCiOS, so I didn't update this change to be breaking.

**Testing steps**
Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/10549.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
