### PR TITLE
Add Accessbility identifier to passkeys button

### DIFF
--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -556,7 +556,9 @@ private extension TwoFAViewController {
     /// Configure the security key link cell.
     ///
     func configureEnterSecurityKeyLinkButton(_ cell: TextLinkButtonTableViewCell) {
-        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.securityKeyButtonTitle, icon: .keyIcon)
+        cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.securityKeyButtonTitle,
+                             icon: .keyIcon,
+                             accessibilityIdentifier: TextLinkButtonTableViewCell.Constants.passkeysID)
 
         cell.actionHandler = { [weak self] in
             guard let self = self else { return }

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -29,7 +29,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
 
     public func configureButton(text: String?,
                                 icon: UIImage? = nil,
-                                accessibilityTrait: UIAccessibilityTraits = .button, 
+                                accessibilityTrait: UIAccessibilityTraits = .button,
                                 showBorder: Bool = false,
                                 accessibilityIdentifier: String? = nil) {
         button.setTitle(text, for: .normal)

--- a/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextLinkButtonTableViewCell.swift
@@ -27,7 +27,11 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         styleBorder()
     }
 
-    public func configureButton(text: String?, icon: UIImage? = nil, accessibilityTrait: UIAccessibilityTraits = .button, showBorder: Bool = false) {
+    public func configureButton(text: String?,
+                                icon: UIImage? = nil,
+                                accessibilityTrait: UIAccessibilityTraits = .button, 
+                                showBorder: Bool = false,
+                                accessibilityIdentifier: String? = nil) {
         button.setTitle(text, for: .normal)
 
         let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
@@ -35,6 +39,7 @@ class TextLinkButtonTableViewCell: UITableViewCell {
         button.setTitleColor(buttonTitleColor, for: .normal)
         button.setTitleColor(buttonHighlightColor, for: .highlighted)
         button.accessibilityTraits = accessibilityTrait
+        button.accessibilityIdentifier = accessibilityIdentifier
 
         borderView.isHidden = !showBorder
 
@@ -60,5 +65,12 @@ private extension TextLinkButtonTableViewCell {
         let borderColor = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         borderView.backgroundColor = borderColor
         borderWidth.constant = WPStyleGuide.hairlineBorderWidth
+    }
+}
+
+// MARK: - Constants
+extension TextLinkButtonTableViewCell {
+    struct Constants {
+        static let passkeysID = "Passkeys"
     }
 }


### PR DESCRIPTION
As the title says, this PR adds an accessibility identifier to the "Use security key button". This is needed to enhance the WooCommerce iOS App UI Tests. 

This changed is used here: 
- https://github.com/woocommerce/woocommerce-ios/pull/11538

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
