### PR TITLE
Hide site credential login button from Get Started screen after entering a WPCom site address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,17 @@ _None._
 
 ### Bug Fixes
 
-- Hide site credential login option from Get Started screen after entering a WPCom site address [#855]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 9.0.9
+
+### Bug Fixes
+
+- Hide site credential login option from Get Started screen after entering a WPCom site address [#855]
 
 ## 9.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Hide site credential login option from Get Started screen after entering a WPCom site address [#855]
 
 ### Internal Changes
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (9.0.8):
+  - WordPressAuthenticator (9.0.9):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -67,7 +67,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: f396f27104420ef617ffdc73dc76fab169508867
+  WordPressAuthenticator: f8dcccf4661255208fb54e5558b5175e1f5bdda9
   WordPressKit: a71cc550f4b525ab5eef057984c8de071462edd5
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '9.0.8'
+  s.version       = '9.0.9'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -45,7 +45,7 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
     private enum ScreenMode {
         /// For signing in using site address
         ///
-        case signInUsingSiteAddress
+        case signInUsingSiteAddress(isWPComSite: Bool)
 
         /// For signing in using WPCOM credentials or social accounts
         case signInUsingWordPressComOrSocialAccounts
@@ -87,6 +87,9 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
 
     private var passwordCoordinator: PasswordCoordinator?
 
+    // This is internal so it can be set from SiteAddressViewController.
+    var wpcomSiteAddressDetected = false
+
     /// Sign in with site credentials button will be displayed based on the `screenMode`
     ///
     private var screenMode: ScreenMode {
@@ -94,7 +97,7 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
               loginFields.siteAddress.isEmpty == false else {
             return .signInUsingWordPressComOrSocialAccounts
         }
-        return .signInUsingSiteAddress
+        return .signInUsingSiteAddress(isWPComSite: wpcomSiteAddressDetected)
     }
 
     // Submit button displayed in the table footer.
@@ -145,8 +148,8 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         setupTableFooterView()
         configureDivider()
 
-        if screenMode == .signInUsingSiteAddress {
-            configureButtonViewControllerForSiteAddressMode()
+        if case .signInUsingSiteAddress(let isWPComSite) = screenMode {
+            configureButtonViewControllerForSiteAddressMode(isWPComSite: isWPComSite)
         } else if configuration.enableSocialLogin == false {
             configureButtonViewControllerWithoutSocialLogin()
         } else {
@@ -803,7 +806,7 @@ private extension GetStartedViewController {
         termsButton.addTarget(self, action: #selector(termsTapped), for: .touchUpInside)
     }
 
-    func configureButtonViewControllerForSiteAddressMode() {
+    func configureButtonViewControllerForSiteAddressMode(isWPComSite: Bool) {
         guard let buttonViewController = buttonViewController else {
             return
         }
@@ -813,11 +816,13 @@ private extension GetStartedViewController {
         if configuration.enableSocialLogin {
             configureSocialButtons()
 
-            // Setup Sign in with site credentials button
-            buttonViewController.setupTertiaryButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
-                                                   isPrimary: false,
-                                                   accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier) { [weak self] in
-                self?.handleSiteCredentialsButtonTapped()
+            if isWPComSite == false {
+                // Setup Sign in with site credentials button
+                buttonViewController.setupTertiaryButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
+                                                         isPrimary: false,
+                                                         accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier) { [weak self] in
+                    self?.handleSiteCredentialsButtonTapped()
+                }
             }
         } else {
             // Add a "Continue" button here as the `continueButton` at the top will be hidden
@@ -830,11 +835,13 @@ private extension GetStartedViewController {
                 }
             }
 
-            // Setup Sign in with site credentials button
-            buttonViewController.setupBottomButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
-                                                   isPrimary: false,
-                                                   accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier) { [weak self] in
-                self?.handleSiteCredentialsButtonTapped()
+            if isWPComSite == false {
+                // Setup Sign in with site credentials button
+                buttonViewController.setupBottomButton(attributedTitle: WPStyleGuide.formattedSignInWithSiteCredentialsString(),
+                                                       isPrimary: false,
+                                                       accessibilityIdentifier: ButtonConfiguration.SignInWithSiteCredentials.accessibilityIdentifier) { [weak self] in
+                    self?.handleSiteCredentialsButtonTapped()
+                }
             }
         }
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -43,9 +43,9 @@ public enum SignInError: Error {
 class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
 
     private enum ScreenMode {
-        /// For signing in using .org site credentials
+        /// For signing in using site address
         ///
-        case signInUsingSiteCredentials
+        case signInUsingSiteAddress
 
         /// For signing in using WPCOM credentials or social accounts
         case signInUsingWordPressComOrSocialAccounts
@@ -94,7 +94,7 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
               loginFields.siteAddress.isEmpty == false else {
             return .signInUsingWordPressComOrSocialAccounts
         }
-        return .signInUsingSiteCredentials
+        return .signInUsingSiteAddress
     }
 
     // Submit button displayed in the table footer.
@@ -145,8 +145,8 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
         setupTableFooterView()
         configureDivider()
 
-        if screenMode == .signInUsingSiteCredentials {
-            configureButtonViewControllerForSiteCredentialsMode()
+        if screenMode == .signInUsingSiteAddress {
+            configureButtonViewControllerForSiteAddressMode()
         } else if configuration.enableSocialLogin == false {
             configureButtonViewControllerWithoutSocialLogin()
         } else {
@@ -462,7 +462,7 @@ private extension GetStartedViewController {
     func configureAnalyticsTracker() {
         // Configure tracker flow based on screen mode.
         switch screenMode {
-        case .signInUsingSiteCredentials:
+        case .signInUsingSiteAddress:
             tracker.set(flow: .loginWithSiteAddress)
         case .signInUsingWordPressComOrSocialAccounts:
             tracker.set(flow: .wpCom)
@@ -803,7 +803,7 @@ private extension GetStartedViewController {
         termsButton.addTarget(self, action: #selector(termsTapped), for: .touchUpInside)
     }
 
-    func configureButtonViewControllerForSiteCredentialsMode() {
+    func configureButtonViewControllerForSiteAddressMode() {
         guard let buttonViewController = buttonViewController else {
             return
         }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -584,7 +584,7 @@ private extension SiteAddressViewController {
         }
 
         guard siteInfo?.isWPCom == false else {
-            showGetStarted()
+            showGetStarted(forWPComSite: true)
             return
         }
 
@@ -600,7 +600,7 @@ private extension SiteAddressViewController {
 
                 self.showWPUsernamePassword()
             case .presentEmailController:
-                self.showGetStarted()
+                self.showGetStarted(forWPComSite: false)
             case let .injectViewController(customUI):
                 self.pushCustomUI(customUI)
             }
@@ -651,16 +651,16 @@ private extension SiteAddressViewController {
 
     /// If the site is WordPressDotCom, redirect to WP login.
     ///
-    func showGetStarted() {
+    func showGetStarted(forWPComSite: Bool) {
         guard let vc = GetStartedViewController.instantiate(from: .getStarted) else {
             WPAuthenticatorLogError("Failed to navigate from SiteAddressViewController to GetStartedViewController")
             return
         }
         vc.source = .wpComSiteAddress
-
         vc.loginFields = loginFields
         vc.dismissBlock = dismissBlock
         vc.errorToPresent = errorToPresent
+        vc.wpcomSiteAddressDetected = forWPComSite
 
         navigationController?.pushViewController(vc, animated: true)
     }


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/13622

**Description**
On WCiOS we support site credential login for self-hosted sites with JP connection. In a previous attempt to add the site credential login option, we accidentally enabled that option for WPCom sites. This option is not functional as it's impossible to log in to WPCom sites with site credentials, so this PR fixes this by hiding that option for WPCom sites.

**Testing steps**
Test the demo app to ensure that the credential login button is not available in the default case.
Additionally, follow the steps in https://github.com/woocommerce/woocommerce-ios/pull/13623 to check the cases for WCiOS.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
