### PR TITLE
Use latest WordPressKit version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+* Depend on WordPressKit 9.0.0 and make necessary code changes to adopt the new API. [808]
 
 ## 7.3.1
 

--- a/Podfile
+++ b/Podfile
@@ -28,7 +28,7 @@ def wordpress_authenticator_pods
   ## These should match the version requirement from the podspec.
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7-beta'
-  pod 'WordPressKit', '~> 8.7-beta'
+  pod 'WordPressKit', '~> 9.0.0'
   pod 'WordPressShared', '~> 2.1-beta'
 
   third_party_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,10 +13,10 @@ PODS:
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 8.7-beta)
+    - WordPressKit (~> 9.0.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.11.0):
+  - WordPressKit (9.0.0):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -35,7 +35,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.49)
   - WordPressAuthenticator (from `.`)
-  - WordPressKit (~> 8.7-beta)
+  - WordPressKit (~> 9.0.0)
   - WordPressShared (~> 2.1-beta)
   - WordPressUI (~> 1.7-beta)
 
@@ -71,12 +71,12 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: 503a174d8ccc0781a0f5769e5e284e07cb294dc0
-  WordPressKit: 13e01ed70f6ab2397c228959bc47cb2073521f63
+  WordPressAuthenticator: 5e7eadec3fecf2e1382a5ae8a810149413de962e
+  WordPressKit: 3f599b50b996e4352efa5594e6de95e53315da12
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: 537f0cb26852aae6d94a89c678a95bc8bd640a01
+PODFILE CHECKSUM: 53b90d4674a5a238bb3fca5e6e500c0a2d220ca6
 
 COCOAPODS: 1.11.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressUI', '~> 1.7-beta'
+  # TODO: Update to latest version after the PR below is merged and released
+  # https://github.com/wordpress-mobile/WordPressKit-iOS/pull/650
   s.dependency 'WordPressKit', '~> 8.7-beta'
   s.dependency 'WordPressShared', '~> 2.1-beta'
 end

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,8 +40,6 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressUI', '~> 1.7-beta'
-  # TODO: Update to latest version after the PR below is merged and released
-  # https://github.com/wordpress-mobile/WordPressKit-iOS/pull/650
-  s.dependency 'WordPressKit', '~> 8.7-beta'
+  s.dependency 'WordPressKit', '~> 9.0.0'
   s.dependency 'WordPressShared', '~> 2.1-beta'
 end

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.swift
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacade.swift
@@ -17,12 +17,12 @@ import WordPressKit
         password: String,
         multifactorCode: String?,
         success: @escaping (_ authToken: String?) -> Void,
