### PR TITLE
Allow login for WPCOM suspended sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add support for logging in into WPCOM suspended sites.
 
 ### Bug Fixes
 

--- a/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
+++ b/WordPressAuthenticator/Authenticator/WordPressAuthenticatorConfiguration.swift
@@ -178,6 +178,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let enableSiteCreationGuide: Bool
 
+    /// If enabled allows login into sites marked as suspended in WordPress.com
+    ///
+    let enableSiteCredentialsLoginForWPCOMSuspendedSites: Bool
+
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -215,7 +219,8 @@ public struct WordPressAuthenticatorConfiguration {
                  enableManualErrorHandlingForSiteCredentialLogin: Bool = false,
                  useEnterEmailAddressAsStepValueForGetStartedVC: Bool = false,
                  enableSiteAddressLoginOnlyInPrologue: Bool = false,
-                 enableSiteCreationGuide: Bool = false
+                 enableSiteCreationGuide: Bool = false,
+                 enableSiteCredentialsLoginForWPCOMSuspendedSites: Bool = false
     ) {
 
         self.wpcomClientId = wpcomClientId
@@ -254,5 +259,6 @@ public struct WordPressAuthenticatorConfiguration {
         self.useEnterEmailAddressAsStepValueForGetStartedVC = useEnterEmailAddressAsStepValueForGetStartedVC
         self.enableSiteAddressLoginOnlyInPrologue = enableSiteAddressLoginOnlyInPrologue
         self.enableSiteCreationGuide = enableSiteCreationGuide
+        self.enableSiteCredentialsLoginForWPCOMSuspendedSites = enableSiteCredentialsLoginForWPCOMSuspendedSites
     }
 }

--- a/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
+++ b/WordPressAuthenticator/Model/WordPressComSiteInfo.swift
@@ -44,6 +44,19 @@ public class WordPressComSiteInfo {
     ///
     public let exists: Bool
 
+    public init(name: String, tagline: String, url: String, hasJetpack: Bool, isJetpackActive: Bool, isJetpackConnected: Bool, icon: String, isWPCom: Bool, isWP: Bool, exists: Bool) {
+        self.name = name
+        self.tagline = tagline
+        self.url = url
+        self.hasJetpack = hasJetpack
+        self.isJetpackActive = isJetpackActive
+        self.isJetpackConnected = isJetpackConnected
+        self.icon = icon
+        self.isWPCom = isWPCom
+        self.isWP = isWP
+        self.exists = exists
+    }
+
     /// Initializes the current SiteInfo instance with a raw dictionary.
     ///
     public init(remote: [AnyHashable: Any]) {

--- a/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -20,7 +20,7 @@ class WordPressComBlogService {
 
         remote.fetchSiteInfo(forAddress: address, success: { response in
             guard let response = response else {
-                failure(ServiceError.unknown)
+                failure(WordPressComBlogServiceError.unknown)
                 return
             }
 
@@ -28,7 +28,7 @@ class WordPressComBlogService {
             success(site)
 
         }, failure: { error in
-            let result = error ?? ServiceError.unknown
+            let result = error ?? WordPressComBlogServiceError.unknown
             failure(result)
         })
     }
@@ -37,13 +37,13 @@ class WordPressComBlogService {
         let remote = BlogServiceRemoteREST(wordPressComRestApi: anonymousAPI, siteID: 0)
         remote.fetchUnauthenticatedSiteInfo(forAddress: address, success: { response in
             guard let response = response else {
-                failure(ServiceError.unknown)
+                failure(WordPressComBlogServiceError.unknown)
                 return
             }
 
             let site = WordPressComSiteInfo(remote: response)
             guard site.url != Constants.wordPressBlogURL else {
-                failure(ServiceError.invalidWordPressAddress)
+                failure(WordPressComBlogServiceError.invalidWordPressAddress)
                 return
             }
             success(site)
@@ -60,9 +60,12 @@ extension WordPressComBlogService {
     enum Constants {
         static let wordPressBlogURL = "https://wordpress.com/blog"
     }
+}
 
-    enum ServiceError: Error {
-        case unknown
-        case invalidWordPressAddress
-    }
+public enum WordPressComBlogServiceError: Error {
+    case unknown
+    case invalidWordPressAddress
+    /// Whether the site is suspended on WordPress.com and can't be connected using Jetpack
+    ///
+    case wpcomSiteSuspended
 }

--- a/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -48,7 +48,17 @@ class WordPressComBlogService {
             }
             success(site)
         }, failure: { error in
-            let result = error ?? ServiceError.unknown
+            let result: Error = {
+                /// Check whether the site is suspended on WordPress.com and can't be connected using Jetpack
+                ///
+                if let apiError = error as? WordPressAPIError<WordPressComRestApiEndpointError>,
+                   case let .endpointError(endpointError) = apiError,
+                   endpointError.apiErrorCode == "connection_disabled" {
+                    return WordPressComBlogServiceError.wpcomSiteSuspended
+                }
+
+                return error ?? WordPressComBlogServiceError.unknown
+            }()
             failure(result)
         })
     }

--- a/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -552,6 +552,23 @@ private extension SiteAddressViewController {
                     self?.navigationController?.pushViewController(customUI, animated: true)
                 }
             } else {
+                // Don't display error and allow login for suspended sites
+                //
+                if configuration.enableSiteCredentialsLoginForWPCOMSuspendedSites,
+                   let serviceError = error as? WordPressComBlogServiceError,
+                   serviceError == .wpcomSiteSuspended {
+                    successBlock(WordPressComSiteInfo(name: "",
+                                                      tagline: "",
+                                                      url: baseSiteUrl,
+                                                      hasJetpack: false,
+                                                      isJetpackActive: false,
+                                                      isJetpackConnected: false,
+                                                      icon: "",
+                                                      isWPCom: false,
+                                                      isWP: true,
+                                                      exists: true))
+                    return
+                }
                 self.displayError(message: Localization.invalidURL)
             }
         })


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/13348

**Description**
When users attempt to log into the app with a site suspended by WPCOM, they receive an error message stating the URL is invalid and cannot proceed with login.

This PR adds a new configuration and updates the login flow to handle this case by directing those users to use site credentials instead of WordPress.com.


**Testing steps**

Follow the testing steps at https://github.com/woocommerce/woocommerce-ios/pull/14257 to check the cases for WCiOS.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
