### PR TITLE
Avoid casting to NSError when handling HTTP API errors

### DIFF
--- a/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -74,7 +74,8 @@ extension FancyAlertViewController {
     ///
     /// - Returns: A FancyAlertViewController instance.
     ///
-    static func alertForError(_ error: NSError, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
+    static func alertForError(_ originalError: Error, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
+        let error = originalError as NSError
         var message = error.localizedDescription
 
         WPAuthenticatorLogError(message)

--- a/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -71,9 +71,9 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
     /// Displays a login error in an attractive dialog
     ///
-    func displayError(_ error: NSError, sourceTag: WordPressSupportSourceTag) {
+    func displayError(_ error: Error, sourceTag: WordPressSupportSourceTag) {
         let presentingController = navigationController ?? self
-        let controller = FancyAlertViewController.alertForError(error as NSError, loginFields: loginFields, sourceTag: sourceTag)
+        let controller = FancyAlertViewController.alertForError(error, loginFields: loginFields, sourceTag: sourceTag)
         controller.modalPresentationStyle = .custom
         controller.transitioningDelegate = self
         presentingController.present(controller, animated: true, completion: nil)

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -328,7 +328,7 @@ extension Login2FAViewController {
             }
             displayError(message: bad2FAMessage)
         } else {
-            displayError(error as NSError, sourceTag: sourceTag)
+            displayError(error, sourceTag: sourceTag)
         }
     }
 }

--- a/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -402,7 +402,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
                                                 // username instead.
                                                 strongSelf.showSelfHostedUsernamePasswordAndError(error)
                                         } else {
-                                            strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
+                                            strongSelf.displayError(error, sourceTag: strongSelf.sourceTag)
                                         }
         })
     }

--- a/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
@@ -117,7 +117,7 @@ class LoginLinkRequestViewController: LoginViewController {
                 guard let strongSelf = self else {
                     return
                 }
-                strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
+                strongSelf.displayError(error, sourceTag: strongSelf.sourceTag)
                 strongSelf.configureLoading(false)
         })
     }

--- a/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -264,7 +264,7 @@ extension LoginSelfHostedViewController {
                                             comment: "An error message shown during log in when the username or password is incorrect.")
             displayError(message: message, moveVoiceOverFocus: true)
         } else {
-            displayError(error as NSError, sourceTag: sourceTag)
+            displayError(error, sourceTag: sourceTag)
         }
     }
 }

--- a/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -185,7 +185,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                 self.displayError(message: msg, moveVoiceOverFocus: true)
 
             } else {
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                self.displayError(error, sourceTag: self.sourceTag)
             }
         })
     }

--- a/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginUsernamePasswordViewController.swift
@@ -228,7 +228,7 @@ extension LoginUsernamePasswordViewController {
         if err.code == 403 {
             displayError(message: NSLocalizedString("It looks like this username/password isn't associated with this site.", comment: "An error message shown during log in when the username or password is incorrect."))
         } else {
-            displayError(error as NSError, sourceTag: sourceTag)
+            displayError(error, sourceTag: sourceTag)
         }
     }
 }

--- a/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
+++ b/WordPressAuthenticator/Signup/SignupGoogleViewController.swift
@@ -70,7 +70,7 @@ extension SignupGoogleViewController: GoogleAuthenticatorSignupDelegate {
         self.loginFields = loginFields
         titleLabel?.textColor = WPStyleGuide.errorRed()
         titleLabel?.text = LocalizedText.signupFailed
-        displayError(error as NSError, sourceTag: .wpComSignup)
+        displayError(error, sourceTag: .wpComSignup)
     }
 
     func googleSignupCancelled() {

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -139,7 +139,7 @@ final class TwoFAViewController: LoginViewController {
             }
             displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
         } else {
-            displayError(error as NSError, sourceTag: sourceTag)
+            displayError(error, sourceTag: sourceTag)
         }
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -580,7 +580,7 @@ private extension GetStartedViewController {
             let signInError = SignInError(error: error, source: source) ?? error
             guard let authenticationDelegate = WordPressAuthenticator.shared.delegate,
                   authenticationDelegate.shouldHandleError(signInError) else {
-                displayError(error as NSError, sourceTag: sourceTag)
+                displayError(error, sourceTag: sourceTag)
                 return
             }
 
@@ -621,7 +621,7 @@ private extension GetStartedViewController {
                 }
 
                 self.tracker.track(failure: error.localizedDescription)
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                self.displayError(error, sourceTag: self.sourceTag)
                 self.configureSubmitButton(animating: false)
         })
     }
@@ -664,7 +664,7 @@ private extension GetStartedViewController {
 
                 self.tracker.track(failure: error.localizedDescription)
 
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                self.displayError(error, sourceTag: self.sourceTag)
                 self.configureViewLoading(false)
         })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -154,7 +154,7 @@ class PasswordViewController: LoginViewController {
             }
             displayError(message: displayMessage, moveVoiceOverFocus: true)
         } else {
-            displayError(nsError, sourceTag: sourceTag)
+            displayError(error, sourceTag: sourceTag)
         }
     }
 
@@ -304,7 +304,7 @@ private extension PasswordViewController {
                 present(alert, animated: true, completion: nil)
             default:
                 tracker.track(failure: error.localizedDescription)
-                displayError(error as NSError, sourceTag: sourceTag)
+                displayError(error, sourceTag: sourceTag)
             }
         }
         updateLoadingUI(isRequestingMagicLink: false)

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -548,7 +548,7 @@ private extension SiteAddressViewController {
                 if let message = errorMessage {
                     self.displayError(message: message, moveVoiceOverFocus: true)
                 } else {
-                    self.displayError(error as NSError, sourceTag: self.sourceTag)
+                    self.displayError(error, sourceTag: self.sourceTag)
                 }
         })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -476,7 +476,7 @@ private extension SiteCredentialsViewController {
                                             comment: "An error message shown during log in when the username or password is incorrect.")
             displayError(message: message, moveVoiceOverFocus: true)
         } else {
-            displayError(error as NSError, sourceTag: sourceTag)
+            displayError(error, sourceTag: sourceTag)
         }
     }
 
@@ -583,7 +583,7 @@ extension SiteCredentialsViewController {
                                             comment: "An error message shown during log in when the username or password is incorrect.")
             displayError(message: message, moveVoiceOverFocus: true)
         } else {
-            displayError(error as NSError, sourceTag: sourceTag)
+            displayError(error, sourceTag: sourceTag)
         }
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -196,7 +196,7 @@ private extension VerifyEmailViewController {
 
                 self.tracker.track(failure: error.localizedDescription)
 
-                self.displayError(error as NSError, sourceTag: self.sourceTag)
+                self.displayError(error, sourceTag: self.sourceTag)
                 self.configureViewLoading(false)
         })
     }


### PR DESCRIPTION
We want to preserve the type information of the original error, instead of making them all `NSError` type. 

This code change doesn't have any real runtime impact at the moment, because the errors are still converted to `NSError`. But later, I'll create PRs to refactor error handling, and at that point the `alertForError` function will be dealing with concrete error types, like:

```swift
func alertForError(error: Error, ...) {
  if let oauthError = error as? OAuthError {
    // ...
  }

  if let xmlrpcError = error as? XMLRPCError {
    // ...
  }

  // ...
}

```

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
