### PR TITLE
Security Keys: Handle Errors

### DIFF
--- a/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
@@ -32,6 +32,9 @@ extension WordPressSupportSourceTag {
     public static var login2FA: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "login2FA", origin: "origin:login-2fa")
     }
+    public static var loginWebauthn: WordPressSupportSourceTag {
+        return WordPressSupportSourceTag(name: "loginWebauthn", origin: "origin:login-webauthn")
+    }
     public static var loginMagicLink: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "loginMagicLink", origin: "origin:login-magic-link")
     }

--- a/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -13,9 +13,11 @@ extension FancyAlertViewController {
 
     typealias ButtonConfig = FancyAlertViewController.Config.ButtonConfig
 
-    private static func defaultButton() -> ButtonConfig {
+    private static func defaultButton(onTap: (() -> ())? = nil) -> ButtonConfig {
         return ButtonConfig(Strings.OK) { controller, _ in
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true, completion: {
+                onTap?()
+            })
         }
     }
 
@@ -144,7 +146,7 @@ extension FancyAlertViewController {
     /// - Parameter message: The error message to show.
     /// - Parameter sourceTag: tag of the source of the error
     ///
-    static func alertForGenericErrorMessageWithHelpButton(_ message: String, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
+    static func alertForGenericErrorMessageWithHelpButton(_ message: String, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag, onDismiss: (() -> ())? = nil) -> FancyAlertViewController {
 
         // If support is not enabled, don't add a Help Button since it won't do anything.
         var moreHelpButton: ButtonConfig?
@@ -172,7 +174,7 @@ extension FancyAlertViewController {
                                                      bodyText: message,
                                                      headerImage: nil,
                                                      dividerPosition: .top,
-                                                     defaultButton: defaultButton(),
+                                                     defaultButton: defaultButton(onTap: onDismiss),
                                                      cancelButton: nil,
                                                      moreInfoButton: moreHelpButton,
                                                      titleAccessoryButton: nil,

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -81,9 +81,9 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
     /// Displays a login error message in an attractive dialog
     ///
-    public func displayErrorAlert(_ message: String, sourceTag: WordPressSupportSourceTag) {
+    public func displayErrorAlert(_ message: String, sourceTag: WordPressSupportSourceTag, onDismiss: (() -> ())? = nil) {
         let presentingController = navigationController ?? self
-        let controller = FancyAlertViewController.alertForGenericErrorMessageWithHelpButton(message, loginFields: loginFields, sourceTag: sourceTag)
+        let controller = FancyAlertViewController.alertForGenericErrorMessageWithHelpButton(message, loginFields: loginFields, sourceTag: sourceTag, onDismiss: onDismiss)
         controller.modalPresentationStyle = .custom
         controller.transitioningDelegate = self
         presentingController.present(controller, animated: true, completion: nil)

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -298,7 +298,7 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
               let clientDataJson = extractClientData(from: credential, challengeInfo: challengeInfo) else {
             return displaySecurityKeyErrorMessageAndExitFlow()
         }
-        
+
         // Validate that the submitted passkey is allowed.
         guard challengeInfo.allowedCredentialIDs.contains(credential.credentialID.base64EncodedString()) else {
             return displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.invalidKey)
@@ -633,7 +633,7 @@ private extension TwoFAViewController {
         static let smsSent = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
         static let invalidKey = NSLocalizedString("Whoops, that security key does not seem valid. Please try again with another one",
                                                   comment: "Error when the uses chooses an invalid security key on the 2FA screen.")
-        static let timeoutError = NSLocalizedString("Time's up, but don't worry, your security is our priority. Please try again!", 
+        static let timeoutError = NSLocalizedString("Time's up, but don't worry, your security is our priority. Please try again!",
                                                     comment: "Error when the uses takes more than 1 minute to submit a security key.")
         static let unknownError = NSLocalizedString("Whoops, something went wrong. Please try again!", comment: "Generic error on the 2FA screen")
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -18,6 +18,9 @@ final class TwoFAViewController: LoginViewController {
     private var pasteboardChangeCountBeforeBackground: Int?
     private var shouldChangeVoiceOverFocus: Bool = false
 
+    /// Tracks when the initial challenge request was made.
+    private var initialChallengeRequestTime: Date?
+
     override var sourceTag: WordPressSupportSourceTag {
         get {
             return .login2FA
@@ -111,13 +114,21 @@ final class TwoFAViewController: LoginViewController {
     override func configureViewLoading(_ loading: Bool) {
         super.configureViewLoading(loading)
         codeField?.isEnabled = !loading
+        initialChallengeRequestTime = nil
     }
 
     override func displayRemoteError(_ error: Error) {
         displayError(message: "")
 
-        configureViewLoading(false)
         let err = error as NSError
+
+        // If the error happened because the security key challenge request started more than 1 minute ago, show a timeout error.
+        // This check is needed because the server sends a generic error.
+        if let initialChallengeRequestTime, Date().timeIntervalSince(initialChallengeRequestTime) >= 60, err.code == .zero {
+            return displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.timeoutError)
+        }
+
+        configureViewLoading(false)
         if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue {
             // Invalid verification code.
             displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
@@ -202,14 +213,15 @@ private extension TwoFAViewController {
     func loginWithSecurityKeys() {
 
         guard let twoStepNonce = loginFields.nonceInfo?.nonceWebauthn else {
-            return displaySecurityKeyUnknownErrorAndExitFlow()
+            return displaySecurityKeyErrorMessageAndExitFlow()
         }
 
         configureViewLoading(true)
+        initialChallengeRequestTime = Date()
 
         Task { @MainActor in
             guard let challengeInfo = await loginFacade.requestWebauthnChallenge(userID: loginFields.nonceUserID, twoStepNonce: twoStepNonce) else {
-                return displaySecurityKeyUnknownErrorAndExitFlow()
+                return displaySecurityKeyErrorMessageAndExitFlow()
             }
 
             signChallenge(challengeInfo)
@@ -233,9 +245,9 @@ private extension TwoFAViewController {
     }
 
     // When an security key error occurs, we need to restart the flow to regenerate the necessary nonces.
-    func displaySecurityKeyUnknownErrorAndExitFlow() {
+    func displaySecurityKeyErrorMessageAndExitFlow(message: String = LocalizedText.unknownError) {
         configureViewLoading(false)
-        displayErrorAlert(LocalizedText.unknownError, sourceTag: .loginWebauthn, onDismiss: { [weak self] in
+        displayErrorAlert(message, sourceTag: .loginWebauthn, onDismiss: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         })
     }
@@ -283,7 +295,8 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
               let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
               let challengeInfo = loginFields.webauthnChallengeInfo,
               let clientDataJson = extractClientData(from: credential, challengeInfo: challengeInfo) else {
-            return displaySecurityKeyUnknownErrorAndExitFlow()
+            displayErrorAlert(LocalizedText.unknownError, sourceTag: .loginWebauthn)
+            return displaySecurityKeyErrorMessageAndExitFlow()
         }
 
         loginFacade.authenticateWebauthnSignature(userID: loginFields.nonceUserID,
@@ -310,7 +323,7 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         WPAuthenticatorLogError("Error signing challenge: \(error.localizedDescription)")
-        displaySecurityKeyUnknownErrorAndExitFlow()
+        displaySecurityKeyErrorMessageAndExitFlow()
     }
 
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
@@ -613,7 +626,8 @@ private extension TwoFAViewController {
         static let numericalCode = NSLocalizedString("A verification code will only contain numbers.", comment: "Shown when a user types a non-number into the two factor field.")
         static let invalidCode = NSLocalizedString("That doesn't appear to be a valid verification code.", comment: "Shown when a user pastes a code into the two factor field that contains letters or is the wrong length")
         static let smsSent = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
-        static let unknownError = NSLocalizedString("Whoops, something went wrong. Please try again later!", comment: "Generic error on the 2FA screen")
+        static let timeoutError = NSLocalizedString("Time's up, but don't worry, your security is our priority. Please try again!", comment: "Generic error on the 2FA screen")
+        static let unknownError = NSLocalizedString("Whoops, something went wrong. Please try again!", comment: "Generic error on the 2FA screen")
     }
 
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -300,7 +300,7 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
         }
 
         // Validate that the submitted passkey is allowed.
-        guard challengeInfo.allowedCredentialIDs.contains(credential.credentialID.base64EncodedString()) else {
+        guard challengeInfo.allowedCredentialIDs.contains(credential.credentialID.base64URLEncodedString()) else {
             return displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.invalidKey)
         }
 


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/10857
Closes https://github.com/woocommerce/woocommerce-ios/issues/10858
Closes https://github.com/woocommerce/woocommerce-ios/issues/10926

# Why

This PR handles the possible errors the security key flow can encounter.

Specifically, it handles:

- When a user uses an incorrect/invalid passkey
- When a user takes more than one minute to complete the flow
- When a generic or unknown error happens.

When any error happens, we exit the flow. This is to be able to easily regenerate nonces as they can only be used once.

# How

## For Invalid Keys

- Check the submitted key credential ID against the list of allowed credential IDs.
- If the submitted key is not part of the allowed keys, show an error and exit the flow.

## Timeout error

- Store the time when the flow was started and compare it against the time when the error occurred.
- If the time difference is more than one minute show a timeout error and exit the flow.

## Generic Error

- Any other error shows a generic error and exits the flow.

# Demo

### Incorrect key Error
https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/562080/a3f39159-96e5-4b82-98e5-f15fe684e29f

### Timeout Error
https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/562080/f27a4ad3-cc61-4aac-99fb-c9da85631087

### Generic Error
https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/562080/0b733d25-eafe-43d5-bfd0-79f60b871c77

# Testing

You can believe the videos 😅 or you can test on this [experimental branch](https://github.com/woocommerce/woocommerce-ios/pull/10904)

## Notes

- Compiling the experimental branch may be a bit buggy, Cocoapods doesn't work that well with unreleased versions of a pod.
- You need to have a WordPress.com account with a non-A8C email to test social logins
- Magic links do not work. pe5pgL-3QM-p2

## Steps

- Launch the woo app from the [experimental branch](https://github.com/woocommerce/woocommerce-ios/pull/10904)
- Continue with user name/password OR continue with Google or Apple with a non-A8C email.
- Tap on the  "Use a security key" CTA

### Invalid Key

For this step you need to have two security keys from different accounts (eg automatic or personal) stored in your device.

- Select a security key that does not belong to the account you are logging in to.
- See that an "Invalid key" error is presented.
- After tapping "ok", see that the flow exits.

### Timeout Error

- When the security key selection form is presented, wait for 1 minute before continuing.
- Continue after the minute and see that a "Timeout error" error is presented.
- After tapping "ok", see that the flow exits.

### Generic Error

- When the security key selection form is presented, tap the close button.
- See that a "Generic error" is presented
- After tapping "ok", see that the flow exits.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
