### PR TITLE
Test PR for WordPressKit 8.7.0 breaking change fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -28,7 +28,8 @@ def wordpress_authenticator_pods
   ## These should match the version requirement from the podspec.
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7-beta'
-  pod 'WordPressKit', '~> 8.0-beta'
+  # See https://github.com/wordpress-mobile/WordPressKit-iOS/pull/633
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS', commit: 'ff5b38c50ea64bac216bf46f5e5eb6e65c66e36a'
   pod 'WordPressShared', '~> 2.1-beta'
 
   third_party_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,7 +35,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.49)
   - WordPressAuthenticator (from `.`)
-  - WordPressKit (~> 8.0-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS`, commit `ff5b38c50ea64bac216bf46f5e5eb6e65c66e36a`)
   - WordPressShared (~> 2.1-beta)
   - WordPressUI (~> 1.7-beta)
 
@@ -51,7 +51,6 @@ SPEC REPOS:
     - SVProgressHUD
     - SwiftLint
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
@@ -59,6 +58,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   WordPressAuthenticator:
     :path: "."
+  WordPressKit:
+    :commit: ff5b38c50ea64bac216bf46f5e5eb6e65c66e36a
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS
+
+CHECKOUT OPTIONS:
+  WordPressKit:
+    :commit: ff5b38c50ea64bac216bf46f5e5eb6e65c66e36a
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
@@ -77,6 +84,6 @@ SPEC CHECKSUMS:
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: 39d49f77667f2645b9a7575b7288487421a70c5d
+PODFILE CHECKSUM: d14defc6d69b1b43072c777c9cd6b3ce136e5a4b
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - Specta (1.0.7)
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
-  - UIDeviceIdentifier (2.2.0)
+  - UIDeviceIdentifier (2.3.0)
   - WordPressAuthenticator (7.1.0):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -16,7 +16,7 @@ PODS:
     - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.0.0):
+  - WordPressKit (8.7.0):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -70,9 +70,9 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
-  UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
+  UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPressAuthenticator: f73ba530531bb14eedd2f2b69c9b2d387004026c
-  WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
+  WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPressKit-iOS/pull/633

You can see the [failing build with 8.7.0](https://buildkite.com/automattic/wordpresskit-ios/builds/1029#_)...

<img width="1173" alt="image" src="https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/1218433/8d054fd8-74be-4282-a880-1c8282beb8de">

...and [the passing one pointing to the WordPressKit PR
](https://buildkite.com/automattic/wordpress-authenticator-ios/builds/899)

<img width="1197" alt="Screenshot 2023-10-17 at 16 34 34" src="https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/1218433/215215f4-880c-4e72-9e4c-44a707d0f68e">

_Notice that the validation failed, but that's because it validated against 8.7.0 not the new branch._
