### PR TITLE
Fixes issue where "Use Security Key" option should not be present

### DIFF
--- a/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -216,6 +216,10 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
             return
         }
 
+        // Make sure we don't provide any old nonce information when we are required to present only the multi-factor code option.
+        loginFields.nonceInfo = nil
+        loginFields.nonceUserID = 0
+
         presentUnified2FA()
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -491,7 +491,7 @@ private extension TwoFAViewController {
         rows.append(.spacer(4))
         rows.append(.sendCode)
 
-        if #available(iOS 16, *), WordPressAuthenticator.shared.configuration.enablePasskeys, loginFields.nonceInfo?.nonceWebauthn != nil {
+        if #available(iOS 16, *), WordPressAuthenticator.shared.configuration.enablePasskeys, loginFields.nonceInfo?.nonceWebauthn.isEmpty == false {
             rows.append(.spacer(4))
             rows.append(.enterSecurityKey)
         }


### PR DESCRIPTION
closes #817 

# Why

This PR fixes an issue where the Security Key option is displayed for an account that does not have a Security Key setup.

This happened because there were some nonce state that weren't being cleared properly when logging in with a new account.

# How

- Clean the nonce state when the 2Factor code screen is presented.
- For extra safety, improve the check before rendering the security key option.

# Demo

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/562080/69de42dd-437f-4149-949d-2e8668f81151

# Testing Steps

You can follow the steps on this PR 

- https://github.com/woocommerce/woocommerce-ios/pull/11579