### PR TITLE
Pass allow warnings option to cocoapods commands

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,9 @@ steps:
   - label: "🔬 Validate Podspec"
     key: "validate"
     command: |
-      validate_podspec --patch-cocoapods
+      # This library use deprecated Gravatar API in WordPressUI.
+      # Allow warning for now, until we are ready to migrate to Gravatar SDK.
+      validate_podspec --patch-cocoapods --allow-warnings
     env: *common_env
     plugins: *common_plugins
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.1.0
+    - automattic/a8c-ci-toolkit#3.2.2
   env: &common_env
     IMAGE_ID: xcode-15.0.1
 

--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -8,7 +8,7 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- :cocoapods: Publishing Pod to CocoaPods CDN"
-publish_pod --patch-cocoapods $PODSPEC_PATH
+publish_pod --patch-cocoapods $PODSPEC_PATH --allow-warnings
 
 echo "--- :cocoapods: Publishing Pod to WP Specs Repo"
 publish_private_pod --patch-cocoapods $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"


### PR DESCRIPTION
Fix pipeline issues in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/849.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
