### PR TITLE
Relax WordPressKit dependency from `~> 9.0.0` to `~> 9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Relax WordPressKit dependency to `~> 9.0` [#824]
 
 ## 8.0.1
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 9.0.0)
+    - WordPressKit (~> 9.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
   - WordPressKit (9.0.0):
@@ -71,7 +71,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: b4b6bfdac703bf3c25312995dec6bfd302d61801
+  WordPressAuthenticator: f351f1efbf0cc4970c3c9c9e983cf7780b967442
   WordPressKit: 3f599b50b996e4352efa5594e6de95e53315da12
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressUI', '~> 1.7-beta'
-  s.dependency 'WordPressKit', '~> 9.0.0'
+  s.dependency 'WordPressKit', '~> 9.0'
   s.dependency 'WordPressShared', '~> 2.1-beta'
 end


### PR DESCRIPTION
A dependency on `~> 9.0.0` results in only versions `9.0.x` being compatible. Under the assumption WordPressKit always respects semantic versioning, that approach limits the versions WordPressAuthenticator can be compatible with. In particular, prevents seamlessly using something like WordPressKit 9.1.0 in a client of both WordPressAuthenticator and WordPressKit.

Case in point, I just created WordPressKit 9.0.3,
https://github.com/wordpress-mobile/WordPressKit-iOS/pull/677, in place of 9.1.0 in order to avoid having to ship a new WordPressAuthenticator version in the middle of a release cycle.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
