### PR TITLE
Implement needsMultifactorCode with userId and nonceinfo delegate in StoredCredentialsAuthenticator

### DIFF
--- a/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -155,6 +155,13 @@ extension StoredCredentialsAuthenticator: LoginFacadeDelegate {
         presentTwoFactorAuthenticationView()
     }
 
+    func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo) {
+        loginFields?.nonceInfo = nonceInfo
+        loginFields?.nonceUserID = userID
+
+        needsMultifactorCode()
+    }
+
     func finishedLogin(withAuthToken authToken: String, requiredMultifactorCode: Bool) {
         let wpcom = WordPressComCredentials(
             authToken: authToken,


### PR DESCRIPTION
Fix login being stuck in a loading state when the account has 2FA with passkeys enabled.

Fix implements `needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo)` delegate which is called when `nonceInfo != nil` which presents 2FA login.

Context: p1706533264603049-slack-C012H19SZQ8

---

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/4062343/9874afb2-188d-424d-b656-da03b9f6b9d2

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.