### PR TITLE
Add missing PR number to changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add support for logging in into WPCOM suspended sites.
+- Add support for logging in into WPCOM suspended sites. [#858]
 - Update `WordPressComAccountService/requestAuthenticationLink` with a new argument `createAccountIfNotFound` to allow creating new accounts. [#861]
 
 ### Bug Fixes


### PR DESCRIPTION
While working on https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/858, I missed adding the PR number to the changelog. 

This PR adds the missing PR number to the changelog entry. 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
