### PR TITLE
Add unit tests for how the rows in the TwoFAVC are computed

### DIFF
--- a/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		3F881660298150FB00AEC4C0 /* URLSesison+DataGetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F88165F298150FB00AEC4C0 /* URLSesison+DataGetting.swift */; };
 		3F8816702983EB4A00AEC4C0 /* IDToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F88166F2983EB4A00AEC4C0 /* IDToken.swift */; };
 		3F9439BE27D6F9B60067183A /* LoginPrologueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */; };
+		3FD6950F2B16C0D7005397E3 /* TwoFAViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD6950E2B16C0D7005397E3 /* TwoFAViewControllerTests.swift */; };
 		3FE8071529364C410088420C /* Result+ConvenienceInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */; };
 		3FE80717293650190088420C /* Result+ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE80716293650190088420C /* Result+ConvenienceInit.swift */; };
 		3FE8071B2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE8071A2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift */; };
@@ -323,6 +324,7 @@
 		3F88165F298150FB00AEC4C0 /* URLSesison+DataGetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSesison+DataGetting.swift"; sourceTree = "<group>"; };
 		3F88166F2983EB4A00AEC4C0 /* IDToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDToken.swift; sourceTree = "<group>"; };
 		3F9439BD27D6F9B60067183A /* LoginPrologueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPrologueViewController.swift; sourceTree = "<group>"; };
+		3FD6950E2B16C0D7005397E3 /* TwoFAViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoFAViewControllerTests.swift; sourceTree = "<group>"; };
 		3FE8071429364C410088420C /* Result+ConvenienceInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInitTests.swift"; sourceTree = "<group>"; };
 		3FE80716293650190088420C /* Result+ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+ConvenienceInit.swift"; sourceTree = "<group>"; };
 		3FE8071A2936515F0088420C /* ASWebAuthenticationSession+Utils.swift .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASWebAuthenticationSession+Utils.swift .swift"; sourceTree = "<group>"; };
@@ -965,6 +967,7 @@
 				F18DF0E32525009200D83AFE /* SupportingFiles */,
 				3F338B6B289B87E60014ADC5 /* UnitTests.xctestplan */,
 				0193F7742A615521004D7C16 /* MemoryManagementTests.swift */,
+				3FD6950E2B16C0D7005397E3 /* TwoFAViewControllerTests.swift */,
 			);
 			path = WordPressAuthenticatorTests;
 			sourceTree = "<group>";
@@ -1583,6 +1586,7 @@
 				3F86A84829D2A42D005D20C0 /* WordPressAuthenticator+TestsUtils.swift in Sources */,
 				3F879FF4293A7F46005C2B48 /* GoogleOAuthTokenGetterTests.swift in Sources */,
 				B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */,
+				3FD6950F2B16C0D7005397E3 /* TwoFAViewControllerTests.swift in Sources */,
 				3F879FD7293A44F2005C2B48 /* OAuthTokenRequestBodyTests.swift in Sources */,
 				3108613125AFA4830022F75E /* PasteboardTests.swift in Sources */,
 				3FE8071F2936558F0088420C /* URL+GoogleSignInTests.swift in Sources */,

--- a/WordPressAuthenticatorTests/TwoFAViewControllerTests.swift
+++ b/WordPressAuthenticatorTests/TwoFAViewControllerTests.swift
@@ -7,19 +7,19 @@ import XCTest
 class TwoFAViewControllerTests: XCTestCase {
 
     func testLoadRowsWithNoErrorAndNoPasskeys() {
-        let defualtRows: [TwoFAViewController.Row] = [.instructions, .code, .alternateInstructions, .sendCode]
+        let defaultRows: [TwoFAViewController.Row] = [.instructions, .code, .alternateInstructions, .sendCode]
 
         XCTAssertEqual(
             TwoFAViewController.computeRows(errorMessage: nil, nonceWebauthn: nil, passkeysEnabled: false),
-            defualtRows
+            defaultRows
         )
         XCTAssertEqual(
             TwoFAViewController.computeRows(errorMessage: nil, nonceWebauthn: nil, passkeysEnabled: true),
-            defualtRows
+            defaultRows
         )
         XCTAssertEqual(
             TwoFAViewController.computeRows(errorMessage: nil, nonceWebauthn: "some error", passkeysEnabled: false),
-            defualtRows
+            defaultRows
         )
     }
 

--- a/WordPressAuthenticatorTests/TwoFAViewControllerTests.swift
+++ b/WordPressAuthenticatorTests/TwoFAViewControllerTests.swift
@@ -1,0 +1,56 @@
+@testable import WordPressAuthenticator
+import XCTest
+
+// The logic depends, in part, on iOS 16 features.
+// We could test for the earlier versions but that would optimizing for a small minority and not worth at this point in time.
+@available(iOS 16, *)
+class TwoFAViewControllerTests: XCTestCase {
+
+    func testLoadRowsWithNoErrorAndNoPasskeys() {
+        let defualtRows: [TwoFAViewController.Row] = [.instructions, .code, .alternateInstructions, .sendCode]
+
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: nil, nonceWebauthn: nil, passkeysEnabled: false),
+            defualtRows
+        )
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: nil, nonceWebauthn: nil, passkeysEnabled: true),
+            defualtRows
+        )
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: nil, nonceWebauthn: "some error", passkeysEnabled: false),
+            defualtRows
+        )
+    }
+
+    func testLoadRowsWithErrorAndNoPasskeys() {
+        let expectedRows: [TwoFAViewController.Row] = [.instructions, .code, .errorMessage, .alternateInstructions, .sendCode]
+
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: "some error", nonceWebauthn: nil, passkeysEnabled: false),
+            expectedRows
+        )
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: "some error", nonceWebauthn: nil, passkeysEnabled: true),
+            expectedRows
+        )
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: "some error", nonceWebauthn: "some nonce", passkeysEnabled: false),
+            expectedRows
+        )
+    }
+
+    func testLoadRowsWithNoErrorButPasskeys() {
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: "some error", nonceWebauthn: "some nonce", passkeysEnabled: true),
+            [.instructions, .code, .errorMessage, .alternateInstructions, .sendCode, .enterSecurityKey]
+        )
+    }
+
+    func testLoadRowsWithErrorAndPasskeys() {
+        XCTAssertEqual(
+            TwoFAViewController.computeRows(errorMessage: "some error", nonceWebauthn: "some nonce", passkeysEnabled: true),
+            [.instructions, .code, .errorMessage, .alternateInstructions, .sendCode, .enterSecurityKey]
+        )
+    }
+}


### PR DESCRIPTION
Builds on top #809 . While looking at that PR, I noticed that there are three essentially boolean parameters that drive the rows behavior (either actual `Bool` or `Optional` `.some` vs `.none`). That results into eight _possible_ runtime input configurations. Too many to test manually, but easily testable via unit tests.

In truth, there's an additional boolean parameter, `#available(iOS 16)` but I decided to ignore that under the assumption that it's most of the user base.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.
