### PR TITLE
Support WCiOS app login links with WPCOM and site credentials navigation

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.2.0)
-  - WordPressAuthenticator (7.0.0):
+  - WordPressAuthenticator (7.1.0):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
-  WordPressAuthenticator: 6ae29636e22143b6237a841708713b308503d10c
+  WordPressAuthenticator: f73ba530531bb14eedd2f2b69c9b2d387004026c
   WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.0.0'
+  s.version       = '7.1.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
@@ -4,25 +4,32 @@ import Foundation
 ///
 public struct NavigateToEnterSiteCredentials: NavigationCommand {
     private let loginFields: LoginFields
+    private let onDismiss: () -> Void
 
-    public init(loginFields: LoginFields) {
+    public init(loginFields: LoginFields, onDismiss: (() -> Void)?) {
         self.loginFields = loginFields
+        self.onDismiss = onDismiss ?? {}
     }
     public func execute(from: UIViewController?) {
         let navigationController = (from as? UINavigationController) ?? from?.navigationController
         presentSiteCredentialsView(navigationController: navigationController,
-                                   loginFields: loginFields)
+                                   loginFields: loginFields,
+                                   onDismiss: onDismiss)
     }
 }
 
 private extension NavigateToEnterSiteCredentials {
-    func presentSiteCredentialsView(navigationController: UINavigationController?, loginFields: LoginFields) {
+    func presentSiteCredentialsView(navigationController: UINavigationController?, loginFields: LoginFields, onDismiss: @escaping () -> Void) {
         guard let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
             WPAuthenticatorLogError("Failed to navigate to SiteCredentialsViewController")
             return
         }
 
         controller.loginFields = loginFields
+        controller.dismissBlock = { _ in
+            onDismiss()
+        }
+
         navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
@@ -4,32 +4,25 @@ import Foundation
 ///
 public struct NavigateToEnterSiteCredentials: NavigationCommand {
     private let loginFields: LoginFields
-    private let onDismiss: () -> Void
 
-    public init(loginFields: LoginFields, onDismiss: (() -> Void)?) {
+    public init(loginFields: LoginFields) {
         self.loginFields = loginFields
-        self.onDismiss = onDismiss ?? {}
     }
     public func execute(from: UIViewController?) {
         let navigationController = (from as? UINavigationController) ?? from?.navigationController
         presentSiteCredentialsView(navigationController: navigationController,
-                                   loginFields: loginFields,
-                                   onDismiss: onDismiss)
+                                   loginFields: loginFields)
     }
 }
 
 private extension NavigateToEnterSiteCredentials {
-    func presentSiteCredentialsView(navigationController: UINavigationController?, loginFields: LoginFields, onDismiss: @escaping () -> Void) {
+    func presentSiteCredentialsView(navigationController: UINavigationController?, loginFields: LoginFields) {
         guard let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
             WPAuthenticatorLogError("Failed to navigate to SiteCredentialsViewController")
             return
         }
 
         controller.loginFields = loginFields
-        controller.dismissBlock = { _ in
-            onDismiss()
-        }
-
         navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
@@ -9,21 +9,24 @@ public struct NavigateToEnterSiteCredentials: NavigationCommand {
         self.loginFields = loginFields
     }
     public func execute(from: UIViewController?) {
-        presentUsernameAndPasswordView(navigationController: (from as? UINavigationController) ?? from?.navigationController, loginFields: loginFields)
+        let navigationController = (from as? UINavigationController) ?? from?.navigationController
+        presentSiteCredentialsView(navigationController: navigationController,
+                                   loginFields: loginFields)
     }
 }
 
 private extension NavigateToEnterSiteCredentials {
-    func presentUsernameAndPasswordView(navigationController: UINavigationController?, loginFields: LoginFields) {
-        guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
+    func presentSiteCredentialsView(navigationController: UINavigationController?, loginFields: LoginFields) {
+        guard let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
             WPAuthenticatorLogError("Failed to navigate to SiteCredentialsViewController")
             return
         }
 
-        vc.loginFields = loginFields
-//        vc.dismissBlock = dismissBlock
-//        vc.errorToPresent = errorToPresent
+        // TODO: test the dismissal & error handling
+        controller.loginFields = loginFields
+//        controller.dismissBlock = dismissBlock
+//        controller.errorToPresent = errorToPresent
 
-        navigationController?.pushViewController(vc, animated: true)
+        navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
@@ -22,11 +22,7 @@ private extension NavigateToEnterSiteCredentials {
             return
         }
 
-        // TODO: test the dismissal & error handling
         controller.loginFields = loginFields
-//        controller.dismissBlock = dismissBlock
-//        controller.errorToPresent = errorToPresent
-
         navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterSiteCredentials.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Navigates to the wp-admin site credentials flow.
+///
+public struct NavigateToEnterSiteCredentials: NavigationCommand {
+    private let loginFields: LoginFields
+
+    public init(loginFields: LoginFields) {
+        self.loginFields = loginFields
+    }
+    public func execute(from: UIViewController?) {
+        presentUsernameAndPasswordView(navigationController: (from as? UINavigationController) ?? from?.navigationController, loginFields: loginFields)
+    }
+}
+
+private extension NavigateToEnterSiteCredentials {
+    func presentUsernameAndPasswordView(navigationController: UINavigationController?, loginFields: LoginFields) {
+        guard let vc = SiteCredentialsViewController.instantiate(from: .siteAddress) else {
+            WPAuthenticatorLogError("Failed to navigate to SiteCredentialsViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+//        vc.dismissBlock = dismissBlock
+//        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
+    }
+}

--- a/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Navigates to the WPCOM password flow.
+///
+public struct NavigateToEnterWPCOMPassword: NavigationCommand {
+    private let loginFields: LoginFields
+
+    public init(loginFields: LoginFields) {
+        self.loginFields = loginFields
+    }
+    public func execute(from: UIViewController?) {
+        presentUsernameAndPasswordView(navigationController: (from as? UINavigationController) ?? from?.navigationController, loginFields: loginFields)
+    }
+}
+
+private extension NavigateToEnterWPCOMPassword {
+    func presentUsernameAndPasswordView(navigationController: UINavigationController?, loginFields: LoginFields) {
+        guard let vc = PasswordViewController.instantiate(from: .password) else {
+            WPAuthenticatorLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
+            return
+        }
+
+        vc.loginFields = loginFields
+//        vc.dismissBlock = dismissBlock
+//        vc.errorToPresent = errorToPresent
+
+        navigationController?.pushViewController(vc, animated: true)
+    }
+}

--- a/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
@@ -22,11 +22,7 @@ private extension NavigateToEnterWPCOMPassword {
             return
         }
 
-        // TODO: test the dismissal & error handling
         controller.loginFields = loginFields
-//        controller.dismissBlock = dismissBlock
-//        controller.errorToPresent = errorToPresent
-
         navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
@@ -9,21 +9,24 @@ public struct NavigateToEnterWPCOMPassword: NavigationCommand {
         self.loginFields = loginFields
     }
     public func execute(from: UIViewController?) {
-        presentUsernameAndPasswordView(navigationController: (from as? UINavigationController) ?? from?.navigationController, loginFields: loginFields)
+        let navigationController = (from as? UINavigationController) ?? from?.navigationController
+        presentPasswordView(navigationController: navigationController,
+                            loginFields: loginFields)
     }
 }
 
 private extension NavigateToEnterWPCOMPassword {
-    func presentUsernameAndPasswordView(navigationController: UINavigationController?, loginFields: LoginFields) {
-        guard let vc = PasswordViewController.instantiate(from: .password) else {
+    func presentPasswordView(navigationController: UINavigationController?, loginFields: LoginFields) {
+        guard let controller = PasswordViewController.instantiate(from: .password) else {
             WPAuthenticatorLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
             return
         }
 
-        vc.loginFields = loginFields
-//        vc.dismissBlock = dismissBlock
-//        vc.errorToPresent = errorToPresent
+        // TODO: test the dismissal & error handling
+        controller.loginFields = loginFields
+//        controller.dismissBlock = dismissBlock
+//        controller.errorToPresent = errorToPresent
 
-        navigationController?.pushViewController(vc, animated: true)
+        navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
@@ -4,25 +4,32 @@ import Foundation
 ///
 public struct NavigateToEnterWPCOMPassword: NavigationCommand {
     private let loginFields: LoginFields
+    private let onDismiss: () -> Void
 
-    public init(loginFields: LoginFields) {
+    public init(loginFields: LoginFields, onDismiss: (() -> Void)?) {
         self.loginFields = loginFields
+        self.onDismiss = onDismiss ?? {}
     }
     public func execute(from: UIViewController?) {
         let navigationController = (from as? UINavigationController) ?? from?.navigationController
         presentPasswordView(navigationController: navigationController,
-                            loginFields: loginFields)
+                            loginFields: loginFields,
+                            onDismiss: onDismiss)
     }
 }
 
 private extension NavigateToEnterWPCOMPassword {
-    func presentPasswordView(navigationController: UINavigationController?, loginFields: LoginFields) {
+    func presentPasswordView(navigationController: UINavigationController?, loginFields: LoginFields, onDismiss: @escaping () -> Void) {
         guard let controller = PasswordViewController.instantiate(from: .password) else {
             WPAuthenticatorLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
             return
         }
 
         controller.loginFields = loginFields
+        controller.dismissBlock = { _ in
+            onDismiss()
+        }
+
         navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
+++ b/WordPressAuthenticator/Navigation/NavigateToEnterWPCOMPassword.swift
@@ -4,32 +4,25 @@ import Foundation
 ///
 public struct NavigateToEnterWPCOMPassword: NavigationCommand {
     private let loginFields: LoginFields
-    private let onDismiss: () -> Void
 
-    public init(loginFields: LoginFields, onDismiss: (() -> Void)?) {
+    public init(loginFields: LoginFields) {
         self.loginFields = loginFields
-        self.onDismiss = onDismiss ?? {}
     }
     public func execute(from: UIViewController?) {
         let navigationController = (from as? UINavigationController) ?? from?.navigationController
         presentPasswordView(navigationController: navigationController,
-                            loginFields: loginFields,
-                            onDismiss: onDismiss)
+                            loginFields: loginFields)
     }
 }
 
 private extension NavigateToEnterWPCOMPassword {
-    func presentPasswordView(navigationController: UINavigationController?, loginFields: LoginFields, onDismiss: @escaping () -> Void) {
+    func presentPasswordView(navigationController: UINavigationController?, loginFields: LoginFields) {
         guard let controller = PasswordViewController.instantiate(from: .password) else {
             WPAuthenticatorLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
             return
         }
 
         controller.loginFields = loginFields
-        controller.dismissBlock = { _ in
-            onDismiss()
-        }
-
         navigationController?.pushViewController(controller, animated: true)
     }
 }


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-ios/pull/10831

## Description
Introduces two navigations entry points for both the Site Credentials view and the Password view. Those will be used for the login deep link, where the Site Credentials view will be called when a non-jetpack installed store is trying to log in, and the Password view for WPCOM accounts trying to log in.

## Testing steps

Please follow the steps at https://github.com/woocommerce/woocommerce-ios/pull/10831

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