-        needsMultifactor: ((_ userID: Int, _ nonceInfo: SocialLogin2FANonceInfo?) -> Void)?,
+        needsMultifactor: @escaping ((_ userID: Int, _ nonceInfo: SocialLogin2FANonceInfo?) -> Void),
         failure: ((_ error: Error) -> Void)?
     ) {
-        self.client.authenticateWithUsername(username, password: password, multifactorCode: multifactorCode, needsMultifactor: needsMultifactor, success: success, failure: { error in
-            if error.code == WordPressComOAuthError.needsMultifactorCode.rawValue {
-                needsMultifactor?(0, nil)
+        self.client.authenticate(username: username, password: password, multifactorCode: multifactorCode, needsMultifactor: needsMultifactor, success: success, failure: { error in
+            if case let .endpointError(authenticationFailure) = error, authenticationFailure.kind == .needsMultifactorCode {
+                needsMultifactor(0, nil)
             } else {
                 failure?(error)
             }
@@ -35,7 +35,7 @@ import WordPressKit
         success: @escaping () -> Void,
         failure: @escaping (_ error: Error) -> Void
     ) {
-        self.client.requestOneTimeCodeWithUsername(username, password: password, success: success, failure: failure)
+        self.client.requestOneTimeCode(username: username, password: password, success: success, failure: failure)
     }
 
     public func requestSocial2FACode(
@@ -44,7 +44,7 @@ import WordPressKit
         success: @escaping (_ newNonce: String) -> Void,
         failure: @escaping (_ error: Error, _ newNonce: String?) -> Void
     ) {
-        self.client.requestSocial2FACodeWithUserID(userID, nonce: nonce, success: success, failure: failure)
+        self.client.requestSocial2FACode(userID: userID, nonce: nonce, success: success, failure: failure)
     }
 
     public func authenticate(
@@ -55,8 +55,8 @@ import WordPressKit
         existingUserNeedsConnection: @escaping (_ email: String) -> Void,
         failure: @escaping (_ error: Error) -> Void
     ) {
-        self.client.authenticateWithIDToken(
-            socialIDToken,
+        self.client.authenticate(
+            socialIDToken: socialIDToken,
             service: service,
             success: success,
             needsMultifactor: needsMultifactor,
@@ -73,8 +73,8 @@ import WordPressKit
         success: @escaping (_ authToken: String?) -> Void,
         failure: @escaping (_ error: Error) -> Void
     ) {
-        self.client.authenticateSocialLoginUser(
-            userID,
+        self.client.authenticate(
+            socialLoginUserID: userID,
             authType: authType,
             twoStepCode: twoStepCode,
             twoStepNonce: twoStepNonce,

--- a/WordPressAuthenticator/Services/WordPressComOAuthClientFacadeProtocol.swift
+++ b/WordPressAuthenticator/Services/WordPressComOAuthClientFacadeProtocol.swift
@@ -11,7 +11,7 @@ import WordPressKit
         password: String,
         multifactorCode: String?,
         success: @escaping (_ authToken: String?) -> Void,
-        needsMultifactor: ((_ userID: Int, _ nonceInfo: SocialLogin2FANonceInfo?) -> Void)?,
+        needsMultifactor: @escaping ((_ userID: Int, _ nonceInfo: SocialLogin2FANonceInfo?) -> Void),
         failure: ((_ error: Error) -> Void)?
     )
 

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -318,12 +318,12 @@ extension Login2FAViewController {
         configureViewLoading(false)
         let err = error as NSError
         let bad2FAMessage = NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!", comment: "Error message shown when an incorrect two factor code is provided.")
-        if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue {
+        if (error as? WordPressComOAuthError)?.authenticationFailureKind == .invalidOneTimePassword {
             // Invalid verification code.
             displayError(message: bad2FAMessage)
-        } else if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidTwoStepCode.rawValue {
+        } else if case let .endpointError(authenticationFailure) = (error as? WordPressComOAuthError), authenticationFailure.kind == .invalidTwoStepCode {
             // Invalid 2FA during social login
-            if let newNonce = (error as NSError).userInfo[WordPressComOAuthClient.WordPressComOAuthErrorNewNonceKey] as? String {
+            if let newNonce = authenticationFailure.newNonce {
                 loginFields.nonceInfo?.updateNonce(with: newNonce)
             }
             displayError(message: bad2FAMessage)

--- a/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -316,7 +316,6 @@ extension Login2FAViewController {
         displayError(message: "")
 
         configureViewLoading(false)
-        let err = error as NSError
         let bad2FAMessage = NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!", comment: "Error message shown when an incorrect two factor code is provided.")
         if (error as? WordPressComOAuthError)?.authenticationFailureKind == .invalidOneTimePassword {
             // Invalid verification code.

--- a/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -206,9 +206,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     override func displayRemoteError(_ error: Error) {
         configureViewLoading(false)
 
-        let errorCode = (error as NSError).code
-        let errorDomain = (error as NSError).domain
-        if errorDomain == WordPressComOAuthClient.WordPressComOAuthErrorDomain, errorCode == WordPressComOAuthError.invalidRequest.rawValue {
+        if (error as? WordPressComOAuthError)?.authenticationFailureKind == .invalidRequest {
             let message = NSLocalizedString("It seems like you've entered an incorrect password. Want to give it another try?", comment: "An error message shown when a wpcom user provides the wrong password.")
             displayError(message: message)
         } else {

--- a/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -340,7 +340,7 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
 
         var errorTitle = LocalizedText.googleUnableToConnect
         var errorDescription = error.localizedDescription
-        let unknownUser = (error as NSError).code == WordPressComOAuthError.unknownUser.rawValue
+        let unknownUser = (error as? WordPressComOAuthError)?.authenticationFailureKind == .unknownUser
 
         if unknownUser {
             errorTitle = LocalizedText.googleConnected

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -129,12 +129,12 @@ final class TwoFAViewController: LoginViewController {
         }
 
         configureViewLoading(false)
-        if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue {
+        if (error as? WordPressComOAuthError)?.authenticationFailureKind == .invalidOneTimePassword {
             // Invalid verification code.
             displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)
-        } else if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidTwoStepCode.rawValue {
+        } else if case let .endpointError(authenticationFailure) = (error as? WordPressComOAuthError), authenticationFailure.kind == .invalidTwoStepCode {
             // Invalid 2FA during social login
-            if let newNonce = (error as NSError).userInfo[WordPressComOAuthClient.WordPressComOAuthErrorNewNonceKey] as? String {
+            if let newNonce = authenticationFailure.newNonce {
                 loginFields.nonceInfo?.updateNonce(with: newNonce)
             }
             displayError(message: LocalizedText.bad2FAMessage, moveVoiceOverFocus: true)


### PR DESCRIPTION
This PR adopts the `WordPressComOAuthClient` API changes in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/650

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
