### PR TITLE
Cherry pick changes from #809 into `release/7.3.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ _None._
 
 _None._
 
+## 7.3.1
+
+_Shipped as a patch even though it contains only a new feature to prioritize releasing the change fast._
+_See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/809#issuecomment-1832211708._
+
+### New Features
+
+- Add an `enablePasskeys` option to `WordPressAuthenticatorConfiguration` to allow disabling the Passkeys support. For backward compatibility, the default value is set to `true` (enabled) [#809]
+
 ## 7.3.0
 
 ### New Features

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -96,6 +96,9 @@ public struct WordPressAuthenticatorConfiguration {
     /// If enabled, displays the new carousel.
     let enableUnifiedCarousel: Bool
 
+    /// Flag for the Passkeys, or WebAuthn, login.
+    let enablePasskeys: Bool
+
     /// Flag for the unified login/signup flows.
     /// If disabled, the "Continue With WordPress" button in the login prologue is shown first.
     /// If enabled, the "Enter your existing site address" button in the login prologue is shown first.
@@ -190,6 +193,7 @@ public struct WordPressAuthenticatorConfiguration {
                  enableSignupWithGoogle: Bool = false,
                  enableUnifiedAuth: Bool = false,
                  enableUnifiedCarousel: Bool = false,
+                 enablePasskeys: Bool = true,
                  displayHintButtons: Bool = true,
                  continueWithSiteAddressFirst: Bool = false,
                  enableSiteCredentialsLoginForSelfHostedSites: Bool = false,
@@ -225,6 +229,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableSignInWithApple = enableSignInWithApple
         self.enableUnifiedAuth = enableUnifiedAuth
         self.enableUnifiedCarousel = enableUnifiedCarousel
+        self.enablePasskeys = enablePasskeys
         self.displayHintButtons = displayHintButtons
         self.enableSignupWithGoogle = enableSignupWithGoogle
         self.continueWithSiteAddressFirst = continueWithSiteAddressFirst

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -485,8 +485,7 @@ private extension TwoFAViewController {
 
         rows.append(.alternateInstructions)
         rows.append(.sendCode)
-
-        if #available(iOS 16, *), loginFields.nonceInfo?.nonceWebauthn != nil {
+        if #available(iOS 16, *), WordPressAuthenticator.shared.configuration.enablePasskeys, loginFields.nonceInfo?.nonceWebauthn != nil {
             rows.append(.enterSecurityKey)
         }
     }


### PR DESCRIPTION
Cherry pick changes from #809 into `release/7.3.1`

I will admin-merge this PR on the basis that #809 has already been reviewed and approved. Also see #810 which adds unit tests to further validate the changes.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
