### PR TITLE
Tooling: Define SwiftLint version and run on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.0.1
+    - automattic/a8c-ci-toolkit#3.1.0
   env: &common_env
     IMAGE_ID: xcode-15.0.1
 
@@ -35,6 +35,15 @@ steps:
   #################
   # Lint
   #################
+  - label: ":swift: SwiftLint"
+    command: run_swiftlint --strict
+    plugins: *common_plugins
+    notify:
+      - github_commit_status:
+          context: "SwiftLint"
+    agents:
+      queue: "default"
+
   - label: "🧹 Lint"
     key: "lint"
     command: |

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,4 @@
+swiftlint_version: 0.54.0
+
 parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/0f8ab6388bd8d15a04391825ab125f80cfb90704/.swiftlint.yml
 remote_timeout: 10.0

--- a/Podfile
+++ b/Podfile
@@ -63,9 +63,17 @@ target 'AuthenticatorDemo' do
   pod 'WordPressAuthenticator', path: '.'
 end
 
-# Used to donwload CLI tools.
+## Tools
+## ==========
+##
+def swiftlint_version
+  require 'yaml'
+
+  YAML.load_file('.swiftlint.yml')['swiftlint_version']
+end
+
 abstract_target 'Tools' do
-  pod 'SwiftLint', '~> 0.49'
+  pod 'SwiftLint', swiftlint_version
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ DEPENDENCIES:
   - OCMock (~> 3.4)
   - Specta (= 1.0.7)
   - SVProgressHUD (= 2.2.5)
-  - SwiftLint (~> 0.49)
+  - SwiftLint (= 0.54.0)
   - WordPressAuthenticator (from `.`)
   - WordPressKit (~> 13.0)
   - WordPressShared (~> 2.1-beta)
@@ -78,6 +78,6 @@ SPEC CHECKSUMS:
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: 403e1fb88c6b793469ae1895887ac6fdca395e9f
+PODFILE CHECKSUM: 7a63d2e16ee1b72e07e52ac84a3695578b714447
 
 COCOAPODS: 1.14.3


### PR DESCRIPTION
### Description

This PR uses the `run-swiftlint` command added to https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin.

The main changes:
- Setting the SwiftLint version in the `.swiftlint.yml` file.
- Usage of the `run_swiftlint` command from `a8c-ci-toolkit-buildkite-plugin` in a Buildkite step to run SwiftLint on CI.
- Uses the`swiftlint_version` field from `.swiftlint.yml` to use the right SwiftLint version in the `Podfile`.


### Testing Details

Make sure CI is 🟢

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
