### PR TITLE
Update buildkite command to allow warnings

### DIFF
--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -8,7 +8,7 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- :cocoapods: Publishing Pod to CocoaPods CDN"
-publish_pod --patch-cocoapods $PODSPEC_PATH --allow-warnings
+publish_pod --patch-cocoapods --allow-warnings $PODSPEC_PATH
 
 echo "--- :cocoapods: Publishing Pod to WP Specs Repo"
 publish_private_pod --patch-cocoapods $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"


### PR DESCRIPTION
**Description**

The previous fix in #850 seems to not work for the `publish_pod` step. This PR moves the `--allow-warnings` flag to before `$PODSPEC_PATH` in an attempt to fix the step.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
