### PR TITLE
Release version 9.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ _None._
 
 _None._
 
+## 9.10.2
+
+### New Features
+
+- Woo Brand Update [#867]
+
 ## 9.10.1
 
 ### New Features

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
-  - WordPressAuthenticator (9.10.1):
+  - WordPressAuthenticator (9.10.2):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -67,7 +67,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: d54323ca733b41b10a7fd64f5d1ca2d9efc47720
+  WordPressAuthenticator: e5247b2d9bdb522c5d210dd6b66d58a4013eed99
   WordPressKit: faf8c6de7c2acfe71cf95b4db896901060967089
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -67,7 +67,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPressAuthenticator: e5247b2d9bdb522c5d210dd6b66d58a4013eed99
+  WordPressAuthenticator: 371d830d1703c525fc34979dc23a1bb4dc86d820
   WordPressKit: faf8c6de7c2acfe71cf95b4db896901060967089
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '9.10.1'
+  s.version       = '9.10.2' 
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC

--- a/WordPressAuthenticator.podspec
+++ b/WordPressAuthenticator.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressAuthenticator'
-  s.version       = '9.10.2' 
+  s.version       = '9.10.2'
 
   s.summary       = 'WordPressAuthenticator implements an easy and elegant way to authenticate your WordPress Apps.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

This PR makes the changes in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/867 available in a new version.

---

- [X] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
