### PR TITLE
Allow warnings also on `publish_private_pod`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.2.2
+    - automattic/a8c-ci-toolkit#3.3.0
   env: &common_env
     IMAGE_ID: xcode-15.0.1
 

--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -11,7 +11,7 @@ echo "--- :cocoapods: Publishing Pod to CocoaPods CDN"
 publish_pod --patch-cocoapods --allow-warnings $PODSPEC_PATH
 
 echo "--- :cocoapods: Publishing Pod to WP Specs Repo"
-publish_private_pod --patch-cocoapods $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"
+publish_private_pod --patch-cocoapods --allow-warnings $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"
 
 echo "--- :slack: Notifying Slack"
 slack_notify_pod_published $PODSPEC_PATH "$SLACK_WEBHOOK"


### PR DESCRIPTION
**Related**: #850, #852 

This PR updates the repo to use the `a8c-ci-toolkit` version `3.3.0`, which can allow warnings on `publish_private_pod` with the flag `--allow-warnings`.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
