### PR TITLE
Fix: Submitting wrong code for SMS 2FA can result in a vague error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ _None._
 
 ### Bug Fixes
 
-- Fix an issue where `guessXMLRPCURL` was called with an URL without a scheme resulting in an error [#792]
+- Fix an issue where `guessXMLRPCURL` was called with an URL without a scheme resulting in an error. [#792]
+- Fix an issue that leads to an ambiguous error message when an incorrect SMS 2FA code is submitted. [#793]
 
 ## 7.2.0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (7.2.1-beta.1):
+  - WordPressAuthenticator (7.2.1-beta.2):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: cbf4306acc96a09296603f650e85600fbf74f2d4
+  WordPressAuthenticator: 1d73abee8fdd87032e987c40f140423a6aa0e577
   WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.2.1-beta.1'
+  s.version       = '7.2.1-beta.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -193,7 +193,7 @@ private extension TwoFAViewController {
 
         let (authType, nonce) = nonceInfo.authTypeAndNonce(for: loginFields.multifactorCode)
         if nonce.isEmpty {
-            return validateFormAndLogin()
+            return displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
         }
 
         loginWithNonce(nonce, authType: authType, code: loginFields.multifactorCode)


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/20983
Related PR with testing steps: https://github.com/wordpress-mobile/WordPress-iOS/pull/21863

When a user enters an incorrect length SMS code, `authTypeAndNonce` is constructed as empty. There's no point attempting to log in with an empty nonce since the user would receive a non-descriptive "two_step_nonce required" message.

Changes made https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/788 have slightly changed the originally reported issue. Now it incorrectly displays: "Please fill out all the fields" after entering too short an SMS code. 

Before we would call `loginWithNonce` with an empty nonce resulting in "two_step_nonce required"  error.
Now we called `validateFormAndLogin` with an empty nonce resulting in "Please fill out all the fields" error.

### Changes

Explicitly show "invalid 2fa code message" when entering an incorrect SMS code.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
