### PR TITLE
Add option to show site creation guide on prologue screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add an option to show site creation guide on the prologue screen [#844]
 
 ### Bug Fixes
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -174,6 +174,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSiteAddressLoginOnlyInPrologue: Bool
 
+    /// If enabled, the prologue screen would display a link for site creation guide.
+    ///
+    let enableSiteCreationGuide: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -210,7 +214,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableManualSiteCredentialLogin: Bool = false,
                  enableManualErrorHandlingForSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
-                 enableSiteAddressLoginOnlyInPrologue: Bool = false
+                 enableSiteAddressLoginOnlyInPrologue: Bool = false,
+                 enableSiteCreationGuide: Bool = false
     ) {
 
         self.wpcomClientId = wpcomClientId
@@ -248,5 +253,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.enableManualErrorHandlingForSiteCredentialLogin = enableManualErrorHandlingForSiteCredentialLogin
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
+        self.enableSiteCreationGuide = enableSiteCreationGuide
     }
 }

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDelegateProtocol.swift
@@ -148,6 +148,14 @@ public protocol WordPressAuthenticatorDelegate: AnyObject {
     ///
     func showSiteCreation(in navigationController: UINavigationController)
 
+    /// Signals to the Host App to navigate to the site creation guide.
+    /// This method triggered only if `enableSiteCreationGuide` config is enabled.
+    ///
+    /// - Parameters:
+    ///     - navigationController: the current navigation stack of the login flow.
+    ///
+    func showSiteCreationGuide(in navigationController: UINavigationController)
+
     /// Signals the Host App that a given Analytics Event has occurred.
     ///
     func track(event: WPAnalyticsStat)
@@ -169,6 +177,10 @@ public extension WordPressAuthenticatorDelegate {
     }
 
     func showSiteCreation(in navigationController: UINavigationController) {
+        // No-op
+    }
+
+    func showSiteCreationGuide(in navigationController: UINavigationController) {
         // No-op
     }
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorDisplayStrings.swift
@@ -54,6 +54,7 @@ public struct WordPressAuthenticatorDisplayStrings {
     public let signupTermsOfService: String
     public let whatIsWPComLinkTitle: String
     public let siteCreationButtonTitle: String
+    public let siteCreationGuideButtonTitle: String
 
 	/// Placeholder text for textfields.
 	///
@@ -109,7 +110,8 @@ public struct WordPressAuthenticatorDisplayStrings {
                 passwordPlaceholder: String = defaultStrings.passwordPlaceholder,
                 siteAddressPlaceholder: String = defaultStrings.siteAddressPlaceholder,
                 twoFactorCodePlaceholder: String = defaultStrings.twoFactorCodePlaceholder,
-                emailAddressPlaceholder: String = defaultStrings.emailAddressPlaceholder) {
+                emailAddressPlaceholder: String = defaultStrings.emailAddressPlaceholder,
+                siteCreationGuideButtonTitle: String = defaultStrings.siteCreationGuideButtonTitle) {
         self.emailLoginInstructions = emailLoginInstructions
         self.getStartedInstructions = getStartedInstructions
         self.jetpackLoginInstructions = jetpackLoginInstructions
@@ -155,6 +157,7 @@ public struct WordPressAuthenticatorDisplayStrings {
         self.siteAddressPlaceholder = siteAddressPlaceholder
         self.twoFactorCodePlaceholder = twoFactorCodePlaceholder
         self.emailAddressPlaceholder = emailAddressPlaceholder
+        self.siteCreationGuideButtonTitle = siteCreationGuideButtonTitle
     }
 }
 
@@ -245,7 +248,12 @@ public extension WordPressAuthenticatorDisplayStrings {
             twoFactorCodePlaceholder: NSLocalizedString("Authentication code",
                                                         comment: "Placeholder for the 2FA code textfield."),
             emailAddressPlaceholder: NSLocalizedString("Email address",
-                                                       comment: "Placeholder for the email address textfield.")
+                                                       comment: "Placeholder for the email address textfield."),
+            siteCreationGuideButtonTitle: NSLocalizedString(
+                "wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle",
+                value: "Starting a new site?",
+                comment: "Title for the link for site creation guide."
+            )
         )
     }
 }

--- a/WordPressAuthenticator/NUX/Button/NUXButton.swift
+++ b/WordPressAuthenticator/NUX/Button/NUXButton.swift
@@ -25,6 +25,25 @@ public struct NUXButtonStyle {
         self.highlighted = highlighted
         self.disabled = disabled
     }
