### PR TITLE
Add custom spacing to the TwoFAViewController

### DIFF
--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -711,4 +711,3 @@ private extension TwoFAViewController {
         }
     }
 }
-

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -472,6 +472,8 @@ private extension TwoFAViewController {
         for (reuseIdentifier, nib) in cells {
             tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
         }
+
+        tableView.register(SpacerTableViewCell.self, forCellReuseIdentifier: SpacerTableViewCell.reuseIdentifier)
     }
 
     /// Describes how the tableView rows should be rendered.
@@ -483,9 +485,14 @@ private extension TwoFAViewController {
             rows.append(.errorMessage)
         }
 
+        rows.append(.spacer(20))
         rows.append(.alternateInstructions)
+
+        rows.append(.spacer(4))
         rows.append(.sendCode)
+
         if #available(iOS 16, *), WordPressAuthenticator.shared.configuration.enablePasskeys, loginFields.nonceInfo?.nonceWebauthn != nil {
+            rows.append(.spacer(4))
             rows.append(.enterSecurityKey)
         }
     }
@@ -506,6 +513,10 @@ private extension TwoFAViewController {
             configureEnterSecurityKeyLinkButton(cell)
         case let cell as TextLabelTableViewCell where row == .errorMessage:
             configureErrorLabel(cell)
+        case let cell as SpacerTableViewCell:
+            if case let .spacer(spacing) = row {
+                configureSpacerCell(cell, spacing: spacing)
+            }
         default:
             WPAuthenticatorLogError("Error: Unidentified tableViewCell type found.")
         }
@@ -579,6 +590,12 @@ private extension TwoFAViewController {
         }
     }
 
+    /// Configure the spacer cell.
+    ///
+    func configureSpacerCell(_ cell: SpacerTableViewCell, spacing: CGFloat) {
+        cell.spacing = spacing
+    }
+
     /// Configure the view for an editing state.
     ///
     func configureViewForEditingIfNeeded() {
@@ -604,13 +621,14 @@ private extension TwoFAViewController {
 
     /// Rows listed in the order they were created.
     ///
-    enum Row {
+    enum Row: Equatable {
         case instructions
         case code
         case alternateInstructions
         case sendCode
         case enterSecurityKey
         case errorMessage
+        case spacer(CGFloat)
 
         var reuseIdentifier: String {
             switch self {
@@ -626,6 +644,8 @@ private extension TwoFAViewController {
                 return TextLinkButtonTableViewCell.reuseIdentifier
             case .errorMessage:
                 return TextLabelTableViewCell.reuseIdentifier
+            case .spacer:
+                return SpacerTableViewCell.reuseIdentifier
             }
         }
     }
@@ -641,5 +661,54 @@ private extension TwoFAViewController {
                                                     comment: "Error when the uses takes more than 1 minute to submit a security key.")
         static let unknownError = NSLocalizedString("Whoops, something went wrong. Please try again!", comment: "Generic error on the 2FA screen")
     }
-
 }
+
+private extension TwoFAViewController {
+    /// Simple spacer cell for a table view.
+    ///
+    final class SpacerTableViewCell: UITableViewCell {
+
+        /// Static identifier
+        ///
+        static let reuseIdentifier = "SpacerTableViewCell"
+
+        /// Gets or sets the desired vertical spacing.
+        ///
+        var spacing: CGFloat {
+            get {
+                heightConstraint.constant
+            }
+            set {
+                heightConstraint.constant = newValue
+            }
+        }
+
+        /// Determines the view height internally
+        ///
+        private let heightConstraint: NSLayoutConstraint
+
+
+        override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+
+            let spacerView = UIView()
+            spacerView.translatesAutoresizingMaskIntoConstraints = false
+            heightConstraint = spacerView.heightAnchor.constraint(equalToConstant: 0)
+
+            super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+            addSubview(spacerView)
+            NSLayoutConstraint.activate([
+                spacerView.topAnchor.constraint(equalTo: topAnchor),
+                spacerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                spacerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                spacerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                heightConstraint
+            ])
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("Not implemented")
+        }
+    }
+}
+


### PR DESCRIPTION
closes #804 

# Why

This PR adds some specific spacings requested by the design team to the 2FA screen.

# How

Adds a new(private) spacer cell that allows us to add some custom spacings. I opted to not modify the spacings on the current cells (instructions, security key, etc) to avoid misalignments in other screens as those types are reused in other places of the lib.

# Screenshots

| Before | After |
|--------|--------|
![old](https://github.com/woocommerce/woocommerce-ios/assets/562080/75867e18-f12b-4b2e-b06a-66e7743126e6) | ![new](https://github.com/woocommerce/woocommerce-ios/assets/562080/f3faec51-5aab-4e85-9882-b144a36aa62c)

# Testing

You can test these changes on the following Woo integration PR.

- https://github.com/woocommerce/woocommerce-ios/pull/11568