### PR TITLE
Update WordPressKit dependency to `~> 15.0` + Release 9.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 9.0.4
+
+### Internal Changes
+
+- Depend on WordPressKit 15.0. [#845]
+
 ## 9.0.3
 
 ### Bug Fixes

--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,7 @@ def wordpress_authenticator_pods
   ## These should match the version requirement from the podspec.
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7-beta'
-  pod 'WordPressKit', '~> 14.0'
+  pod 'WordPressKit', '~> 15.0'
   pod 'WordPressShared', '~> 2.1-beta'
 
   third_party_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (9.0.3):
+  - WordPressAuthenticator (9.0.4):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -67,7 +67,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: 3d8aa41dc2701129fda5dc955757a0d26686901f
+  WordPressAuthenticator: b5915609e4b569cc26cda5e33d3924d3bdaef7ba
   WordPressKit: d4db2fa5861380bd6b71d5574f2bc63cdeee47ba
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,10 +12,10 @@ PODS:
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 14.0)
+    - WordPressKit (~> 15.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (14.0.0):
+  - WordPressKit (15.0.0):
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
@@ -33,13 +33,11 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (= 0.54.0)
   - WordPressAuthenticator (from `.`)
-  - WordPressKit (~> 14.0)
+  - WordPressKit (~> 15.0)
   - WordPressShared (~> 2.1-beta)
   - WordPressUI (~> 1.7-beta)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressKit
   trunk:
     - Expecta
     - Gridicons
@@ -50,6 +48,7 @@ SPEC REPOS:
     - SVProgressHUD
     - SwiftLint
     - UIDeviceIdentifier
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
@@ -68,12 +67,12 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: 01489772aa777842626d527b0f44026ca6ed5148
-  WordPressKit: 6fbe0528c43df471a73de17909413a1e42f862b1
+  WordPressAuthenticator: 3d8aa41dc2701129fda5dc955757a0d26686901f
+  WordPressKit: d4db2fa5861380bd6b71d5574f2bc63cdeee47ba
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: d7dd88d5316c6df1fdd7e05964da727e51783ba1
+PODFILE CHECKSUM: 64d33bcfea34f300f162f3ffac9fd2d31af36917
 
 COCOAPODS: 1.14.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '9.0.3'
+  s.version       = '9.0.4'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressUI', '~> 1.7-beta'
-  s.dependency 'WordPressKit', '~> 14.0'
+  s.dependency 'WordPressKit', '~> 15.0'
   s.dependency 'WordPressShared', '~> 2.1-beta'
 end


### PR DESCRIPTION
This version bump PR is part of the release workflow for WordPress iOS 24.5 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

See also https://github.com/wordpress-mobile/WordPressKit-iOS/pull/769