### PR TITLE
Merge 7.3.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,17 +48,16 @@ _None._
 
 _None._
 
-## 7.3.1
-
-### Bug Fixes
-
-- Fix a regression where app-based 2FA stopped working on accounts with passkeys enabled. [#802]
-
 ## 7.3.0
 
 ### New Features
 
 - Make extensions for `LoginFacade` and `Data` public to be accessible from external modules. [#798]
+
+### Bug Fixes
+
+- Fix a regression where app-based 2FA stopped working on accounts with passkeys enabled. [#802]
+
 
 ## 7.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,19 +30,35 @@ _None._
 
 -->
 
+## Unreleased
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
 ## 7.3.1
 
 ### Bug Fixes
 
-- Fix a regression where app-based 2FA stopped working on accounts with passkeys enabled
-
+- Fix a regression where app-based 2FA stopped working on accounts with passkeys enabled. [#802]
 
 ## 7.3.0
 
 ### New Features
 
-- Make extensions for `LoginFacade` and `Data` public to be accessible from external modules.
-
+- Make extensions for `LoginFacade` and `Data` public to be accessible from external modules. [#798]
 
 ## 7.2.1
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (7.3.1):
+  - WordPressAuthenticator (7.3.0):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: 503a174d8ccc0781a0f5769e5e284e07cb294dc0
+  WordPressAuthenticator: 16f6560a06008cc502b92c85e76eaaa90248c12b
   WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.49.1)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (7.3.1-beta.1):
+  - WordPressAuthenticator (7.3.1):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: e8f06f2162972d652770247ed79572f5c276b383
+  WordPressAuthenticator: 503a174d8ccc0781a0f5769e5e284e07cb294dc0
   WordPressKit: a5432c2e3c2247c2b83b3ebf0acec75ae00782ef
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.3.1-beta.1'
+  s.version       = '7.3.1'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '7.3.1'
+  s.version       = '7.3.0'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR finalizes a fix for the upcoming Jetpack/WordPress 23.6 and WooCommerce 16.1 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

---

Update: This was originally 7.3.1, but it turned out that the version was changed to 7.3.0 in the `podspec`, but
a tag for it was never pushed. It would be confusing to have a 7.3.1 without a 7.3.0, so I thought I'd just "downgrade" and ship the current changes as 7.3.0.