### PR TITLE
Remove an usage of Alamofire API

### DIFF
--- a/WordPressAuthenticator/GoogleSignIn/URLRequest+GoogleSignIn.swift
+++ b/WordPressAuthenticator/GoogleSignIn/URLRequest+GoogleSignIn.swift
@@ -3,7 +3,8 @@ extension URLRequest {
     static func googleSignInTokenRequest(
         body: OAuthTokenRequestBody
     ) throws -> URLRequest {
-        var request = try URLRequest(url: URL.googleSignInOAuthTokenURL, method: .post)
+        var request = URLRequest(url: URL.googleSignInOAuthTokenURL)
+        request.httpMethod = "POST"
 
         request.setValue(
             "application/x-www-form-urlencoded; charset=UTF-8",


### PR DESCRIPTION
Do not use [`URLRequest(url:method:)` from Alamofire](https://github.com/Alamofire/Alamofire/blob/4.8.2/Source/Alamofire.swift#L99).

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
