### PR TITLE
Fix compiler issues for Xcode 16 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Fixed compiler issues for Xcode 16 support [#856]
 
 ## 9.0.9
 

--- a/WordPressAuthenticator/Email Client Picker/URLHandler.swift
+++ b/WordPressAuthenticator/Email Client Picker/URLHandler.swift
@@ -2,10 +2,18 @@
 public protocol URLHandler {
     /// checks if the specified URL can be opened
     func canOpenURL(_ url: URL) -> Bool
+
+#if compiler(>=6)
+    /// opens the specified URL
+    func open(_ url: URL,
+              options: [UIApplication.OpenExternalURLOptionsKey: Any],
+              completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?)
+#else
     /// opens the specified URL
     func open(_ url: URL,
               options: [UIApplication.OpenExternalURLOptionsKey: Any],
               completionHandler completion: ((Bool) -> Void)?)
+#endif
 }
 
 /// conforms UIApplication to URLHandler to allow dependency injection


### PR DESCRIPTION
This is a fix for compiler errors for Xcode 16 support.

I used WordPress-iOS as an example https://github.com/wordpress-mobile/WordPress-iOS/pull/23497. They have already made this fix since they copied these dependencies on the repository.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
