### PR TITLE
Passkeys: Don't show error if users cancels Passkey authentication

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -28,7 +28,7 @@ def wordpress_authenticator_pods
   ## These should match the version requirement from the podspec.
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7-beta'
-  pod 'WordPressKit', '~> 8.7-beta'
+  pod 'WordPressKit', '~> 9.0-beta'
   pod 'WordPressShared', '~> 2.1-beta'
 
   third_party_pods

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressUI', '~> 1.7-beta'
-  s.dependency 'WordPressKit', '~> 8.7-beta'
+  s.dependency 'WordPressKit', '~> 9.0-beta'
   s.dependency 'WordPressShared', '~> 2.1-beta'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.3.0'
+  s.version       = '7.3.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -331,6 +331,14 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         WPAuthenticatorLogError("Error signing challenge: \(error.localizedDescription)")
+
+        // Don't show error if user cancelled authentication.
+        if let authorizationError = error as? ASAuthorizationError,
+            authorizationError.code == .canceled {
+            configureViewLoading(false)
+            return
+        }
+
         displaySecurityKeyErrorMessageAndExitFlow()
     }
 


### PR DESCRIPTION
## Description

Fixes an issue where an error was displayed when you exit out of Passkey authentication

### Before


https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/6711616/c76c9fd1-311e-4d53-bee4-7c1eb71b0e75


### After

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/6711616/951a4b74-04a7-4163-8405-5ec95c508998


## How to test
Test via https://github.com/wordpress-mobile/WordPress-iOS/pull/22001

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
