### PR TITLE
Make extensions for `LoginFacade` and `Data` for external access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ _None._
 
 -->
 
+## 7.3.0
+
+### New Features
+
+- Make extensions for `LoginFacade` and `Data` public to be accessible from external modules.
+
+
 ## 7.2.1
 
 ### Bug Fixes

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (7.2.1):
+  - WordPressAuthenticator (7.3.0):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: eb60491871a2b8819017deed2970b054d2678547
+  WordPressAuthenticator: 16f6560a06008cc502b92c85e76eaaa90248c12b
   WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.2.1'
+  s.version       = '7.3.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/GoogleSignIn/Data+Base64URL.swift
+++ b/WordPressAuthenticator/GoogleSignIn/Data+Base64URL.swift
@@ -1,4 +1,4 @@
-extension Data {
+public extension Data {
 
     /// "base64url" is an encoding that is safe to use with URLs.
     /// It is defined in RFC 4648, section 5.

--- a/WordPressAuthenticator/Services/LoginFacade.swift
+++ b/WordPressAuthenticator/Services/LoginFacade.swift
@@ -1,7 +1,9 @@
 import Foundation
 import WordPressKit
 
-extension LoginFacade {
+/// Extension for handling 2FA authentication.
+///
+public extension LoginFacade {
     private var tracker: AuthenticatorAnalyticsTracker {
         AuthenticatorAnalyticsTracker.shared
     }
@@ -113,7 +115,7 @@ extension LoginFacade {
     }
 
     @objc
-    public func trackSuccess() {
+    func trackSuccess() {
         tracker.track(step: .success)
     }
 }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/10590

**Description**
As part of  the effort for https://github.com/woocommerce/woocommerce-ios/issues/10590, we want to support the login feature with custom UI from WCiOS while using the main logic from `WordPressAuthenticator` library. To support security key login, we need access to the new extensions of `LoginFacade` and `Data`.

**Testing**
Please follow the testing step in https://github.com/woocommerce/woocommerce-ios/pull/11070.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
