### PR TITLE
Add `useURLSession` configuration to pass to WordPressKit

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,10 +13,10 @@ PODS:
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 13.0)
+    - WordPressKit (~> 13.1)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (13.0.0):
+  - WordPressKit (13.1.0):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -40,8 +40,6 @@ DEPENDENCIES:
   - WordPressUI (~> 1.7-beta)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressKit
   trunk:
     - Alamofire
     - Expecta
@@ -53,6 +51,7 @@ SPEC REPOS:
     - SVProgressHUD
     - SwiftLint
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
@@ -72,8 +71,8 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: ba69878bfa1368636e92d29fcfb5bd1e0a11a3ef
-  WordPressKit: 5eb7d27d27f84e875266a72281d0a4b80c825b74
+  WordPressAuthenticator: 415b7a0957826ebde01f944f540fd502913b8a35
+  WordPressKit: c1ba7b4f531693a0914f676423808fdffd820d81
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressUI', '~> 1.7-beta'
-  s.dependency 'WordPressKit', '~> 13.0'
+  s.dependency 'WordPressKit', '~> 13.1'
   s.dependency 'WordPressShared', '~> 2.1-beta'
 end

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -77,6 +77,9 @@ import WordPressKit
         self.unifiedStyle = unifiedStyle
         self.displayImages = displayImages
         self.displayStrings = displayStrings
+
+        WordPressOrgXMLRPCApi.useURLSession = configuration.useURLSession
+        WordPressComRestApi.useURLSession = configuration.useURLSession
     }
 
     /// Initializes the WordPressAuthenticator with the specified Configuration.

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -174,6 +174,11 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSiteAddressLoginOnlyInPrologue: Bool
 
+    /// Whether to use `URLSession` or Alamofire for certain requests.
+    ///
+    /// Defaults to `false` but will soon become `true` as we are actively working to remove Alamofire.
+    let useURLSession: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -210,7 +215,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableManualSiteCredentialLogin: Bool = false,
                  enableManualErrorHandlingForSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
-                 enableSiteAddressLoginOnlyInPrologue: Bool = false
+                 enableSiteAddressLoginOnlyInPrologue: Bool = false,
+                 useURLSession: Bool = false
     ) {
 
         self.wpcomClientId = wpcomClientId
@@ -248,5 +254,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableManualErrorHandlingForSiteCredentialLogin = enableManualErrorHandlingForSiteCredentialLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
+        self.useURLSession = useURLSession
     }
 }


### PR DESCRIPTION
This will allow clients that do no need access to WordPressKit (i.e. WooCommerce) to explicitly depend only on WordPressAuthenticator and still configure whether to use `URLSession`.

See it in use in https://github.com/woocommerce/woocommerce-ios/pull/12063

For context: I discovered this possibility while looking around the apps and the libraries searching for ways to redistribute concerns. I wanted to know how many of the WordPressKit APIs Woo used, go I grepped `import WordPressKit`. I found a single usage, which this PR plus https://github.com/woocommerce/woocommerce-ios/pull/12063 remove.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
