### PR TITLE
Detect invalid WP site and return error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Detect invalid WordPress site address. [#841]
 
 ### Internal Changes
 

--- a/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -42,6 +42,10 @@ class WordPressComBlogService {
             }
 
             let site = WordPressComSiteInfo(remote: response)
+            guard site.url != Constants.wordPressBlogURL else {
+                failure(WordPressOrgXMLRPCValidatorError.invalid)
+                return
+            }
             success(site)
         }, failure: { error in
             let result = error ?? ServiceError.unknown
@@ -53,6 +57,9 @@ class WordPressComBlogService {
 // MARK: - Nested Types
 //
 extension WordPressComBlogService {
+    enum Constants {
+        static let wordPressBlogURL = "https://wordpress.com/blog"
+    }
 
     enum ServiceError: Error {
         case unknown

--- a/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -43,7 +43,7 @@ class WordPressComBlogService {
 
             let site = WordPressComSiteInfo(remote: response)
             guard site.url != Constants.wordPressBlogURL else {
-                failure(WordPressOrgXMLRPCValidatorError.invalid)
+                failure(ServiceError.invalidWordPressAddress)
                 return
             }
             success(site)
@@ -63,5 +63,6 @@ extension WordPressComBlogService {
 
     enum ServiceError: Error {
         case unknown
+        case invalidWordPressAddress
     }
 }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -541,12 +541,19 @@ private extension SiteAddressViewController {
             self.presentNextControllerIfPossible(siteInfo: siteInfo)
         }
 
-        service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] _ in
+        service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] error in
             self?.configureViewLoading(false)
             guard let self = self else {
                 return
             }
-            self.presentNextControllerIfPossible(siteInfo: nil)
+
+            if self.authenticationDelegate.shouldHandleError(error) {
+                self.authenticationDelegate.handleError(error) { [weak self] customUI in
+                    self?.navigationController?.pushViewController(customUI, animated: true)
+                }
+            } else {
+                self.displayError(error, sourceTag: self.sourceTag)
+            }
         })
     }
 

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -552,7 +552,7 @@ private extension SiteAddressViewController {
                     self?.navigationController?.pushViewController(customUI, animated: true)
                 }
             } else {
-                self.displayError(error, sourceTag: self.sourceTag)
+                self.displayError(message: Localization.invalidURL)
             }
         })
     }


### PR DESCRIPTION
**Description**
Previously, we are ignoring when a user enters an incorrect WP address. The URL after redirect would then be `https://wordpress.com/blog`, and they would be directed to the next screen for WPCom credential input.

This PR fixes this by checking for the redirected URL and returning an error when it's `https://wordpress.com/blog`.

**Testing steps**
- Run the demo app.
- Select Show Login > Enter your existing site address.
- Enter an invalid WP site that ends with "wpcomstaging.com" or "wordpress.com".
- Confirm that an alert is displayed and you cannot reach the WPCom login flow.

**Screencast**

https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/assets/5533851/28e8bea5-33ff-46b6-9887-4d2b90c853bb



---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