+
+    public static var linkButtonStyle: NUXButtonStyle {
+        let backgroundColor = UIColor.clear
+        let buttonTitleColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonColor ?? WordPressAuthenticator.shared.style.textButtonColor
+        let buttonHighlightColor = WordPressAuthenticator.shared.unifiedStyle?.textButtonHighlightColor ?? WordPressAuthenticator.shared.style.textButtonHighlightColor
+
+        let normalButtonStyle = ButtonStyle(backgroundColor: backgroundColor,
+                                            borderColor: backgroundColor,
+                                            titleColor: buttonTitleColor)
+        let highlightedButtonStyle = ButtonStyle(backgroundColor: backgroundColor,
+                                                 borderColor: backgroundColor,
+                                                 titleColor: buttonHighlightColor)
+        let disabledButtonStyle = ButtonStyle(backgroundColor: backgroundColor,
+                                              borderColor: backgroundColor,
+                                              titleColor: buttonTitleColor.withAlphaComponent(0.5))
+        return NUXButtonStyle(normal: normalButtonStyle,
+                              highlighted: highlightedButtonStyle,
+                              disabled: disabledButtonStyle)
+    }
 }
 /// A stylized button used by Login controllers. It also can display a `UIActivityIndicatorView`.
 @objc open class NUXButton: UIButton {

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -45,7 +45,7 @@ class LoginPrologueViewController: LoginViewController {
     /// Return`true` to use new `NUXStackedButtonsViewController` instead of `NUXButtonViewController` to create buttons
     ///
     private var useStackedButtonsViewController: Bool {
-        configuration.enableWPComLoginOnlyInPrologue || 
+        configuration.enableWPComLoginOnlyInPrologue ||
         configuration.enableSiteCreation ||
         configuration.enableSiteAddressLoginOnlyInPrologue ||
         configuration.enableSiteCreationGuide

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -271,13 +271,22 @@ class LoginPrologueViewController: LoginViewController {
         let displayStrings = WordPressAuthenticator.shared.displayStrings
         let buttons: [StackedButton]
 
-        let continueWithWPButton = StackedButton(title: displayStrings.continueWithWPButtonTitle,
-                                                 isPrimary: true,
-                                                 configureBodyFontForTitle: true,
-                                                 accessibilityIdentifier: "Prologue Continue Button",
-                                                 style: primaryButtonStyle,
-                                                 onTap: loginTapCallback())
-        let enterYourSiteAddressButton: StackedButton = {
+        let continueWithWPButton: StackedButton? = {
+            guard !configuration.enableSiteAddressLoginOnlyInPrologue else {
+                return nil
+            }
+            return StackedButton(title: displayStrings.continueWithWPButtonTitle,
+                                 isPrimary: true,
+                                 configureBodyFontForTitle: true,
+                                 accessibilityIdentifier: "Prologue Continue Button",
+                                 style: primaryButtonStyle,
+                                 onTap: loginTapCallback())
+        }()
+
+        let enterYourSiteAddressButton: StackedButton? = {
+            guard !configuration.enableWPComLoginOnlyInPrologue else {
+                return nil
+            }
             let isPrimary = configuration.enableSiteAddressLoginOnlyInPrologue && !configuration.enableSiteCreation
             return StackedButton(title: displayStrings.enterYourSiteAddressButtonTitle,
                                  isPrimary: isPrimary,
@@ -286,7 +295,11 @@ class LoginPrologueViewController: LoginViewController {
                                  style: secondaryButtonStyle,
                                  onTap: siteAddressTapCallback())
         }()
-        let createSiteButton: StackedButton = {
+
+        let createSiteButton: StackedButton? = {
+            guard configuration.enableSiteCreation else {
+                return nil
+            }
             let isPrimary = configuration.enableSiteAddressLoginOnlyInPrologue
             return StackedButton(title: displayStrings.siteCreationButtonTitle,
                                  isPrimary: isPrimary,
@@ -296,20 +309,32 @@ class LoginPrologueViewController: LoginViewController {
                                  onTap: simplifiedLoginSiteCreationCallback())
         }()
 
-        let siteCreationGuideButton: StackedButton = {
-            StackedButton(title: displayStrings.siteCreationGuideButtonTitle,
-                          isPrimary: false,
-                          configureBodyFontForTitle: true,
-                          accessibilityIdentifier: "Prologue Site Creation Guide button",
-                          style: NUXButtonStyle.linkButtonStyle,
-                          onTap: siteCreationGuideCallback())
+        let createSiteButtonForBottomStackView: StackedButton? = {
+            guard let createSiteButton else {
+                return nil
+            }
+            return StackedButton(using: createSiteButton, stackView: .bottom)
         }()
 
+        let siteCreationGuideButton: StackedButton? = {
+            guard configuration.enableSiteCreationGuide else {
+                return nil
+            }
+            return StackedButton(title: displayStrings.siteCreationGuideButtonTitle,
+                                 isPrimary: false,
+                                 configureBodyFontForTitle: true,
+                                 accessibilityIdentifier: "Prologue Site Creation Guide button",
+                                 style: NUXButtonStyle.linkButtonStyle,
+                                 onTap: siteCreationGuideCallback())
+        }()
+
+        let showBothLoginOptions = continueWithWPButton != nil && enterYourSiteAddressButton != nil
         buttons = [
-            configuration.enableWPComLoginOnlyInPrologue ? nil : enterYourSiteAddressButton,
-            configuration.enableSiteAddressLoginOnlyInPrologue ? nil : continueWithWPButton,
-            configuration.enableSiteCreation ? createSiteButton : nil,
-            configuration.enableSiteCreationGuide ? siteCreationGuideButton : nil
+            continueWithWPButton,
+            !showBothLoginOptions ? createSiteButton : nil,
+            enterYourSiteAddressButton,
+            showBothLoginOptions ? createSiteButtonForBottomStackView : nil,
+            siteCreationGuideButton
         ].compactMap { $0 }
 
         let showDivider = configuration.enableWPComLoginOnlyInPrologue == false &&

--- a/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -298,6 +298,8 @@ class LoginPrologueViewController: LoginViewController {
 
         let siteCreationGuideButton: StackedButton = {
             StackedButton(title: displayStrings.siteCreationGuideButtonTitle,
+                          isPrimary: false,
+                          configureBodyFontForTitle: true,
                           accessibilityIdentifier: "Prologue Site Creation Guide button",
                           style: NUXButtonStyle.linkButtonStyle,
                           onTap: siteCreationGuideCallback())


### PR DESCRIPTION
**Description**
As part of https://github.com/woocommerce/woocommerce-ios/issues/12324, we want to update the prologue screen to show a button for site creation guide.

This PR updates the configuration and delegate to support showing site creation guide on the prologue screen

**Testing**

Please follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/12328 for testing.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
