### PR TITLE
Revert change to fix 2FA issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ _None._
 
 -->
 
+## 7.3.1
+
+### Bug Fixes
+
+- Fix a regression where app-based 2FA stopped working on accounts with passkeys enabled
+
+
 ## 7.3.0
 
 ### New Features

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (7.3.0):
+  - WordPressAuthenticator (7.3.1-beta.1):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: 16f6560a06008cc502b92c85e76eaaa90248c12b
+  WordPressAuthenticator: e8f06f2162972d652770247ed79572f5c276b383
   WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.3.0'
+  s.version       = '7.3.1-beta.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -193,7 +193,7 @@ private extension TwoFAViewController {
 
         let (authType, nonce) = nonceInfo.authTypeAndNonce(for: loginFields.multifactorCode)
         if nonce.isEmpty {
-            return displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
+            return validateFormAndLogin()
         }
 
         loginWithNonce(nonce, authType: authType, code: loginFields.multifactorCode)


### PR DESCRIPTION
A regression related to the changes in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/793 caused app-based 2FA to stop working on passkey-enabled WP.com accounts.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
