### PR TITLE
Fix an issue where `guessXMLRPCURL` is called with an URL without a scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ _None._
 
 -->
 
+## 7.2.1
+
+### Bug Fixes
+
+- Fix an issue where `guessXMLRPCURL` was called with an URL without a scheme resulting in an error [#792]
+
 ## 7.2.0
 
 ### New Features

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (7.2.0):
+  - WordPressAuthenticator (7.2.1-beta.1):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: 1990484092eef67843515a5ed90f3e7db41caf35
+  WordPressAuthenticator: cbf4306acc96a09296603f650e85600fbf74f2d4
   WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.2.0'
+  s.version       = '7.2.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -450,7 +450,7 @@ private extension SiteAddressViewController {
                 return
             }
             // Proceeds to check for the site's WordPress
-            self.guessXMLRPCURL(for: self.loginFields.siteAddress)
+            self.guessXMLRPCURL(for: url.absoluteString)
         }
     }
 


### PR DESCRIPTION
Related issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/20985
Can be tested with this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/21848

## Technical details

`guessXMLRPCURL` can be called with a URL without a scheme due to a race condition which results in an error.

When user submits self-hoste site url, `validateForm()` updates `loginFields.siteAddress` to have appropriate scheme. However, in between asynchronuous `checkSiteExistence()` and `guessXMLRPCURL()` calls `loginFields.siteAddress` can be changed by textField delegate methods back to an URL without a scheme.

### Solution

Make sure `guessXMLRPCURL` is called with an url with a scheme

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
