### PR TITLE
Display error message from URLError when the site's SSL is invalid

### DIFF
--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -483,7 +483,7 @@ private extension SiteAddressViewController {
 
                     var message: String?
 
-                    // Use `URLError`'s error message (which usually contains more accuruate description), if the
+                    // Use `URLError`'s error message (which usually contains more accurate description), if the
                     // error is SSL error.
                     if let urlError = error as? URLError, urlError.failureURLPeerTrust != nil {
                         message = urlError.localizedDescription

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -481,7 +481,15 @@ private extension SiteAddressViewController {
                         return
                     }
 
-                    return self.displayError(message: Localization.nonExistentSiteError, moveVoiceOverFocus: true)
+                    var message: String?
+
+                    // Use `URLError`'s error message (which usually contains more accuruate description), if the
+                    // error is SSL error.
+                    if let urlError = error as? URLError, urlError.failureURLPeerTrust != nil {
+                        message = urlError.localizedDescription
+                    }
+
+                    return self.displayError(message: message ?? Localization.nonExistentSiteError, moveVoiceOverFocus: true)
                 }
 
                 onCompletion()


### PR DESCRIPTION
## Description

When connecting to a site which has invalid SSL certs, the error message is not super clear. This PR uses the error message came with URLError, which has more accurate information about the connection failure, for SSL handshake related errors.

Here is a comparison:

| Before  | After |
| ------- | ----- |
| <img width="559" alt="Screenshot 2024-02-05 at 9 43 45 AM" src="https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/1101828/affa4c76-d7af-4be9-ab4a-21a6341c9528">  | <img width="559" alt="Screenshot 2024-02-05 at 9 52 35 AM" src="https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/1101828/615699bb-ad01-41b8-b1c7-d5465e674055">  |

## Test Instructions

[This docker project](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/files/14158542/local-site.zip) can be use to set up a test site locally, which has invalid SSL certificate.
1. Download and unzip the file.
2. Go to the unzipped directory and execute `make run`. Requirements:
  - You'll need to have Docker Desktop or equivalent running.
  - The 80 port on your Mac needs to be available for the docker container.
4. Open Safari from a device (which needs to be in the same network as your Mac), or an iOS simulator.
5. Enter `https://<your-mac-hostname>.local` to test the site is accessible and it has an invalid SSL certificate (Safari should warn you about it).
6. Open Jetpack/WordPress iOS app from the same deivce or simulator.
7. Use "Enter your existing site address" option and enter the same https address as above.
8. Checkout the error message.


- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
