### PR TITLE
Passkeys: Show actionable error if the only supported auth type is webauthn

### DIFF
--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.3.0'
+  s.version       = '7.3.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -191,6 +191,10 @@ private extension TwoFAViewController {
             return validateFormAndLogin()
         }
 
+        if nonceInfo.supportedAuthTypes == ["webauthn"] {
+            return displayError(message: LocalizedText.securityKeyEnabledMessage, moveVoiceOverFocus: true)
+        }
+
         let (authType, nonce) = nonceInfo.authTypeAndNonce(for: loginFields.multifactorCode)
         if nonce.isEmpty {
             return displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
@@ -630,6 +634,7 @@ private extension TwoFAViewController {
     }
 
     enum LocalizedText {
+        static let securityKeyEnabledMessage = NSLocalizedString("Whoops, a security key is enabled for this account. Please use your security key to log in.", comment: "Error message shown when a security key is enabled for an account but a different type of two factor code is provided.")
         static let bad2FAMessage = NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!", comment: "Error message shown when an incorrect two factor code is provided.")
         static let numericalCode = NSLocalizedString("A verification code will only contain numbers.", comment: "Shown when a user types a non-number into the two factor field.")
         static let invalidCode = NSLocalizedString("That doesn't appear to be a valid verification code.", comment: "Shown when a user pastes a code into the two factor field that contains letters or is the wrong length")


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPressKit-iOS/pull/645

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
