### PR TITLE
Update WordPressKit dependency to ~> 16.0 + Release 9.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ _None._
 
 ### New Features
 
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 9.0.5
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
 - Add an option to show site creation guide on the prologue screen [#844]
 
 ### Bug Fixes

--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,7 @@ def wordpress_authenticator_pods
   ## These should match the version requirement from the podspec.
   pod 'Gridicons', '~> 1.0'
   pod 'WordPressUI', '~> 1.7-beta'
-  pod 'WordPressKit', '~> 15.0'
+  pod 'WordPressKit', '~> 16.0'
   pod 'WordPressShared', '~> 2.1-beta'
 
   third_party_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,14 +8,14 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (9.0.4):
+  - WordPressAuthenticator (9.0.3):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 15.0)
+    - WordPressKit (~> 16.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (15.0.0):
+  - WordPressKit (16.0.0):
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
@@ -33,7 +33,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (= 0.54.0)
   - WordPressAuthenticator (from `.`)
-  - WordPressKit (~> 15.0)
+  - WordPressKit (~> 16.0)
   - WordPressShared (~> 2.1-beta)
   - WordPressUI (~> 1.7-beta)
 
@@ -67,12 +67,12 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: b5915609e4b569cc26cda5e33d3924d3bdaef7ba
-  WordPressKit: d4db2fa5861380bd6b71d5574f2bc63cdeee47ba
+  WordPressAuthenticator: 4c3520f9b66dbbb065677509e63c8bd5c13e628e
+  WordPressKit: f6dc2acce37a526ddb59e02388b3d59da50918ed
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: 64d33bcfea34f300f162f3ffac9fd2d31af36917
+PODFILE CHECKSUM: ce2d9c056b5321bd076856e0f02f7b50485b0798
 
 COCOAPODS: 1.14.3

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '9.0.4'
+  s.version       = '9.0.3'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressUI', '~> 1.7-beta'
-  s.dependency 'WordPressKit', '~> 15.0'
+  s.dependency 'WordPressKit', '~> 16.0'
   s.dependency 'WordPressShared', '~> 2.1-beta'
 end


### PR DESCRIPTION
This version bump PR is part of the release workflow for WordPress iOS 24.6 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.