### PR TITLE
Fix issue checking site existence for a number of sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ _None._
 - Fix an issue where `guessXMLRPCURL` was called with an URL without a scheme resulting in an error. [#792]
 - Fix an issue that leads to an ambiguous error message when an incorrect SMS 2FA code is submitted. [#793]
 - Fix an issue where two 2FA controllers were being opened at the same time when logging in. [#794]
+- Fix an issue where site address check fails for some sites. [#795]
 
 ## 7.2.0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (7.2.1-beta.2):
+  - WordPressAuthenticator (7.2.1-beta.3):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: 1d73abee8fdd87032e987c40f140423a6aa0e577
+  WordPressAuthenticator: ce0a8e79bfd97dcf996e1b66ac57a8105fe0cb6b
   WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.2.1-beta.2'
+  s.version       = '7.2.1-beta.3'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -456,7 +456,7 @@ private extension SiteAddressViewController {
 
     func checkSiteExistence(url: URL, onCompletion: @escaping () -> Void) {
         var request = URLRequest(url: url)
-        request.httpMethod = "HEAD"
+        request.httpMethod = "GET"
         request.timeoutInterval = 10.0 // waits for 10 seconds
         let task = URLSession.shared.dataTask(with: request) { [weak self] _, _, error in
             DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/11005

**Description**
As discussed in peaMlT-d1-p2, some users reported that their sites cannot pass the site check on the site address login screen on iOS, but it works for them on Android.

The code on the Android app is using GET to check the site info whereas we're using HEAD for iOS. I could not find any documentation about why we decided to use HEAD, but since GET helps unstuck users and make us align with Android, this PR updates the check to use GET for the check.

**Testing**

Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/11006.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
